### PR TITLE
Add v1.6 DB-backed read models + DB API server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ diff.txt
 
 # Local exports
 fs.txt
+
+# local ingest reports
+reports/

--- a/README.md
+++ b/README.md
@@ -11,6 +11,36 @@ Currently, two official plugins are available:
 
 If you are developing a production application, we recommend using TypeScript with type-aware lint rules enabled. Check out the [TS template](https://github.com/vitejs/vite/tree/main/packages/create-vite/template-react-ts) for information on how to integrate TypeScript and [`typescript-eslint`](https://typescript-eslint.io) in your project.
 
+## Dev: UI + DB API
+
+Run the DB API server and Vite together (no UI changes needed):
+
+```sh
+export DATABASE_URL="postgres://postgres:postgres@localhost:5432/hockey"
+export TOURNAMENT_ID="hj-indoor-allstars-2025"
+export VITE_PROVIDER="db"
+export VITE_DB_API_BASE="http://localhost:8787/api"
+npm run dev:full
+```
+
+If you prefer two terminals:
+
+```sh
+# terminal 1
+export DATABASE_URL="postgres://postgres:postgres@localhost:5432/hockey"
+export TOURNAMENT_ID="hj-indoor-allstars-2025"
+npm run server
+```
+
+```sh
+# terminal 2
+export VITE_PROVIDER="db"
+export VITE_DB_API_BASE="http://localhost:8787/api"
+npm run dev
+```
+
+Smoke test examples are listed in `specs/db/ingestion_v1.6.md`.
+
 ## Shipping
 
 Tag a release (e.g., `v1.2.3`) and push the tag to trigger the release workflow:

--- a/db/migrate.sh
+++ b/db/migrate.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${DATABASE_URL:?DATABASE_URL is required}"
+
+psql "$DATABASE_URL" -v ON_ERROR_STOP=1 <<'SQL'
+CREATE TABLE IF NOT EXISTS schema_migrations (
+  filename TEXT PRIMARY KEY,
+  applied_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+SQL
+
+for file in db/migrations/*.sql; do
+  [ -e "$file" ] || continue
+  fname=$(basename "$file")
+  applied=$(psql "$DATABASE_URL" -tA -c "SELECT 1 FROM schema_migrations WHERE filename='${fname}'")
+  if [ "$applied" = "1" ]; then
+    continue
+  fi
+  psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f "$file"
+  psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -c "INSERT INTO schema_migrations (filename) VALUES ('${fname}')"
+  echo "Applied ${fname}"
+done

--- a/db/migrations/001_init.sql
+++ b/db/migrations/001_init.sql
@@ -1,0 +1,192 @@
+CREATE TABLE IF NOT EXISTS tournament (
+  id TEXT PRIMARY KEY,
+  name TEXT NOT NULL,
+  season TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  source TEXT,
+  source_row_hash TEXT,
+  ingested_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS groups (
+  tournament_id TEXT NOT NULL REFERENCES tournament(id) ON DELETE CASCADE,
+  id TEXT NOT NULL,
+  label TEXT NOT NULL,
+  format TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  source TEXT,
+  source_row_hash TEXT,
+  ingested_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (tournament_id, id)
+);
+
+CREATE TABLE IF NOT EXISTS team (
+  tournament_id TEXT NOT NULL REFERENCES tournament(id) ON DELETE CASCADE,
+  id TEXT NOT NULL,
+  group_id TEXT NOT NULL,
+  name TEXT NOT NULL,
+  is_placeholder BOOLEAN NOT NULL DEFAULT FALSE,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  source TEXT,
+  source_row_hash TEXT,
+  ingested_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (tournament_id, id),
+  FOREIGN KEY (tournament_id, group_id)
+    REFERENCES groups(tournament_id, id) ON DELETE RESTRICT,
+  UNIQUE (tournament_id, group_id, name)
+);
+
+CREATE TABLE IF NOT EXISTS fixture (
+  tournament_id TEXT NOT NULL REFERENCES tournament(id) ON DELETE CASCADE,
+  id TEXT NOT NULL,
+  group_id TEXT NOT NULL,
+  date DATE NOT NULL,
+  time TEXT NOT NULL,
+  venue TEXT,
+  round TEXT,
+  pool TEXT,
+  team1_id TEXT NOT NULL,
+  team2_id TEXT NOT NULL,
+  fixture_key TEXT NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  source TEXT,
+  source_row_hash TEXT,
+  ingested_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (tournament_id, id),
+  FOREIGN KEY (tournament_id, group_id)
+    REFERENCES groups(tournament_id, id) ON DELETE RESTRICT,
+  FOREIGN KEY (tournament_id, team1_id)
+    REFERENCES team(tournament_id, id) ON DELETE RESTRICT,
+  FOREIGN KEY (tournament_id, team2_id)
+    REFERENCES team(tournament_id, id) ON DELETE RESTRICT,
+  UNIQUE (tournament_id, fixture_key)
+);
+
+CREATE TABLE IF NOT EXISTS result (
+  tournament_id TEXT NOT NULL,
+  fixture_id TEXT NOT NULL,
+  score1 INTEGER,
+  score2 INTEGER,
+  status TEXT,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  source TEXT,
+  source_row_hash TEXT,
+  ingested_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (tournament_id, fixture_id),
+  FOREIGN KEY (tournament_id, fixture_id)
+    REFERENCES fixture(tournament_id, id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_groups_tournament
+  ON groups (tournament_id);
+
+CREATE INDEX IF NOT EXISTS idx_team_group
+  ON team (tournament_id, group_id);
+
+CREATE INDEX IF NOT EXISTS idx_team_name
+  ON team (tournament_id, name);
+
+CREATE INDEX IF NOT EXISTS idx_fixture_group_date
+  ON fixture (tournament_id, group_id, date);
+
+CREATE INDEX IF NOT EXISTS idx_fixture_team1
+  ON fixture (tournament_id, team1_id);
+
+CREATE INDEX IF NOT EXISTS idx_fixture_team2
+  ON fixture (tournament_id, team2_id);
+
+CREATE INDEX IF NOT EXISTS idx_result_status
+  ON result (tournament_id, status);
+
+CREATE OR REPLACE VIEW v1_standings AS
+WITH played AS (
+  SELECT
+    f.tournament_id,
+    f.group_id,
+    f.pool,
+    f.team1_id AS team_id,
+    r.score1 AS gf,
+    r.score2 AS ga,
+    CASE WHEN r.score1 > r.score2 THEN 1 ELSE 0 END AS w,
+    CASE WHEN r.score1 = r.score2 THEN 1 ELSE 0 END AS d,
+    CASE WHEN r.score1 < r.score2 THEN 1 ELSE 0 END AS l
+  FROM fixture f
+  JOIN result r
+    ON r.tournament_id = f.tournament_id
+   AND r.fixture_id = f.id
+  WHERE r.score1 IS NOT NULL AND r.score2 IS NOT NULL
+
+  UNION ALL
+
+  SELECT
+    f.tournament_id,
+    f.group_id,
+    f.pool,
+    f.team2_id AS team_id,
+    r.score2 AS gf,
+    r.score1 AS ga,
+    CASE WHEN r.score2 > r.score1 THEN 1 ELSE 0 END AS w,
+    CASE WHEN r.score2 = r.score1 THEN 1 ELSE 0 END AS d,
+    CASE WHEN r.score2 < r.score1 THEN 1 ELSE 0 END AS l
+  FROM fixture f
+  JOIN result r
+    ON r.tournament_id = f.tournament_id
+   AND r.fixture_id = f.id
+  WHERE r.score1 IS NOT NULL AND r.score2 IS NOT NULL
+),
+agg AS (
+  SELECT
+    tournament_id,
+    group_id,
+    pool,
+    team_id,
+    COUNT(*) AS gp,
+    SUM(w) AS w,
+    SUM(d) AS d,
+    SUM(l) AS l,
+    SUM(gf) AS gf,
+    SUM(ga) AS ga
+  FROM played
+  GROUP BY tournament_id, group_id, pool, team_id
+),
+final AS (
+  SELECT
+    a.tournament_id,
+    a.group_id,
+    a.pool,
+    t.name AS "Team",
+    a.gp AS "GP",
+    a.w AS "W",
+    a.d AS "D",
+    a.l AS "L",
+    a.gf AS "GF",
+    a.ga AS "GA",
+    (a.gf - a.ga) AS "GD",
+    (a.w * 3 + a.d) AS "Points"
+  FROM agg a
+  JOIN team t
+    ON t.tournament_id = a.tournament_id
+   AND t.id = a.team_id
+)
+SELECT
+  f.tournament_id,
+  f.group_id,
+  g.id AS "Age",
+  f.pool AS "Pool",
+  f."Team",
+  f."GP",
+  f."W",
+  f."D",
+  f."L",
+  f."GF",
+  f."GA",
+  f."GD",
+  f."Points",
+  ROW_NUMBER() OVER (
+    PARTITION BY f.tournament_id, f.group_id, f.pool
+    ORDER BY f."Points" DESC, f."GD" DESC, f."GF" DESC, f."Team" ASC
+  ) AS "Rank"
+FROM final f
+JOIN groups g
+  ON g.tournament_id = f.tournament_id
+ AND g.id = f.group_id;

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "hockey-app",
       "version": "1.5.1",
       "dependencies": {
+        "pg": "^8.16.3",
         "prop-types": "^15.8.1",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
@@ -2635,6 +2636,96 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/pg": {
+      "version": "8.16.3",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.16.3.tgz",
+      "integrity": "sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "pg-connection-string": "^2.9.1",
+        "pg-pool": "^3.10.1",
+        "pg-protocol": "^1.10.3",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.2.7"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.2.7.tgz",
+      "integrity": "sha512-YgCtzMH0ptvZJslLM1ffsY4EuGaU0cx4XSdXLRFae8bPP4dS5xL1tNB3k2o/N64cHJpwU7dxKli/nZ2lUa5fLg==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.9.1.tgz",
+      "integrity": "sha512-nkc6NpDcvPVpZXxrreI/FOtX3XemeLl8E0qFr6F2Lrm/I8WOnaWNhIPK2Z7OHpw7gh5XJThi6j6ppgNoaT1w4w==",
+      "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.10.1.tgz",
+      "integrity": "sha512-Tu8jMlcX+9d8+QVzKIvM/uJtp07PKr82IUOYEphaWcoBhIYkoHpLXN3qO59nAI11ripznDsEzEv8nUxBVWajGg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.10.3.tgz",
+      "integrity": "sha512-6DIBgBQaTKDJyxnXaLiLR8wBpQQcGWuAESkRBX/t6OwA8YsqP+iVSiond2EDy6Y/dsGk8rh/jtax3js5NeV7JQ==",
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -2683,6 +2774,45 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+      "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/prelude-ls": {
@@ -2904,6 +3034,15 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
       }
     },
     "node_modules/stackback": {
@@ -3239,6 +3378,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
       }
     },
     "node_modules/yallist": {

--- a/package.json
+++ b/package.json
@@ -5,6 +5,8 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
+    "server": "node server/index.mjs",
+    "dev:full": "node scripts/dev-full.mjs",
     "build": "vite build",
     "lint": "eslint .",
     "test": "vitest run",
@@ -12,6 +14,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "pg": "^8.16.3",
     "prop-types": "^15.8.1",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",

--- a/scripts/dev-full.mjs
+++ b/scripts/dev-full.mjs
@@ -1,0 +1,18 @@
+import { spawn } from "node:child_process";
+
+const npmCmd = process.platform === "win32" ? "npm.cmd" : "npm";
+
+const server = spawn(npmCmd, ["run", "server"], { stdio: "inherit" });
+const vite = spawn(npmCmd, ["run", "dev"], { stdio: "inherit" });
+
+function shutdown(code) {
+  if (server.exitCode == null) server.kill("SIGTERM");
+  if (vite.exitCode == null) vite.kill("SIGTERM");
+  if (code != null) process.exit(code);
+}
+
+server.on("exit", (code) => shutdown(code ?? 0));
+vite.on("exit", (code) => shutdown(code ?? 0));
+
+process.on("SIGINT", () => shutdown(0));
+process.on("SIGTERM", () => shutdown(0));

--- a/scripts/ingest.mjs
+++ b/scripts/ingest.mjs
@@ -1,0 +1,657 @@
+#!/usr/bin/env node
+import fs from "node:fs";
+import path from "node:path";
+import crypto from "node:crypto";
+import { fileURLToPath } from "node:url";
+import { Client } from "pg";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const USAGE = `
+Usage: node scripts/ingest.mjs [options]
+
+Options:
+  --database-url       Postgres connection string (or set DATABASE_URL)
+  --tournament-id      Tournament id (default: hj-indoor-allstars-2025)
+  --fixtures-sheet-id  Fixtures Google Sheet ID
+  --teams-sheet-id     Teams/Standings Google Sheet ID
+  --api-base           Apps Script base URL (optional; falls back to CSV)
+  --debug-args         Print parsed args and resolved provider choice
+  --commit             Write to DB (default: false)
+  --report-dir         Output reports directory (default: reports/ingestion)
+  --limit-groups       Comma-separated group ids to include (optional)
+`;
+
+const DEFAULTS = {
+  tournamentId: "hj-indoor-allstars-2025",
+  fixturesSheetId: "1TT9CHE-L_HmrXuuVGGJy1_p4PYkw-IXkhcTt84UdUEU",
+  teamsSheetId: "1BFHC_NmY7CIlTvMopE-9BftnSzOA2AJpQ37tqnXZnTs",
+  reportDir: "reports/ingestion",
+};
+
+function parseArgs(argv) {
+  const out = { commit: false };
+  const boolKeys = new Set(["commit", "debugArgs", "help"]);
+  const normalizeKey = (rawKey) => rawKey.replace(/-([a-z0-9])/g, (_, ch) => ch.toUpperCase());
+  const setValue = (rawKey, value) => {
+    const key = normalizeKey(rawKey);
+    out[key] = value;
+    if (key !== rawKey) out[rawKey] = value;
+  };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (!arg.startsWith("--")) continue;
+    const rawKeyValue = arg.slice(2);
+    const eqIndex = rawKeyValue.indexOf("=");
+    const rawKey = eqIndex === -1 ? rawKeyValue : rawKeyValue.slice(0, eqIndex);
+    const key = normalizeKey(rawKey);
+    const hasEquals = eqIndex !== -1;
+    const inlineValue = hasEquals ? rawKeyValue.slice(eqIndex + 1) : undefined;
+
+    if (boolKeys.has(key)) {
+      if (!hasEquals) {
+        setValue(rawKey, true);
+      } else if (inlineValue === "false") {
+        setValue(rawKey, false);
+      } else if (inlineValue === "true") {
+        setValue(rawKey, true);
+      } else {
+        setValue(rawKey, true);
+      }
+      continue;
+    }
+    if (hasEquals) {
+      setValue(rawKey, inlineValue);
+      continue;
+    }
+
+    const val = argv[i + 1];
+    if (!val || val.startsWith("--")) continue;
+    setValue(rawKey, val);
+    i += 1;
+  }
+  return out;
+}
+
+function hashString(value) {
+  return crypto.createHash("sha256").update(value).digest("hex");
+}
+
+function slug(input) {
+  const base = String(input || "")
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/(^-|-$)/g, "");
+  const digest = hashString(String(input)).slice(0, 12);
+  return base ? `${base}-${digest}` : digest;
+}
+
+function stableStringify(obj) {
+  if (obj === null || typeof obj !== "object") return JSON.stringify(obj);
+  if (Array.isArray(obj)) return `[${obj.map(stableStringify).join(",")}]`;
+  const keys = Object.keys(obj).sort();
+  return `{${keys.map((k) => `${JSON.stringify(k)}:${stableStringify(obj[k])}`).join(",")}}`;
+}
+
+function parseCsv(text) {
+  const rows = [];
+  let row = [];
+  let current = "";
+  let inQuotes = false;
+  for (let i = 0; i < text.length; i += 1) {
+    const ch = text[i];
+    const next = text[i + 1];
+    if (inQuotes) {
+      if (ch === '"' && next === '"') {
+        current += '"';
+        i += 1;
+      } else if (ch === '"') {
+        inQuotes = false;
+      } else {
+        current += ch;
+      }
+      continue;
+    }
+    if (ch === '"') {
+      inQuotes = true;
+      continue;
+    }
+    if (ch === ",") {
+      row.push(current);
+      current = "";
+      continue;
+    }
+    if (ch === "\n") {
+      row.push(current);
+      rows.push(row);
+      row = [];
+      current = "";
+      continue;
+    }
+    if (ch === "\r") {
+      continue;
+    }
+    current += ch;
+  }
+  row.push(current);
+  rows.push(row);
+  return rows;
+}
+
+function csvToObjects(text) {
+  const rows = parseCsv(text).filter((r) => r.some((c) => String(c).trim() !== ""));
+  if (!rows.length) return [];
+  const header = rows[0].map((h) => String(h || "").trim());
+  const data = [];
+  for (let i = 1; i < rows.length; i += 1) {
+    const obj = {};
+    const row = rows[i];
+    header.forEach((h, idx) => {
+      if (!h) return;
+      obj[h] = row[idx] != null ? String(row[idx]).trim() : "";
+    });
+    data.push(obj);
+  }
+  return data;
+}
+
+function isPlaceholderTeam(name) {
+  const n = String(name || "").trim().toLowerCase();
+  if (!n) return false;
+  if (/^\d+(st|nd|rd|th)\s+place$/.test(n)) return true;
+  if (n.startsWith("winner ") || n.startsWith("loser ")) return true;
+  if (/^[ab][1-4]$/.test(n)) return true;
+  if (n.includes("runner up")) return true;
+  return false;
+}
+
+function normalizeDate(value) {
+  const raw = String(value || "").trim();
+  if (!raw) return "";
+  if (/^\d{4}-\d{2}-\d{2}$/.test(raw)) return raw;
+  const parsed = new Date(raw);
+  if (Number.isNaN(parsed.getTime())) return "";
+  return parsed.toISOString().slice(0, 10);
+}
+
+function normalizeScore(value) {
+  const raw = value == null ? "" : String(value).trim();
+  if (raw === "") return "";
+  const num = Number(raw);
+  if (Number.isNaN(num)) return "";
+  return num;
+}
+
+function normalizeNumber(value) {
+  const num = Number(value);
+  return Number.isFinite(num) ? num : 0;
+}
+
+function reportPath(reportDir, commit) {
+  const stamp = new Date().toISOString().replace(/[:.]/g, "-");
+  const suffix = commit ? "commit" : "preview";
+  return path.join(reportDir, `${stamp}_${suffix}.json`);
+}
+
+async function fetchJson(url) {
+  const res = await fetch(url);
+  if (!res.ok) throw new Error(`HTTP ${res.status} for ${url}`);
+  return res.json();
+}
+
+async function fetchCsv(sheetId) {
+  const url = `https://docs.google.com/spreadsheets/d/${sheetId}/export?format=csv`;
+  const res = await fetch(url);
+  if (!res.ok) throw new Error(`HTTP ${res.status} for ${url}`);
+  return res.text();
+}
+
+async function loadFromApi({ apiBase, limitGroups }) {
+  const source = "AppsScript";
+  const groupJson = await fetchJson(`${apiBase}?groups=1`);
+  const groups = (groupJson.groups || []).map((g) => ({
+    id: String(g.id || "").trim(),
+    label: String(g.label || "").trim(),
+  }));
+  const filteredGroups = limitGroups?.length
+    ? groups.filter((g) => limitGroups.includes(g.id))
+    : groups;
+
+  const fixturesByGroup = new Map();
+  const standingsByGroup = new Map();
+
+  for (const group of filteredGroups) {
+    const fixturesJson = await fetchJson(
+      `${apiBase}?sheet=Fixtures&age=${encodeURIComponent(group.id)}`
+    );
+    const standingsJson = await fetchJson(
+      `${apiBase}?sheet=Standings&age=${encodeURIComponent(group.id)}`
+    );
+    fixturesByGroup.set(group.id, fixturesJson.rows || []);
+    standingsByGroup.set(group.id, standingsJson.rows || []);
+  }
+
+  return { source, groups: filteredGroups, fixturesByGroup, standingsByGroup };
+}
+
+function deriveGroupsFromRows(rows) {
+  const seen = new Map();
+  for (const row of rows) {
+    const id = String(row.ageId || row.Age || row.age || "").trim();
+    if (!id) continue;
+    if (!seen.has(id)) {
+      seen.set(id, { id, label: id });
+    }
+  }
+  return Array.from(seen.values());
+}
+
+async function loadFromCsv({ fixturesSheetId, teamsSheetId, limitGroups }) {
+  const source = "SheetsCSV";
+  const fixturesText = await fetchCsv(fixturesSheetId);
+  const standingsText = await fetchCsv(teamsSheetId);
+
+  const fixtureRows = csvToObjects(fixturesText);
+  const standingsRows = csvToObjects(standingsText);
+
+  const groups = deriveGroupsFromRows([...fixtureRows, ...standingsRows]);
+  const filteredGroups = limitGroups?.length
+    ? groups.filter((g) => limitGroups.includes(g.id))
+    : groups;
+  const allow = new Set(filteredGroups.map((g) => g.id));
+
+  const fixturesByGroup = new Map();
+  const standingsByGroup = new Map();
+
+  for (const row of fixtureRows) {
+    const ageId = String(row.ageId || row.Age || row.age || "").trim();
+    if (!ageId || (allow.size && !allow.has(ageId))) continue;
+    if (!fixturesByGroup.has(ageId)) fixturesByGroup.set(ageId, []);
+    fixturesByGroup.get(ageId).push(row);
+  }
+
+  for (const row of standingsRows) {
+    const ageId = String(row.ageId || row.Age || row.age || "").trim();
+    if (!ageId || (allow.size && !allow.has(ageId))) continue;
+    if (!standingsByGroup.has(ageId)) standingsByGroup.set(ageId, []);
+    standingsByGroup.get(ageId).push(row);
+  }
+
+  return { source, groups: filteredGroups, fixturesByGroup, standingsByGroup };
+}
+
+function validateGroups(groups, errors) {
+  for (const g of groups) {
+    if (!g.id) errors.push(`Group missing id`);
+    if (!g.label) errors.push(`Group ${g.id || "(unknown)"} missing label`);
+  }
+}
+
+function buildTeams({ tournamentId, standingsByGroup, fixturesByGroup }) {
+  const teams = new Map();
+  const byGroup = new Map();
+
+  function upsertTeam(groupId, name, isPlaceholder) {
+    const trimmed = String(name || "").trim();
+    if (!trimmed) return;
+    const id = slug(`${tournamentId}:${groupId}:${trimmed}`);
+    const key = `${groupId}:${id}`;
+    if (!teams.has(key)) {
+      teams.set(key, {
+        id,
+        group_id: groupId,
+        name: trimmed,
+        is_placeholder: !!isPlaceholder,
+      });
+      if (!byGroup.has(groupId)) byGroup.set(groupId, []);
+      byGroup.get(groupId).push(id);
+    }
+  }
+
+  for (const [groupId, rows] of standingsByGroup.entries()) {
+    for (const row of rows) {
+      const teamName = row.Team || row.team || "";
+      if (!teamName) continue;
+      upsertTeam(groupId, teamName, isPlaceholderTeam(teamName));
+    }
+  }
+
+  const missingTeams = [];
+
+  for (const [groupId, rows] of fixturesByGroup.entries()) {
+    for (const row of rows) {
+      const t1 = row.Team1 || row.team1 || "";
+      const t2 = row.Team2 || row.team2 || "";
+      if (t1) {
+        const id = slug(`${tournamentId}:${groupId}:${t1}`);
+        const key = `${groupId}:${id}`;
+        if (!teams.has(key)) {
+          missingTeams.push({ groupId, team: t1 });
+          upsertTeam(groupId, t1, isPlaceholderTeam(t1));
+        }
+      }
+      if (t2) {
+        const id = slug(`${tournamentId}:${groupId}:${t2}`);
+        const key = `${groupId}:${id}`;
+        if (!teams.has(key)) {
+          missingTeams.push({ groupId, team: t2 });
+          upsertTeam(groupId, t2, isPlaceholderTeam(t2));
+        }
+      }
+    }
+  }
+
+  return { teams: Array.from(teams.values()), missingTeams };
+}
+
+function buildFixtures({ tournamentId, fixturesByGroup, errors }) {
+  const fixtures = [];
+  const duplicates = [];
+  const seenKeys = new Set();
+
+  for (const [groupId, rows] of fixturesByGroup.entries()) {
+    for (const row of rows) {
+      const date = normalizeDate(row.Date);
+      if (!date) {
+        errors.push(`Fixture missing/invalid Date in group ${groupId}`);
+        continue;
+      }
+      const time = String(row.Time ?? "").trim() || "";
+      const team1 = String(row.Team1 || "").trim();
+      const team2 = String(row.Team2 || "").trim();
+      if (!team1 || !team2) {
+        errors.push(`Fixture missing Team1/Team2 in group ${groupId} (${date})`);
+        continue;
+      }
+
+      const venue = String(row.Venue || "").trim();
+      const round = String(row.Round || "").trim();
+      const pool = String(row.Pool || "").trim();
+
+      const fixtureKey = `${date}|${time}|${team1}|${team2}|${venue}|${round}|${pool}`;
+      const dedupeKey = `${groupId}:${fixtureKey}`;
+      if (seenKeys.has(dedupeKey)) {
+        duplicates.push({ groupId, fixtureKey });
+        continue;
+      }
+      seenKeys.add(dedupeKey);
+
+      const id = slug(`${tournamentId}:${groupId}:${fixtureKey}`);
+
+      fixtures.push({
+        id,
+        group_id: groupId,
+        date,
+        time: time || "",
+        venue,
+        round,
+        pool,
+        team1,
+        team2,
+        fixture_key: fixtureKey,
+        score1: normalizeScore(row.Score1),
+        score2: normalizeScore(row.Score2),
+        status: String(row.Status || "").trim(),
+      });
+    }
+  }
+
+  return { fixtures, duplicates };
+}
+
+function buildResults(fixtures) {
+  return fixtures.map((fx) => {
+    const hasScores = fx.score1 !== "" && fx.score2 !== "";
+    const status = hasScores ? "Final" : "";
+    return {
+      fixture_id: fx.id,
+      score1: fx.score1 === "" ? null : fx.score1,
+      score2: fx.score2 === "" ? null : fx.score2,
+      status,
+    };
+  });
+}
+
+async function writeReport(reportDir, payload) {
+  fs.mkdirSync(reportDir, { recursive: true });
+  const outPath = reportPath(reportDir, payload.meta.commit);
+  fs.writeFileSync(outPath, JSON.stringify(payload, null, 2));
+  return outPath;
+}
+
+async function upsertAll({ databaseUrl, tournamentId, source, groups, teams, fixtures, results }) {
+  const client = new Client({ connectionString: databaseUrl });
+  await client.connect();
+
+  const now = new Date().toISOString();
+
+  await client.query("BEGIN");
+  try {
+    await client.query(
+      `INSERT INTO tournament (id, name, created_at, source, source_row_hash, ingested_at)
+       VALUES ($1, $2, $3, $4, $5, $6)
+       ON CONFLICT (id) DO UPDATE SET name = EXCLUDED.name, source = EXCLUDED.source, source_row_hash = EXCLUDED.source_row_hash, ingested_at = EXCLUDED.ingested_at`,
+      [tournamentId, tournamentId, now, source, hashString(tournamentId), now]
+    );
+
+    for (const g of groups) {
+      const rowHash = hashString(stableStringify(g));
+      await client.query(
+        `INSERT INTO groups (tournament_id, id, label, created_at, source, source_row_hash, ingested_at)
+         VALUES ($1, $2, $3, $4, $5, $6, $7)
+         ON CONFLICT (tournament_id, id) DO UPDATE SET label = EXCLUDED.label, source = EXCLUDED.source, source_row_hash = EXCLUDED.source_row_hash, ingested_at = EXCLUDED.ingested_at`,
+        [tournamentId, g.id, g.label, now, source, rowHash, now]
+      );
+    }
+
+    for (const t of teams) {
+      const rowHash = hashString(stableStringify(t));
+      await client.query(
+        `INSERT INTO team (tournament_id, id, group_id, name, is_placeholder, created_at, source, source_row_hash, ingested_at)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+         ON CONFLICT (tournament_id, id) DO UPDATE SET name = EXCLUDED.name, is_placeholder = EXCLUDED.is_placeholder, source = EXCLUDED.source, source_row_hash = EXCLUDED.source_row_hash, ingested_at = EXCLUDED.ingested_at`,
+        [tournamentId, t.id, t.group_id, t.name, t.is_placeholder, now, source, rowHash, now]
+      );
+    }
+
+    for (const f of fixtures) {
+      const rowHash = hashString(stableStringify(f));
+      const team1Id = slug(`${tournamentId}:${f.group_id}:${f.team1}`);
+      const team2Id = slug(`${tournamentId}:${f.group_id}:${f.team2}`);
+      await client.query(
+        `INSERT INTO fixture (tournament_id, id, group_id, date, time, venue, round, pool, team1_id, team2_id, fixture_key, created_at, source, source_row_hash, ingested_at)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)
+         ON CONFLICT (tournament_id, id) DO UPDATE SET date = EXCLUDED.date, time = EXCLUDED.time, venue = EXCLUDED.venue, round = EXCLUDED.round, pool = EXCLUDED.pool, team1_id = EXCLUDED.team1_id, team2_id = EXCLUDED.team2_id, fixture_key = EXCLUDED.fixture_key, source = EXCLUDED.source, source_row_hash = EXCLUDED.source_row_hash, ingested_at = EXCLUDED.ingested_at`,
+        [
+          tournamentId,
+          f.id,
+          f.group_id,
+          f.date,
+          f.time,
+          f.venue,
+          f.round,
+          f.pool,
+          team1Id,
+          team2Id,
+          f.fixture_key,
+          now,
+          source,
+          rowHash,
+          now,
+        ]
+      );
+    }
+
+    for (const r of results) {
+      const rowHash = hashString(stableStringify(r));
+      await client.query(
+        `INSERT INTO result (tournament_id, fixture_id, score1, score2, status, updated_at, source, source_row_hash, ingested_at)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+         ON CONFLICT (tournament_id, fixture_id) DO UPDATE SET score1 = EXCLUDED.score1, score2 = EXCLUDED.score2, status = EXCLUDED.status, updated_at = EXCLUDED.updated_at, source = EXCLUDED.source, source_row_hash = EXCLUDED.source_row_hash, ingested_at = EXCLUDED.ingested_at`,
+        [tournamentId, r.fixture_id, r.score1, r.score2, r.status, now, source, rowHash, now]
+      );
+    }
+
+    await client.query("COMMIT");
+  } catch (err) {
+    await client.query("ROLLBACK");
+    throw err;
+  } finally {
+    await client.end();
+  }
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    console.log(USAGE);
+    process.exit(0);
+  }
+
+  const hasOwn = (obj, key) => Object.prototype.hasOwnProperty.call(obj, key);
+  const getArg = (primary, secondary) => {
+    if (hasOwn(args, primary)) return args[primary];
+    if (secondary && hasOwn(args, secondary)) return args[secondary];
+    return undefined;
+  };
+
+  const tournamentId = getArg("tournamentId", "tournament-id") ?? DEFAULTS.tournamentId;
+  const fixturesSheetId = getArg("fixturesSheetId", "fixtures-sheet-id") ?? DEFAULTS.fixturesSheetId;
+  const teamsSheetId = getArg("teamsSheetId", "teams-sheet-id") ?? DEFAULTS.teamsSheetId;
+  const reportDir = getArg("reportDir", "report-dir") ?? DEFAULTS.reportDir;
+  const apiBaseArg = getArg("apiBase", "api-base");
+  const apiBase = apiBaseArg !== undefined ? apiBaseArg : process.env.VITE_API_BASE || "";
+  const databaseUrl = getArg("databaseUrl", "database-url") || process.env.DATABASE_URL || "";
+  const limitGroupsRaw = getArg("limitGroups", "limit-groups");
+  const limitGroups = limitGroupsRaw
+    ? limitGroupsRaw.split(",").map((v) => v.trim()).filter(Boolean)
+    : [];
+  const debugArgs = !!getArg("debugArgs", "debug-args");
+
+  if (debugArgs) {
+    const providerChoice = apiBase ? "AppsScript" : "SheetsCSV";
+    console.log(
+      JSON.stringify(
+        {
+          args,
+          resolved: {
+            apiBase: apiBase || null,
+            provider: providerChoice,
+          },
+        },
+        null,
+        2
+      )
+    );
+  }
+
+  const meta = {
+    commit: !!args.commit,
+    tournamentId,
+    fixturesSheetId,
+    teamsSheetId,
+    apiBase: apiBase || null,
+    reportDir,
+  };
+
+  const report = {
+    meta,
+    counts: {
+      groups: 0,
+      teams: 0,
+      fixtures: 0,
+      results: 0,
+    },
+    duplicates: [],
+    validationErrors: [],
+    missingTeams: [],
+    perGroup: {},
+  };
+
+  let provider;
+  let source = "";
+
+  try {
+    if (apiBase) {
+      provider = await loadFromApi({ apiBase, limitGroups });
+    } else {
+      provider = await loadFromCsv({ fixturesSheetId, teamsSheetId, limitGroups });
+    }
+    source = provider.source;
+  } catch (err) {
+    report.validationErrors.push(`Provider error: ${err.message}`);
+    const outPath = await writeReport(reportDir, report);
+    console.error(`Failed to load provider data. Report written: ${outPath}`);
+    process.exit(1);
+  }
+
+  validateGroups(provider.groups, report.validationErrors);
+
+  const { teams, missingTeams } = buildTeams({
+    tournamentId,
+    standingsByGroup: provider.standingsByGroup,
+    fixturesByGroup: provider.fixturesByGroup,
+  });
+
+  const { fixtures, duplicates } = buildFixtures({
+    tournamentId,
+    fixturesByGroup: provider.fixturesByGroup,
+    errors: report.validationErrors,
+  });
+
+  const results = buildResults(fixtures);
+
+  report.counts.groups = provider.groups.length;
+  report.counts.teams = teams.length;
+  report.counts.fixtures = fixtures.length;
+  report.counts.results = results.length;
+  report.duplicates = duplicates;
+  report.missingTeams = missingTeams;
+
+  const perGroup = {};
+  for (const g of provider.groups) {
+    const groupFixtures = fixtures.filter((f) => f.group_id === g.id);
+    const groupTeams = teams.filter((t) => t.group_id === g.id);
+    perGroup[g.id] = {
+      fixtures: groupFixtures.length,
+      teams: groupTeams.length,
+    };
+  }
+  report.perGroup = perGroup;
+
+  if (report.validationErrors.length) {
+    const outPath = await writeReport(reportDir, report);
+    console.error(`Validation errors found. Report written: ${outPath}`);
+    process.exit(1);
+  }
+
+  if (args.commit) {
+    if (!databaseUrl) {
+      report.validationErrors.push("DATABASE_URL is required for --commit");
+      const outPath = await writeReport(reportDir, report);
+      console.error(`Missing DATABASE_URL. Report written: ${outPath}`);
+      process.exit(1);
+    }
+    await upsertAll({
+      databaseUrl,
+      tournamentId,
+      source,
+      groups: provider.groups,
+      teams,
+      fixtures,
+      results,
+    });
+  }
+
+  const outPath = await writeReport(reportDir, report);
+  console.log(`Report written: ${outPath}`);
+  console.log(args.commit ? "Commit complete." : "Preview complete.");
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/server/.env.example
+++ b/server/.env.example
@@ -1,0 +1,3 @@
+DATABASE_URL="postgres://postgres:postgres@localhost:5432/hockey"
+TOURNAMENT_ID="hj-indoor-allstars-2025"
+PORT=8787

--- a/server/index.mjs
+++ b/server/index.mjs
@@ -1,0 +1,193 @@
+import http from "node:http";
+import { Pool } from "pg";
+
+const PORT = Number(process.env.PORT) || 8787;
+const API_PATH = "/api";
+const TOURNAMENT_ID = process.env.TOURNAMENT_ID || "hj-indoor-allstars-2025";
+const DATABASE_URL = process.env.DATABASE_URL || "";
+
+if (!DATABASE_URL) {
+  console.error("Missing DATABASE_URL for DB API server.");
+  process.exit(1);
+}
+
+const pool = new Pool({ connectionString: DATABASE_URL });
+
+function sendJson(res, status, payload) {
+  res.writeHead(status, {
+    "Content-Type": "application/json",
+    "Access-Control-Allow-Origin": "*",
+    "Access-Control-Allow-Methods": "GET,OPTIONS",
+    "Access-Control-Allow-Headers": "Content-Type",
+  });
+  res.end(JSON.stringify(payload));
+}
+
+function handleOptions(res) {
+  res.writeHead(204, {
+    "Access-Control-Allow-Origin": "*",
+    "Access-Control-Allow-Methods": "GET,OPTIONS",
+    "Access-Control-Allow-Headers": "Content-Type",
+  });
+  res.end();
+}
+
+function mapFixtureRow(row) {
+  const score1 = row.score1 == null ? "" : row.score1;
+  const score2 = row.score2 == null ? "" : row.score2;
+  const hasScores = row.score1 != null && row.score2 != null;
+  return {
+    Date: row.date,
+    Time: row.time || "",
+    Team1: row.team1,
+    Team2: row.team2,
+    Score1: score1,
+    Score2: score2,
+    Pool: row.pool || "",
+    Venue: row.venue || "",
+    Round: row.round || "",
+    Status: hasScores ? "Final" : "",
+    Age: row.age,
+    ageId: row.age,
+  };
+}
+
+function mapStandingsRow(row) {
+  // Coerce numeric fields to match specs/contracts/Standings_ReadModel_Contract.md.
+  const toNumber = (value) => (value == null ? 0 : Number(value));
+  return {
+    Team: row.team,
+    Rank: toNumber(row.rank),
+    Points: toNumber(row.points),
+    GF: toNumber(row.gf),
+    GA: toNumber(row.ga),
+    GD: toNumber(row.gd),
+    GP: toNumber(row.gp),
+    W: toNumber(row.w),
+    D: toNumber(row.d),
+    L: toNumber(row.l),
+    Pool: row.pool || "",
+    Age: row.age,
+    ageId: row.age,
+  };
+}
+
+async function handleGroups(res) {
+  const result = await pool.query(
+    `SELECT id, label
+     FROM groups
+     WHERE tournament_id = $1
+     ORDER BY id`,
+    [TOURNAMENT_ID]
+  );
+  sendJson(res, 200, { groups: result.rows });
+}
+
+async function handleFixtures(res, ageId) {
+  const result = await pool.query(
+    `SELECT
+       to_char(f.date, 'YYYY-MM-DD') AS date,
+       f.time AS time,
+       t1.name AS team1,
+       t2.name AS team2,
+       r.score1 AS score1,
+       r.score2 AS score2,
+       f.pool AS pool,
+       f.venue AS venue,
+       f.round AS round,
+       f.group_id AS age
+     FROM fixture f
+     JOIN team t1
+       ON t1.tournament_id = f.tournament_id
+      AND t1.id = f.team1_id
+     JOIN team t2
+       ON t2.tournament_id = f.tournament_id
+      AND t2.id = f.team2_id
+     LEFT JOIN result r
+       ON r.tournament_id = f.tournament_id
+      AND r.fixture_id = f.id
+     WHERE f.tournament_id = $1
+       AND f.group_id = $2
+     ORDER BY f.date, f.time, f.fixture_key`,
+    [TOURNAMENT_ID, ageId]
+  );
+  sendJson(res, 200, { rows: result.rows.map(mapFixtureRow) });
+}
+
+async function handleStandings(res, ageId) {
+  const result = await pool.query(
+    `SELECT
+       "Team" AS team,
+       "Rank" AS rank,
+       "Points" AS points,
+       "GF" AS gf,
+       "GA" AS ga,
+       "GD" AS gd,
+       "GP" AS gp,
+       "W" AS w,
+       "D" AS d,
+       "L" AS l,
+       "Pool" AS pool,
+       "Age" AS age
+     FROM v1_standings
+     WHERE tournament_id = $1
+       AND "Age" = $2
+     ORDER BY "Pool", "Rank", "Team"`,
+    [TOURNAMENT_ID, ageId]
+  );
+  sendJson(res, 200, { rows: result.rows.map(mapStandingsRow) });
+}
+
+const server = http.createServer(async (req, res) => {
+  try {
+    if (req.method === "OPTIONS") {
+      handleOptions(res);
+      return;
+    }
+    if (req.method !== "GET") {
+      sendJson(res, 405, { ok: false, error: "Method not allowed" });
+      return;
+    }
+
+    const url = new URL(req.url, `http://${req.headers.host}`);
+    if (url.pathname !== API_PATH) {
+      sendJson(res, 404, { ok: false, error: "Not found" });
+      return;
+    }
+
+    const params = url.searchParams;
+    if (params.get("groups") === "1") {
+      await handleGroups(res);
+      return;
+    }
+
+    const sheet = params.get("sheet");
+    if (!sheet) {
+      sendJson(res, 400, { ok: false, error: "Missing sheet parameter" });
+      return;
+    }
+    const ageId = params.get("age") || "";
+    if (!ageId) {
+      sendJson(res, 400, { ok: false, error: "Missing age parameter" });
+      return;
+    }
+
+    if (sheet === "Fixtures") {
+      await handleFixtures(res, ageId);
+      return;
+    }
+    if (sheet === "Standings") {
+      await handleStandings(res, ageId);
+      return;
+    }
+
+    sendJson(res, 400, { ok: false, error: `Unknown sheet: ${sheet}` });
+  } catch (err) {
+    console.error(err);
+    sendJson(res, 500, { ok: false, error: "Server error" });
+  }
+});
+
+server.listen(PORT, () => {
+  console.log(`DB API server listening on http://localhost:${PORT}${API_PATH}`);
+});

--- a/specs/README.md
+++ b/specs/README.md
@@ -22,6 +22,13 @@ validated snapshots to ensure safe deployments and prevent drift.
 ## Contracts
 
 - [Truth Snapshot Contract](contracts/Truth_Snapshot_Contract.md)
+- [Groups Read Model](contracts/Groups_ReadModel_Contract.md)
+- [Fixtures Read Model](contracts/Fixtures_ReadModel_Contract.md)
+- [Standings Read Model](contracts/Standings_ReadModel_Contract.md)
+- [v1 Groups Read Model](contracts/v1/Groups_ReadModel_Contract.md)
+- [v1 Fixtures Read Model](contracts/v1/Fixtures_ReadModel_Contract.md)
+- [v1 Standings Read Model](contracts/v1/Standings_ReadModel_Contract.md)
+- [Contracts Versioning Rules](contracts/README.md)
 
 ## Acceptance
 

--- a/specs/audit/v1.6-ui-data-usage.md
+++ b/specs/audit/v1.6-ui-data-usage.md
@@ -1,0 +1,79 @@
+# v1.6 UI Data Usage Audit
+
+## Routes, Components, and Fields
+
+| Route | Component | Endpoint | Fields Used | Notes |
+| --- | --- | --- | --- | --- |
+| `/` | `App` (global bootstrap) | `API_BASE?groups=1` | `groups[].id`, `groups[].label` | Normalizes to `{ id, label }`, sorts via `sortGroups` (age numeric then division letter). Used to build age selector and default navigation. |
+| `/` | `Welcome` | `API_BASE?groups=1` (via `App`) | `groups[].id` | Uses first group id as default route target. |
+| `/:ageId/fixtures` | `Fixtures` | `API_BASE?sheet=Fixtures&age={ageId}` | `rows[].Date`, `rows[].Time`, `rows[].Team1`, `rows[].Team2`, `rows[].Score1`, `rows[].Score2`, `rows[].Pool`, `rows[].Group`, `rows[].Venue`, `rows[].Round`, `rows[].Status`, `rows[].ageId`, `rows[].Age`, `rows[].age` | Sorts by `Date` + `Time`. Groups by `Date`. Date filter uses `Date`. Follow filter uses `Team1`, `Team2` + derived age. Pool label normalizes `Pool`/`Group` to `Pool X`. Status derives from `Status` or score presence. |
+| `/:ageId/fixtures` (all ages) | `Fixtures` | `API_BASE?sheet=Fixtures&age={ageId}` (multiple) | Same as above + `__ageId` (derived) | For `all`, merges per-age results, sets `__ageId`, groups by derived age label. Age label uses `groups[].label`. |
+| `/:ageId/standings` | `Standings` | `API_BASE?sheet=Standings&age={ageId}` | `rows[].Team`, `rows[].Rank`, `rows[].Points`, `rows[].GF`, `rows[].GA`, `rows[].GD`, `rows[].GP`, `rows[].P`, `rows[].W`, `rows[].D`, `rows[].L`, `rows[].Pool`, `rows[].Age`, `rows[].age`, `rows[].ageId` | Sorts by `Points`, `GD`, `GF`, then `Team`. Pool filter uses `Pool`. Pool labels: `Pool X`, `All teams`, `Unassigned pool`. Follow filter uses `Team` + derived age. Renders stats with fallbacks `GP ?? P ?? 0`. |
+| `/:ageId/standings` (all ages) | `Standings` | `API_BASE?sheet=Standings&age={ageId}` (multiple) | Same as above + `__ageId` (derived) | Merges per-age results, groups by derived age, sorts age buckets via `groups` order. |
+| `/:ageId/teams` | `TeamsPage` (in `App.jsx`) | `API_BASE?sheet=Standings&age={ageId}` | `rows[].Team`, `rows[].team`, `rows[].Pool`, `rows[].Group`, `rows[].Age`, `rows[].age`, `rows[].ageId` | Derives teams list from standings. Filters out placeholder team names (1st Place, Winner SF1, A1, etc). Pool captured for display; age derived like other pages. |
+| `/:ageId/team/:teamId` | `TeamProfile` | `API_BASE?sheet=Fixtures&age={ageId}` | `rows[].Team1`, `rows[].Team2`, `rows[].Date`, `rows[].Time`, `rows[].Score1`, `rows[].Score2`, `rows[].Pool`, `rows[].Group`, `rows[].Venue`, `rows[].Round`, `rows[].Status` | Filters fixtures by matching `teamId` against `Team1`/`Team2`. Computes stats (GP/W/D/L/GF/GA/PTS), win pct, and result pill. Classifies fixture state from `Status`, `Score*`, `Date`. |
+
+## Contract Freeze Candidates
+
+Minimal response shapes inferred from UI usage.
+
+### Groups (`?groups=1`)
+
+```json
+{
+  "groups": [
+    { "id": "U13B", "label": "U13 Boys" }
+  ]
+}
+```
+
+### Fixtures (`?sheet=Fixtures&age=...`)
+
+```json
+{
+  "rows": [
+    {
+      "Date": "2025-03-02",
+      "Time": "09:00",
+      "Team1": "Blue Crane Rebels",
+      "Team2": "Dragons",
+      "Score1": "2",
+      "Score2": "1",
+      "Pool": "A",
+      "Group": "A",
+      "Venue": "Main Turf",
+      "Round": "Round 1",
+      "Status": "Final",
+      "Age": "U13B",
+      "age": "U13B",
+      "ageId": "U13B"
+    }
+  ]
+}
+```
+
+### Standings (`?sheet=Standings&age=...`)
+
+```json
+{
+  "rows": [
+    {
+      "Team": "Blue Crane Rebels",
+      "Rank": 1,
+      "Points": 9,
+      "GF": 10,
+      "GA": 2,
+      "GD": 8,
+      "GP": 3,
+      "P": 3,
+      "W": 3,
+      "D": 0,
+      "L": 0,
+      "Pool": "A",
+      "Age": "U13B",
+      "age": "U13B",
+      "ageId": "U13B"
+    }
+  ]
+}
+```

--- a/specs/contracts/Fixtures_ReadModel_Contract.md
+++ b/specs/contracts/Fixtures_ReadModel_Contract.md
@@ -1,0 +1,122 @@
+# Contract: Fixtures Read Model
+
+**Status**: Draft  
+**Purpose**: UI compatibility for current Apps Script fixtures output.
+
+---
+
+## Canonical Provider Output (v1.6)
+
+Required fields (case-sensitive):
+- `rows` (array)
+  - `Date` (string)
+  - `Time` (string)
+  - `Team1` (string)
+  - `Team2` (string)
+  - `Score1` (number|string "")
+  - `Score2` (number|string "")
+  - `Pool` (string)
+  - `Venue` (string)
+  - `Round` (string)
+  - `Status` (string)
+  - `Age` (string) or `ageId` (string) or `age` (string)
+
+---
+
+## JSON Shape (required fields)
+
+```json
+{
+  "rows": [
+    {
+      "Date": "2025-03-02",
+      "Time": "09:00",
+      "Team1": "Blue Crane Rebels",
+      "Team2": "Dragons",
+      "Score1": "",
+      "Score2": "",
+      "Pool": "A",
+      "Venue": "Main Turf",
+      "Round": "Round 1",
+      "Status": "Final"
+    }
+  ]
+}
+```
+
+---
+
+## Type Notes
+
+- `Date` is a non-empty string.
+- `Time` is a string; may be `"TBD"` or empty.
+- `Team1` and `Team2` are non-empty strings.
+- `Score1` and `Score2` are numbers or empty strings only.
+- `Pool`, `Venue`, `Round`, `Status`, `Age`, `age`, `ageId` are strings when present.
+
+---
+
+## Normalization Rules (provider MUST apply)
+
+- Always emit `Pool` (may be empty string), never substitute `Group` for `Pool` in the canonical output.
+- Emit `Score1`/`Score2` as numbers or empty strings only.
+- Emit `Time` as a string; use `"TBD"` or `""` when unknown.
+- Use consistent casing for all keys as listed above.
+
+---
+
+## Invariants
+
+- `Pool` may be empty.
+- `Time` may be `"TBD"` or empty.
+- `Score1`/`Score2` may be empty until a result is recorded.
+
+---
+
+## Non-contract / UI-derived fields
+
+- `__ageId` (client-derived when merging multiple ages).
+
+---
+
+## Compatibility Notes
+
+- UI can fall back to `Group` when `Pool` is empty, but provider must emit `Pool`.
+- UI derives age from `Age`/`ageId`/`age`; provider must supply at least one.
+
+---
+
+## Examples
+
+```json
+{
+  "rows": [
+    {
+      "Date": "2025-03-02",
+      "Time": "09:00",
+      "Team1": "Blue Crane Rebels",
+      "Team2": "Dragons",
+      "Score1": 2,
+      "Score2": 1,
+      "Pool": "A",
+      "Venue": "Main Turf",
+      "Round": "Round 1",
+      "Status": "Final",
+      "ageId": "U13B"
+    },
+    {
+      "Date": "2025-03-03",
+      "Time": "TBD",
+      "Team1": "Gladiators",
+      "Team2": "Knights",
+      "Score1": "",
+      "Score2": "",
+      "Group": "B",
+      "Venue": "Secondary",
+      "Round": "Round 1",
+      "Status": "TBC",
+      "Age": "U15G"
+    }
+  ]
+}
+```

--- a/specs/contracts/Groups_ReadModel_Contract.md
+++ b/specs/contracts/Groups_ReadModel_Contract.md
@@ -1,0 +1,72 @@
+# Contract: Groups Read Model
+
+**Status**: Draft  
+**Purpose**: UI compatibility for current Apps Script group output.
+
+---
+
+## Canonical Provider Output (v1.6)
+
+Required fields (case-sensitive):
+- `groups` (array)
+  - `id` (string)
+  - `label` (string)
+
+---
+
+## JSON Shape (required fields)
+
+```json
+{
+  "groups": [
+    { "id": "U13B", "label": "U13 Boys" }
+  ]
+}
+```
+
+---
+
+## Type Notes
+
+- `groups` is an array of objects.
+- `id` is a non-empty string.
+- `label` is a non-empty string.
+
+---
+
+## Normalization Rules (provider MUST apply)
+
+- Always emit `groups` (may be empty).
+- Always emit `id` and `label` as non-empty strings.
+
+---
+
+## Invariants
+
+- `groups` may be empty but must be present.
+- `id` values are used for routing and must be unique.
+
+---
+
+## Non-contract / UI-derived fields
+
+- None.
+
+---
+
+## Compatibility Notes
+
+- UI sorts by age number then division letter, but provider order is not relied on.
+
+---
+
+## Examples
+
+```json
+{
+  "groups": [
+    { "id": "U11B", "label": "U11 Boys" },
+    { "id": "U11G", "label": "U11 Girls" }
+  ]
+}
+```

--- a/specs/contracts/README.md
+++ b/specs/contracts/README.md
@@ -1,0 +1,7 @@
+# Contracts
+
+## Versioning Rules
+
+- v1 contracts are frozen for v1.x compatibility.
+- Only additive changes are allowed within v1.
+- Breaking changes require a new v2 contracts folder.

--- a/specs/contracts/Standings_ReadModel_Contract.md
+++ b/specs/contracts/Standings_ReadModel_Contract.md
@@ -1,0 +1,119 @@
+# Contract: Standings Read Model
+
+**Status**: Draft  
+**Purpose**: UI compatibility for current Apps Script standings output.
+
+---
+
+## Canonical Provider Output (v1.6)
+
+Required fields (case-sensitive):
+- `rows` (array)
+  - `Team` (string)
+  - `Points` (number)
+  - `GF` (number)
+  - `GA` (number)
+  - `GD` (number)
+  - `W` (number)
+  - `D` (number)
+  - `L` (number)
+  - `GP` (number)
+  - `Pool` (string)
+  - `Age` (string) or `ageId` (string) or `age` (string)
+
+---
+
+## JSON Shape (required fields)
+
+```json
+{
+  "rows": [
+    {
+      "Team": "Blue Crane Rebels",
+      "Points": 9,
+      "GF": 10,
+      "GA": 2,
+      "GD": 8,
+      "W": 3,
+      "D": 0,
+      "L": 0
+    }
+  ]
+}
+```
+
+---
+
+## Type Notes
+
+- `Team` is a string (canonical field).
+- `Rank` is a number when present.
+- `Points`, `GF`, `GA`, `GD`, `W`, `D`, `L`, `GP` are numbers.
+- `Pool`, `Age`, `age`, `ageId` are strings when present.
+
+---
+
+## Normalization Rules (provider MUST apply)
+
+- Always emit `Team` (never `team`).
+- Emit numeric fields as numbers, not numeric strings.
+- Always emit `GP` as a number; do not rely on `P` fallback.
+- Always emit `Pool` (may be empty string), never substitute `Group` for `Pool` in the canonical output.
+- Use consistent casing for all keys as listed above.
+
+---
+
+## Invariants
+
+- `Pool` may be empty.
+- `Rank` may be missing; UI uses row order.
+
+---
+
+## Non-contract / UI-derived fields
+
+- `__ageId` (client-derived when merging multiple ages).
+
+---
+
+## Compatibility Notes
+
+- UI can fall back to `team`, `P`, or `Group`, but provider must emit canonical fields.
+
+---
+
+## Examples
+
+```json
+{
+  "rows": [
+    {
+      "Team": "Blue Crane Rebels",
+      "Rank": 1,
+      "Points": 9,
+      "GF": 10,
+      "GA": 2,
+      "GD": 8,
+      "GP": 3,
+      "W": 3,
+      "D": 0,
+      "L": 0,
+      "Pool": "A",
+      "ageId": "U13B"
+    },
+    {
+      "Team": "Knights",
+      "Points": 6,
+      "GF": 7,
+      "GA": 4,
+      "GD": 3,
+      "GP": 3,
+      "W": 2,
+      "D": 0,
+      "L": 1,
+      "Pool": "B",
+      "Age": "U15G"
+    }
+  ]
+}
+```

--- a/specs/contracts/v1/Fixtures_ReadModel_Contract.md
+++ b/specs/contracts/v1/Fixtures_ReadModel_Contract.md
@@ -1,0 +1,81 @@
+# Contract: Fixtures Read Model (v1)
+
+**Purpose**: UI compatibility for v1.6 fixtures, team profile fixtures, and follow filters.
+
+---
+
+## Schema (JSON-ish)
+
+Top-level:
+- `rows` (array, required)
+  - `Date` (string, required)
+  - `Time` (string, optional)
+  - `Team1` (string, required)
+  - `Team2` (string, required)
+  - `Score1` (string|number, optional)
+  - `Score2` (string|number, optional)
+  - `Pool` (string, optional)
+  - `Group` (string, optional)
+  - `Venue` (string, optional)
+  - `Round` (string, optional)
+  - `Status` (string, optional)
+  - `Age` (string, optional)
+  - `age` (string, optional)
+  - `ageId` (string, optional)
+
+---
+
+## Invariants and Normalization
+
+- `Date` is a non-empty string; client uses it for grouping and date filtering.
+- `Time` may be missing; UI treats missing/empty as "TBD".
+- `Team1` and `Team2` are non-empty strings.
+- `Score1`/`Score2` may be empty or missing; UI treats empty as no score.
+- `Pool` is used for display; if missing, `Group` is used as fallback.
+- Status is normalized client-side to `live|postponed|cancelled|tbc|final|upcoming`.
+
+---
+
+## Provider/Client Notes
+
+- `Status` is provider-derived; client lowercases and defaults to `final` when scores present, otherwise `upcoming`.
+- `ageId`/`age`/`Age` are used to derive age buckets for "all ages".
+- `Group` is a fallback for `Pool` when present in provider data.
+- `__ageId` is client-derived when merging multiple ages; not required from provider.
+
+---
+
+## Example Rows
+
+```json
+{
+  "rows": [
+    {
+      "Date": "2025-03-02",
+      "Time": "09:00",
+      "Team1": "Blue Crane Rebels",
+      "Team2": "Dragons",
+      "Score1": "2",
+      "Score2": "1",
+      "Pool": "A",
+      "Venue": "Main Turf",
+      "Round": "Round 1",
+      "Status": "Final",
+      "ageId": "U13B"
+    },
+    {
+      "Date": "2025-03-03",
+      "Time": "",
+      "Team1": "Gladiators",
+      "Team2": "Knights",
+      "Score1": "",
+      "Score2": "",
+      "Group": "B",
+      "Venue": "Secondary",
+      "Round": "Round 1",
+      "Status": "TBC",
+      "Age": "U15G"
+    }
+  ]
+}
+```

--- a/specs/contracts/v1/Groups_ReadModel_Contract.md
+++ b/specs/contracts/v1/Groups_ReadModel_Contract.md
@@ -1,0 +1,40 @@
+# Contract: Groups Read Model (v1)
+
+**Purpose**: UI compatibility for v1.6 group selection and routing.
+
+---
+
+## Schema (JSON-ish)
+
+Top-level:
+- `groups` (array, required)
+  - `id` (string, required)
+  - `label` (string, required)
+
+---
+
+## Invariants and Normalization
+
+- `groups` is an array; order may be arbitrary but UI sorts by age number then division letter.
+- `id` is a non-empty string used in routes and API queries.
+- `label` is a non-empty string used in UI labels.
+
+---
+
+## Provider/Client Notes
+
+- Client normalizes to `{ id, label }` and applies sort order.
+- No additional client-derived fields.
+
+---
+
+## Example Rows
+
+```json
+{
+  "groups": [
+    { "id": "U13B", "label": "U13 Boys" },
+    { "id": "U13G", "label": "U13 Girls" }
+  ]
+}
+```

--- a/specs/contracts/v1/Standings_ReadModel_Contract.md
+++ b/specs/contracts/v1/Standings_ReadModel_Contract.md
@@ -1,0 +1,85 @@
+# Contract: Standings Read Model (v1)
+
+**Purpose**: UI compatibility for v1.6 standings, teams list, and follow filters.
+
+---
+
+## Schema (JSON-ish)
+
+Top-level:
+- `rows` (array, required)
+  - `Team` (string, optional)
+  - `team` (string, optional)
+  - `Rank` (number|string, optional)
+  - `Points` (number|string, required)
+  - `GF` (number|string, required)
+  - `GA` (number|string, required)
+  - `GD` (number|string, required)
+  - `GP` (number|string, optional)
+  - `P` (number|string, optional)
+  - `W` (number|string, required)
+  - `D` (number|string, required)
+  - `L` (number|string, required)
+  - `Pool` (string, optional)
+  - `Group` (string, optional)
+  - `Age` (string, optional)
+  - `age` (string, optional)
+  - `ageId` (string, optional)
+
+---
+
+## Invariants and Normalization
+
+- `Team` (or `team`) is required for UI rendering and follow keys.
+- `Points`, `GF`, `GA`, `GD`, `W`, `D`, `L` must parse to numbers; UI coerces via `+value` and defaults to 0.
+- `GP` may be missing; UI falls back to `P`.
+- `Rank` may be missing; UI falls back to row order.
+- `Pool` is used for grouping; if missing, `Group` is used as fallback.
+
+---
+
+## Provider/Client Notes
+
+- `Rank` is optional; UI calculates from index when missing.
+- `GP` vs `P` fallback is client-side (`GP ?? P ?? 0`).
+- `ageId`/`age`/`Age` are used to derive age buckets for "all ages".
+- `Group` is a fallback for `Pool` when present in provider data.
+- `__ageId` is client-derived when merging multiple ages; not required from provider.
+
+---
+
+## Example Rows
+
+```json
+{
+  "rows": [
+    {
+      "Team": "Blue Crane Rebels",
+      "Rank": 1,
+      "Points": 9,
+      "GF": 10,
+      "GA": 2,
+      "GD": 8,
+      "GP": 3,
+      "W": 3,
+      "D": 0,
+      "L": 0,
+      "Pool": "A",
+      "ageId": "U13B"
+    },
+    {
+      "team": "Knights",
+      "Points": "6",
+      "GF": "7",
+      "GA": "4",
+      "GD": "3",
+      "P": "3",
+      "W": "2",
+      "D": "0",
+      "L": "1",
+      "Group": "B",
+      "Age": "U15G"
+    }
+  ]
+}
+```

--- a/specs/db/ingestion_v1.6.md
+++ b/specs/db/ingestion_v1.6.md
@@ -1,0 +1,77 @@
+# Ingestion v1.6 (Preview First)
+
+## Overview
+
+This pipeline ingests v1.6 read-model data into Postgres. The default mode is preview-only: it fetches data, normalizes to the frozen v1 contracts, validates, and writes a report without touching the database.
+
+---
+
+## Preview (no DB writes)
+
+```sh
+node scripts/ingest.mjs \
+  --fixtures-sheet-id 1TT9CHE-L_HmrXuuVGGJy1_p4PYkw-IXkhcTt84UdUEU \
+  --teams-sheet-id 1BFHC_NmY7CIlTvMopE-9BftnSzOA2AJpQ37tqnXZnTs
+```
+
+Optional: use Apps Script API if available.
+
+```sh
+node scripts/ingest.mjs --api-base "$VITE_API_BASE"
+```
+
+You can also pass the API base as `--api-base="$VITE_API_BASE"`. Use `--debug-args` to print the parsed args and resolved provider choice before ingestion continues.
+
+---
+
+## Commit (DB writes)
+
+```sh
+export DATABASE_URL="postgres://postgres:postgres@localhost:5432/hockey"
+node scripts/ingest.mjs --commit
+```
+
+---
+
+## DB API server (UI provider)
+
+Run the DB-backed API server and point the UI at it (no UI component changes required).
+
+```sh
+export DATABASE_URL="postgres://postgres:postgres@localhost:5432/hockey"
+export TOURNAMENT_ID="hj-indoor-allstars-2025"
+node server/index.mjs
+```
+
+Then set the UI env vars:
+
+```sh
+export VITE_PROVIDER="db"
+export VITE_DB_API_BASE="http://localhost:8787/api"
+```
+
+---
+
+## Reports
+
+- Written to `reports/ingestion/` by default.
+- Includes counts, duplicates, validation errors, and group summaries.
+
+---
+
+## Notes
+
+- Fixtures and standings are normalized to the v1 contracts.
+- `Score1`/`Score2` are stored as integers; empty scores map to NULL.
+- Placeholder teams are auto-created when fixtures reference unknown teams.
+
+---
+
+## Smoke tests (DB API)
+
+```sh
+curl "http://localhost:8787/api?groups=1"
+curl "http://localhost:8787/api?sheet=Fixtures&age=U13B"
+curl "http://localhost:8787/api?sheet=Standings&age=U13B"
+python -c "import json,urllib.request; data=json.load(urllib.request.urlopen('http://localhost:8787/api?sheet=Standings&age=U13B')); row=data['rows'][0] if data['rows'] else {}; print({k:type(row.get(k)).__name__ for k in ['Rank','Points','GF','GA','GD','GP','W','D','L']})"
+```

--- a/specs/db/schema_v1.6.md
+++ b/specs/db/schema_v1.6.md
@@ -1,0 +1,105 @@
+# Postgres Schema v1.6 (Truth Read Models)
+
+## Goals
+
+- Store canonical provider output for v1 read-model contracts.
+- Support fixtures + results ingestion and computed standings.
+- Preserve auditability for traceability and replays.
+
+---
+
+## Tables
+
+### tournament
+
+- **Columns**: `id` (PK), `name`, `season`, `created_at`, `source`, `source_row_hash`, `ingested_at`
+- **Primary key**: `id`
+- **Notes**: one row per tournament feed.
+
+### groups (division/age group)
+
+- **Columns**: `tournament_id` (FK), `id`, `label`, `format`, `created_at`, `source`, `source_row_hash`, `ingested_at`
+- **Primary key**: `(tournament_id, id)`
+- **Foreign keys**: `tournament_id -> tournament(id)`
+- **Notes**: `id` matches v1 groups contract.
+
+### team
+
+- **Columns**: `tournament_id` (FK), `id`, `group_id` (FK), `name`, `is_placeholder`, `created_at`, `source`, `source_row_hash`, `ingested_at`
+- **Primary key**: `(tournament_id, id)`
+- **Foreign keys**: `(tournament_id, group_id) -> groups(tournament_id, id)`
+- **Notes**: `is_placeholder` flags derived/placeholder teams.
+
+### fixture
+
+- **Columns**: `tournament_id` (FK), `id`, `group_id` (FK), `date`, `time`, `venue`, `round`, `pool`, `team1_id` (FK), `team2_id` (FK), `fixture_key`, `created_at`, `source`, `source_row_hash`, `ingested_at`
+- **Primary key**: `(tournament_id, id)`
+- **Unique constraints**: `(tournament_id, fixture_key)`
+- **Foreign keys**:
+  - `(tournament_id, group_id) -> groups(tournament_id, id)`
+  - `(tournament_id, team1_id) -> team(tournament_id, id)`
+  - `(tournament_id, team2_id) -> team(tournament_id, id)`
+- **Notes**: `time` is text to preserve `"TBD"` and raw provider values.
+
+### result
+
+- **Columns**: `tournament_id` (FK), `fixture_id` (FK), `score1`, `score2`, `status`, `updated_at`, `source`, `source_row_hash`, `ingested_at`
+- **Primary key**: `(tournament_id, fixture_id)`
+- **Foreign keys**: `(tournament_id, fixture_id) -> fixture(tournament_id, id)`
+- **Notes**: `score1`/`score2` remain nullable; provider outputs numbers or empty string, ingestion maps `""` to NULL.
+
+---
+
+## Indexes
+
+- `groups(tournament_id)`
+- `team(tournament_id, group_id)`
+- `team(tournament_id, name)`
+- `fixture(tournament_id, group_id, date)`
+- `fixture(tournament_id, team1_id)`
+- `fixture(tournament_id, team2_id)`
+- `result(tournament_id, status)`
+
+---
+
+## What Is Stored vs Computed
+
+- **Stored**: canonical provider rows for groups, teams, fixtures, results.
+- **Computed**: standings are derived from `fixture` + `result` using a SQL view (`v1_standings`).
+
+---
+
+## Computed Standings (View)
+
+- **View**: `v1_standings`
+- **Emits**: `Team`, `Rank`, `Points`, `GF`, `GA`, `GD`, `GP`, `W`, `D`, `L`, `Pool`, `Age`
+- **Logic**: sums per team over completed fixtures (scores present), assigns rank by Points/GD/GF/team name.
+
+---
+
+## Auditability Fields
+
+- `source`: string identifier for provider (e.g., `SheetsProvider`, `DbProvider`).
+- `source_row_hash`: stable hash of raw provider row for change detection.
+- `ingested_at`: timestamp for ingestion time.
+
+---
+
+## Local Migrations
+
+Prereqs: `psql` and a local Postgres instance.
+
+Example (local):
+
+```sh
+export DATABASE_URL="postgres://postgres:postgres@localhost:5432/hockey"
+./db/migrate.sh
+```
+
+Optional Docker example:
+
+```sh
+docker run --rm -e POSTGRES_PASSWORD=postgres -p 5432:5432 --name hockey-db postgres:16
+export DATABASE_URL="postgres://postgres:postgres@localhost:5432/postgres"
+./db/migrate.sh
+```

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -1,12 +1,16 @@
 // src/lib/api.js
-export const API_BASE = import.meta.env.VITE_API_BASE;
+const PROVIDER = import.meta.env.VITE_PROVIDER || "apps";
+export const API_BASE =
+  PROVIDER === "db" ? import.meta.env.VITE_DB_API_BASE : import.meta.env.VITE_API_BASE;
 const APP_VER  = import.meta.env.VITE_APP_VERSION || "v1";
 const MAX_AGE_MS = 60_000; // 60s client-side cache
 
 function cacheKey(url) { return `hj:cache:${APP_VER}:${url}`; }
 
 async function fetchJSON(url, { revalidate = true } = {}) {
-  if (!API_BASE) throw new Error("Missing VITE_API_BASE");
+  if (!API_BASE) {
+    throw new Error(`Missing API base for provider: ${PROVIDER}`);
+  }
 
   const key = cacheKey(url);
   const cached = sessionStorage.getItem(key);


### PR DESCRIPTION
## Summary
- Add v1.6 Postgres schema + migrations and ingestion pipeline for read models.
- Introduce minimal DB-backed `/api` server (no framework) with Apps Script-compatible endpoints.
- Add provider switching via env (`VITE_PROVIDER`, `VITE_DB_API_BASE`) without UI changes.
- Update v1 contracts/docs and DB ingestion notes; ensure local reports stay ignored.

## How to test
- `export DATABASE_URL="postgres://postgres:postgres@localhost:5432/hockey"`
- `export TOURNAMENT_ID="hj-indoor-allstars-2025"`
- `npm run server`
- In another terminal:
  - `export VITE_PROVIDER="db"`
  - `export VITE_DB_API_BASE="http://localhost:8787/api"`
  - `npm run dev`
- Smoke checks:
  - `curl "http://localhost:8787/api?groups=1"`
  - `curl "http://localhost:8787/api?sheet=Fixtures&age=U13B"`
  - `curl "http://localhost:8787/api?sheet=Standings&age=U13B"`
  - `python -c "import json,urllib.request; data=json.load(urllib.request.urlopen('http://localhost:8787/api?sheet=Standings&age=U13B')); row=data['rows'][0] if data['rows'] else {}; print({k:type(row.get(k)).__name__ for k in ['Rank','Points','GF','GA','GD','GP','W','D','L']})"`
- Verify fixtures + standings pages render in the UI.