### PR TITLE
docs: make release hygiene checklist enforceable

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,6 +13,12 @@
 - [ ] Screenshots attached (UI changes)
 - [ ] Notes added for release / stakeholders (if relevant)
 
+## Release / Production changes
+
+- [ ] I ran `docs/release-hygiene-checklist.md` (required if prod/release/cutover)
+- [ ] This PR changes production env/provider behaviour (yes/no)
+- [ ] Rollback plan included (env toggle + restart)
+
 ## Risk
 
 - Risk level: Low / Medium / High

--- a/docs/release-hygiene-checklist.md
+++ b/docs/release-hygiene-checklist.md
@@ -1,0 +1,91 @@
+# Release Hygiene Checklist
+
+## When to use this checklist
+
+- Are you switching `PROVIDER_MODE` in production? YES/NO
+- Are you changing Northflank/Supabase env vars? YES/NO
+- Are you creating or pushing a git tag (`vX.Y.Z`)? YES/NO
+- Are you merging something that will deploy to production? YES/NO
+
+If YES to any, run this checklist.
+
+## Stop conditions (do not proceed)
+
+- Working tree is dirty or `main` is not synced to `origin/main`.
+- `npm run lint` or `npm run build` fails.
+- `/health` does not return HTTP 200.
+- Required prod env vars are missing or unclear.
+- Rollback path is not confirmed.
+- Production smoke checks fail or return non-200.
+
+## Preflight (local)
+
+- Clean tree and sync main
+
+```bash
+git status -sb
+git fetch origin
+git switch main
+git pull --ff-only
+```
+
+- Install deps, lint, build
+
+```bash
+npm ci
+npm run lint
+npm run build
+```
+
+- Smoke tests (as applicable)
+
+```bash
+npm run smoke:apps
+npm run smoke:db:server
+```
+
+## Preflight (prod)
+
+- Confirm provider mode and env vars are set
+- Confirm rollback path is known
+
+## Release (tag)
+
+```bash
+git fetch origin
+git switch main
+git pull --ff-only
+git rev-parse HEAD
+git tag -a vX.Y.Z -m "vX.Y.Z"
+git push origin vX.Y.Z
+```
+
+## Post-release
+
+```bash
+export PROD_API_BASE="https://p01--hj-api--wlt9xynp45bk.code.run"
+curl -i "$PROD_API_BASE/health"
+curl -sS "$PROD_API_BASE/api?groups=1"
+curl -sS "$PROD_API_BASE/api?sheet=Fixtures&age=U13B" | head -c 200
+```
+
+- Monitor logs/errors and note rollout status
+- Record the release in `docs/release-audit-trail.md`
+
+## Rollback quick-step
+
+```bash
+export PROD_API_BASE="https://p01--hj-api--wlt9xynp45bk.code.run"
+curl -i "$PROD_API_BASE/health"
+curl -sS "$PROD_API_BASE/api?sheet=Fixtures&age=U13B" | head -c 200
+```
+
+- Set `PROVIDER_MODE=apps` (or unset) and restart
+- Ensure `APPS_SCRIPT_BASE_URL` is set
+
+## Definition of Done
+
+- Runbook updated (if prod change).
+- Release audit trail updated.
+- Tag pushed (if a release).
+- Follow-ups captured.


### PR DESCRIPTION
## Summary

This PR makes the **release hygiene checklist enforceable** by embedding production-safety gates directly into the pull request workflow.

It ensures that any change capable of affecting production (provider switches, infra changes, releases, cutovers) must explicitly confirm:
- preflight checks were run,
- rollback is understood,
- and post-release validation is planned.

This closes the gap between *“we should remember to do this”* and *“we cannot merge unless we’ve thought about this.”*

---

## Change type

- [ ] Feature  
- [ ] Fix  
- [x] Docs / Chore  
- [ ] Refactor  

---

## Checklist (definition of done)

- [x] `npm ci`
- [x] `npm run lint`
- [x] `npm run build`
- [ ] Screenshots attached (UI changes – N/A)
- [ ] Notes added for release / stakeholders (if relevant)

---

## What changed

- Added **`docs/release-hygiene-checklist.md`**
  - Single source of truth for pre-release, release, and rollback steps
  - Explicit *stop conditions* to prevent unsafe merges
- Updated **PR template** to:
  - require explicit acknowledgement of production changes
  - require confirmation that the hygiene checklist was run
  - force rollback thinking *before* merge
- Linked the checklist from existing release documentation

---

## Risk

- **Risk level:** Low  
- **Rollback plan:**
  - [x] Revert commit
  - [ ] Forward fix

This change affects documentation and process enforcement only; no runtime behaviour is modified.

---

## Validation

**Steps**
1. Opened a new PR touching production-adjacent docs.
2. Confirmed PR template prompts for checklist usage.
3. Verified checklist is readable, runnable, and actionable.

**Expected**
- PR author is forced to think about production impact.
- Release steps are explicit and repeatable.

**Actual**
- PR cannot be completed without acknowledging release hygiene.
- The checklist is directly executable with copy-paste commands.

---

## Snapshot expectations (main merges)

When this is merged to `main`, the Snapshot workflow will publish a build artefact.

- [x] I’m okay with this being captured in the snapshot artefact.
