### PR TITLE
chore: add production Dockerfile for Node API

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM node:20-alpine
+
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+RUN npm ci --omit=dev
+
+COPY . .
+
+ENV NODE_ENV=production
+ENV PORT=8787
+
+EXPOSE 8787
+
+CMD ["node", "api/server.js"]


### PR DESCRIPTION
## Change type

- [X] Docs/Chore

## Checklist (definition of done)

- [X] `npm ci`
- [X] `npm run lint`
- [X] `npm run build`

## Risk

- Risk level: Low
- Rollback plan:
  - [X] Revert commit

## Validation

Describe what you tested and how:

- Steps:
1. Added root Dockerfile to run existing Node API (node api/server.js) with PORT=8787.
2. Built container locally (optional) or validated repository-only change with npm ci, npm run lint, npm run build.
3. Deploy to Northflank after merge and verify endpoint: /api?groups=1.

- Expected:
• Repo build/lint succeeds.
• Northflank detects /Dockerfile and can build.
• API responds with JSON for /api?groups=1.

- Actual:
• npm ci, npm run lint, npm run build pass locally.
• Northflank deployment to be validated immediately after the merge.

## Snapshot expectations (main merges)
When this is merged to `main`, the Snapshot workflow will publish a build artefact. This change should not affect the static build output; it only adds a Dockerfile for the API deployment.

- [X] I’m okay with this being captured in the snapshot artefact.
