### PR TITLE
chore: add smoke helper with local server

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "lint": "eslint .",
     "smoke:apps": "node scripts/smoke.mjs --provider apps",
     "smoke:db": "node scripts/smoke.mjs --provider db",
+    "smoke:db:server": "node scripts/smoke-with-server.mjs --provider db",
     "test": "vitest run",
     "test:app:sheets": "node scripts/test-app.mjs --provider apps",
     "test:app:db": "node scripts/test-app.mjs --provider db",

--- a/scripts/smoke-with-server.mjs
+++ b/scripts/smoke-with-server.mjs
@@ -1,0 +1,53 @@
+import { spawn } from "node:child_process";
+
+const SERVER_URL = "http://localhost:8787/api?groups=1";
+const TIMEOUT_MS = 20_000;
+const INTERVAL_MS = 500;
+
+async function waitForServer() {
+  const start = Date.now();
+  while (Date.now() - start < TIMEOUT_MS) {
+    try {
+      const res = await fetch(SERVER_URL);
+      if (res.ok) return;
+    } catch {
+      // ignore and retry
+    }
+    await new Promise((resolve) => setTimeout(resolve, INTERVAL_MS));
+  }
+  throw new Error("Timed out waiting for DB API server");
+}
+
+function killProcess(child) {
+  if (!child || child.exitCode != null) return;
+  child.kill("SIGTERM");
+  setTimeout(() => {
+    if (child.exitCode == null) child.kill("SIGKILL");
+  }, 5_000);
+}
+
+async function run() {
+  const server = spawn("node", ["server/index.mjs"], {
+    stdio: "inherit",
+    env: process.env,
+  });
+
+  try {
+    await waitForServer();
+    const smoke = spawn("node", ["scripts/smoke.mjs", "--provider", "db"], {
+      stdio: "inherit",
+      env: process.env,
+    });
+    const code = await new Promise((resolve) =>
+      smoke.on("exit", (exitCode) => resolve(exitCode ?? 1))
+    );
+    killProcess(server);
+    process.exit(code);
+  } catch (err) {
+    killProcess(server);
+    console.error(err && err.message ? err.message : String(err));
+    process.exit(1);
+  }
+}
+
+run();


### PR DESCRIPTION
## Change type

- [x] Docs/Chore

## Checklist (definition of done)

- [x] `npm ci`
- [x] `npm run lint`
- [x] `npm run build`
- [x] Screenshots attached (UI changes)
- [x] Notes added for release / stakeholders (if relevant)

## Risk

- Risk level: Low / Medium / High
- Rollback plan:
  - [x] Revert commit

## Validation

Describe what you tested and how:

- Steps:
  1. `source .env.supabase.local`
  2. `export PROVIDER_MODE=db`
  3. `export PG_TLS_INSECURE=1` (local-only, if needed for Supabase TLS)
  4. `npm run smoke:db:server`
- Expected:
  - DB API server starts locally
  - Smoke test hits `/api` successfully using DB provider
  - Server shuts down cleanly and command exits 0
- Actual:
  - Pass (see local output)

## Snapshot expectations (main merges)

When this is merged to `main`, the Snapshot workflow will publish a build artefact.

- [x] I’m okay with this being captured in the snapshot artefact.
