### PR TITLE
fix: start API from server/index.mjs in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,4 +12,4 @@ ENV PORT=8787
 
 EXPOSE 8787
 
-CMD ["node", "api/server.js"]
+CMD ["node", "server/index.mjs"]


### PR DESCRIPTION
## Change type

- [x] Fix

## Checklist (definition of done)

- [x] `npm ci`
- [x] `npm run lint`
- [x] `npm run build`

## Risk

- Risk level: Low
- Rollback plan:
  - [x] Revert commit

## Validation

Describe what you tested and how:

- Steps:

• Identified Northflank runtime error: Cannot find module /app/api/server.js.
• Confirmed correct API entrypoint from package.json (server/index.mjs).
• Updated Dockerfile CMD to start server/index.mjs.
• Deployed service on Northflank after the merge.

- Expected:

• Container starts without module resolution errors.
• Node API process stays running.
• /api?groups=1 responds with JSON over HTTPS.

- Actual:

• Docker container starts successfully.
• Node process remains running.
• API responds correctly on Northflank.

## Snapshot expectations (main merges)
When this is merged to `main`, the Snapshot workflow will publish a build artefact. This change only updates the Dockerfile start command and does not affect the static frontend build or snapshot artefacts.

- [x] I’m okay with this being captured in the snapshot artefact.
