### PR TITLE
fix: define rejectUnauthorized for PG_TLS_INSECURE

### DIFF
--- a/server/index.mjs
+++ b/server/index.mjs
@@ -8,6 +8,7 @@ const DATABASE_URL = process.env.DATABASE_URL || "";
 const APPS_SCRIPT_BASE_URL = process.env.APPS_SCRIPT_BASE_URL || "";
 const PROVIDER_MODE = process.env.PROVIDER_MODE === "db" ? "db" : "apps";
 const tlsInsecureFlag = (process.env.PG_TLS_INSECURE || "").toLowerCase();
+let rejectUnauthorized = true;
 
 if (PROVIDER_MODE === "db" && !DATABASE_URL) {
   console.error("Missing DATABASE_URL for DB API server (PROVIDER_MODE=db).");
@@ -15,8 +16,9 @@ if (PROVIDER_MODE === "db" && !DATABASE_URL) {
 }
 
 // Local escape hatch only — secure by default
-if (PROVIDER_MODE === "db" && ["1", "true"].includes(tlsInsecureFlag)) {
+if (PROVIDER_MODE === "db" && ["1", "true", "yes"].includes(tlsInsecureFlag)) {
   process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
+  rejectUnauthorized = false;
 }
 
 const pool =


### PR DESCRIPTION
# fix: define rejectUnauthorized for PG_TLS_INSECURE

## Change type
- [x] Fix

## Checklist (definition of done)
- [x] `npm ci`
- [x] `npm run lint`
- [x] `npm run build`

## Risk
- Risk level: Low
- Rollback plan:
  - [x] Revert commit

## Validation
Describe what you tested and how:

- Steps:
  - Run `npm run smoke:db:server` (DB provider) with Supabase env.
  - Optionally set `PG_TLS_INSECURE=1` for local tests if TLS verification fails.
- Expected:
  - DB API server starts without crashing.
  - Smoke test reaches `/api/groups` and completes successfully.
- Actual:
  - (fill in from output)

## Snapshot expectations (main merges)
When this is merged to `main`, the Snapshot workflow will publish a build artifact.

- [x] I’m okay with this being captured in the snapshot artifact.
