### PR TITLE
docs: add production cutover runbook

### DIFF
--- a/docs/prod-cutover.md
+++ b/docs/prod-cutover.md
@@ -1,0 +1,58 @@
+# Production Cutover Runbook (Apps Script -> Supabase DB)
+
+## Context and Goals
+
+- Move the HJ Hockey App API from Apps Script (Sheets provider) to Supabase Postgres (DB provider).
+- Zero schema changes and no destructive operations.
+- Fast rollback (single env toggle).
+- Do not use `NODE_TLS_REJECT_UNAUTHORIZED` in production.
+
+## Preflight Checklist
+
+- `/health` returns 200.
+- `PROVIDER_MODE=db` is intended for the cutover window.
+- Required env vars are present in Northflank.
+
+## Northflank Environment Variables
+
+- `PROVIDER_MODE=db`
+- `DATABASE_URL` (Supabase pooler connection string; code strips query params for node-postgres)
+- `APPS_SCRIPT_BASE_URL` (only needed for rollback to apps mode)
+- `PG_TLS_INSECURE=1` (TEMPORARY: required due to `SELF_SIGNED_CERT_IN_CHAIN`; follow up with CA-based verification)
+
+## Deployment Steps
+
+1) Set env vars in Northflank.
+2) Redeploy or restart the service.
+
+## Validation Commands (Expected 200)
+
+```sh
+curl -sS "https://p01--hj-api--wlt9xynp45bk.code.run/health"
+curl -sS "https://p01--hj-api--wlt9xynp45bk.code.run/api?groups=1"
+curl -sS "https://p01--hj-api--wlt9xynp45bk.code.run/api?sheet=Fixtures&age=U13B"
+curl -sS "https://p01--hj-api--wlt9xynp45bk.code.run/api?sheet=Standings&age=U13B"
+```
+
+## Parity Expectations
+
+- Rows present for groups, fixtures, and standings.
+- Shapes include `Age`/`ageId`.
+- Fixtures include `Status`.
+
+## Monitoring (First 15 Minutes)
+
+- Error rate spikes.
+- Latency regression.
+- Logs for TLS handshake or DB connection errors.
+
+## Rollback Plan (Single Step)
+
+- Set `PROVIDER_MODE=apps` (or unset) and restart.
+- Ensure `APPS_SCRIPT_BASE_URL` is set.
+
+## Post-Cutover Follow-Ups
+
+- Remove `PG_TLS_INSECURE` from prod by adding proper CA chain handling.
+- Add a DB connectivity health signal when `PROVIDER_MODE=db` (optional).
+- Add a docs note about zsh quoting for curl URLs with `?`.


### PR DESCRIPTION
## Change type

- [ ] Feature
- [ ] Fix
- [x] Docs/Chore
- [ ] Refactor

## Checklist (definition of done)

- [x] `npm ci`
- [x] `npm run lint`
- [x] `npm run build`
- [ ] Screenshots attached (UI changes)
- [x] Notes added for release / stakeholders (runbook added)

## Risk

- Risk level: **Low**
- Rollback plan:
  - [x] Revert commit
  - [ ] Forward fix

## Validation

Describe what you tested and how:

- **Steps:**
  - Verified production API health endpoint
  - Verified DB-backed endpoints in production:
    - `/api?groups=1`
    - `/api?sheet=Fixtures&age=U13B`
    - `/api?sheet=Standings&age=U13B`
  - Confirmed provider mode is DB-backed via Supabase
  - Confirmed temporary TLS workaround (`PG_TLS_INSECURE=1`) is documented

- **Expected:**
  - Endpoints return valid JSON with expected rows
  - No schema changes or destructive operations
  - Rollback path clearly documented

- **Actual:**
  - All endpoints returned expected data from Supabase
  - Production cutover completed successfully
  - Runbook accurately captures steps, validation, and rollback

## Snapshot expectations (main merges)

When this is merged to `main`, the Snapshot workflow will publish a build artefact.

- [x] I’m okay with this being captured in the snapshot artefact.
