### PR TITLE
chore: add pg ssl reject toggle

### DIFF
--- a/server/index.mjs
+++ b/server/index.mjs
@@ -7,6 +7,8 @@ const TOURNAMENT_ID = process.env.TOURNAMENT_ID || "hj-indoor-allstars-2025";
 const DATABASE_URL = process.env.DATABASE_URL || "";
 const APPS_SCRIPT_BASE_URL = process.env.APPS_SCRIPT_BASE_URL || "";
 const PROVIDER_MODE = process.env.PROVIDER_MODE === "db" ? "db" : "apps";
+const sslFlag = (process.env.PG_SSL_REJECT_UNAUTHORIZED || "").toLowerCase();
+const rejectUnauthorized = !["0", "false", "no"].includes(sslFlag);
 
 if (PROVIDER_MODE === "db" && !DATABASE_URL) {
   console.error("Missing DATABASE_URL for DB API server (PROVIDER_MODE=db).");
@@ -14,7 +16,9 @@ if (PROVIDER_MODE === "db" && !DATABASE_URL) {
 }
 
 const pool =
-  PROVIDER_MODE === "db" ? new Pool({ connectionString: DATABASE_URL }) : null;
+  PROVIDER_MODE === "db"
+    ? new Pool({ connectionString: DATABASE_URL, ssl: { rejectUnauthorized } })
+    : null;
 
 function sendJson(res, status, payload) {
   res.writeHead(status, {


### PR DESCRIPTION
## Change type

- [x] Docs/Chore

## Checklist (definition of done)

- [x] `npm ci`

## Risk

- Risk level: Low / Medium / High
- Rollback plan:
  - [x] Revert commit

## Validation

Describe what you tested and how:

- Steps:
• Set PROVIDER_MODE=db and ran the DB API server against an SSL-capable DB.
• Verified TLS behaviour changes via PG_SSL_REJECT_UNAUTHORIZED toggle.

- Expected:
• Default remains secure (TLS verification ON).
• Setting PG_SSL_REJECT_UNAUTHORIZED=0 disables certificate verification while keeping SSL enabled.

- Actual:
• Behaviour matches expectations. Local Postgres without SSL fails (expected), toggle intended for Supabase/SSL environments.

## Snapshot expectations (main merges)

When this is merged to `main`, the Snapshot workflow will publish a build artefact.

- [x] I’m okay with this being captured in the snapshot artefact.
