### PR TITLE
chore: point production VITE_API_BASE to Northflank API

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -1,2 +1,2 @@
-VITE_API_BASE=https://script.google.com/macros/s/AKfycbwiie6uVPuVMRsKFiV2ALQoPkR9SwihsFDab3Lkvr4asFsF0zk4B6bnVOnQMP1YSIN6cw/exec
+VITE_API_BASE=https://p01--hj-api--wlt9xynp45bk.code.run/api
 VITE_APP_VERSION=${GITHUB_SHA}

--- a/docs/provider-switch.md
+++ b/docs/provider-switch.md
@@ -5,4 +5,6 @@ The DB API server supports two modes via `PROVIDER_MODE`:
 - `apps` (default): proxies to Apps Script via `APPS_SCRIPT_BASE_URL`.
 - `db`: requires `DATABASE_URL` to be set; serves the DB-backed read models.
 
+Production frontend uses the Northflank API (apps mode proxy).
+
 Set `PROVIDER_MODE=db` when running the DB API server in production or local DB mode. When `PROVIDER_MODE` is unset or invalid, the server defaults to `apps`.


### PR DESCRIPTION
## Change type

- [x] Docs/Chore

## Checklist (definition of done)

- [x] `npm ci`
- [x] `npm run lint`
- [x] `npm run build`

## Risk

- Risk level: Low
- Rollback plan:
  - [x] Revert commit

## Validation

Describe what you tested and how:

- Steps:

• Ran npm ci
• Ran npm run lint
• Ran npm run build
• Verified production API parity against Apps Script using curl + diff:
*GET /api?groups=1
*GET /api?sheet=Fixtures&age=U13B
*GET /api?sheet=Standings&age=U13B
• Confirmed .env.production now points VITE_API_BASE to the Northflank /api endpoint.

Expected:

• Lint/build succeed.
• Northflank API returns the same JSON as Apps Script for the tested endpoints.
• Production build will use Northflank as the API base without UI code changes.

Actual:

• npm ci, npm run lint, and npm run build all succeeded.
• Parity checks passed: no diffs for groups/fixtures/standings for U13B.
• .env.production updated and documented in docs/provider-switch.md.

## Snapshot expectations (main merges)

When this is merged to `main`, the Snapshot workflow will publish a build artefact.

- [x] I’m okay with this being captured in the snapshot artefact.
