### PR TITLE
chore: document /version contract + add version smoke

### DIFF
--- a/docs/release-hygiene-checklist.md
+++ b/docs/release-hygiene-checklist.md
@@ -88,6 +88,7 @@ npm run standings:burst -- --provider db --base "$PROD_API_BASE/api"
 
 - Verify running build: `curl -sS "$PROD_API_BASE/version"`
 - Note: `HEAD` requests to `/health` and `/api` may return HTTP 200 once merged.
+- /version supports `GET`/`HEAD`/`OPTIONS` and returns SHA from Northflank-injected env (`GIT_SHA`).
 - Monitor logs/errors and note rollout status
 - Record the release in `docs/release-audit-trail.md`
 

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "smoke:db:server": "node scripts/smoke-with-server.mjs --provider db",
     "fixtures:burst": "node scripts/fixtures-burst.mjs",
     "standings:burst": "node scripts/standings-burst.mjs",
+    "version:smoke": "node scripts/version-smoke.mjs",
     "test": "vitest run",
     "test:app:sheets": "node scripts/test-app.mjs --provider apps",
     "test:app:db": "node scripts/test-app.mjs --provider db",

--- a/scripts/version-smoke.mjs
+++ b/scripts/version-smoke.mjs
@@ -1,0 +1,80 @@
+import { parseArgs } from "./_devtools.mjs";
+
+function fail(message) {
+  console.error(`FAIL: ${message}`);
+  process.exit(1);
+}
+
+function printResult(label, data) {
+  const parts = [label];
+  if (data.status !== undefined) parts.push(`status=${data.status}`);
+  if (data.ok !== undefined) parts.push(`ok=${data.ok}`);
+  if (data.sha !== undefined) parts.push(`sha=${data.sha}`);
+  if (data.error) parts.push(`error=${data.error}`);
+  console.log(parts.join(" "));
+}
+
+async function fetchJson(url, options) {
+  const res = await fetch(url, options);
+  let body;
+  try {
+    body = await res.json();
+  } catch (err) {
+    const error = err && err.message ? err.message : String(err);
+    return { status: res.status, error };
+  }
+  return { status: res.status, body };
+}
+
+async function fetchStatus(url, options) {
+  try {
+    const res = await fetch(url, options);
+    return { status: res.status };
+  } catch (err) {
+    const error = err && err.message ? err.message : String(err);
+    return { error };
+  }
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const base = args.base || process.env.PROD_API_BASE || "";
+
+  if (!base) fail("Missing base URL. Set PROD_API_BASE or pass --base.");
+
+  const versionUrl = `${base.replace(/\/$/, "")}/version`;
+
+  const getRes = await fetchJson(versionUrl);
+  if (getRes.error) {
+    printResult("GET", getRes);
+    fail("GET /version did not return valid JSON");
+  }
+  printResult("GET", {
+    status: getRes.status,
+    ok: getRes.body && getRes.body.ok,
+    sha: getRes.body && getRes.body.sha,
+  });
+  if (getRes.status !== 200) fail("GET /version did not return 200");
+  if (!getRes.body || getRes.body.ok !== true) {
+    fail("GET /version missing ok:true");
+  }
+  if (!getRes.body.sha || getRes.body.sha === "unknown") {
+    fail("GET /version sha is missing or unknown");
+  }
+
+  const headRes = await fetchStatus(versionUrl, { method: "HEAD" });
+  printResult("HEAD", headRes);
+  if (headRes.error) fail(`HEAD /version failed: ${headRes.error}`);
+  if (headRes.status !== 200) fail("HEAD /version did not return 200");
+
+  const optionsRes = await fetchStatus(versionUrl, { method: "OPTIONS" });
+  printResult("OPTIONS", optionsRes);
+  if (optionsRes.error) fail(`OPTIONS /version failed: ${optionsRes.error}`);
+  if (optionsRes.status !== 204) fail("OPTIONS /version did not return 204");
+
+  console.log("PASS: /version smoke checks ok");
+}
+
+main().catch((err) => {
+  fail(err && err.message ? err.message : String(err));
+});


### PR DESCRIPTION
## Summary
- Document /version GET/HEAD/OPTIONS + SHA-from-Northflank behavior in release hygiene checklist
- Add scripts/version-smoke.mjs regression guard + npm script version:smoke

## Testing
- npm ci
- npm run lint
- npm run build
- npm test
- version:smoke (not run; PROD_API_BASE not set)

## Verify (after deploy)
- export PROD_API_BASE="https://p01--hj-api--wlt9xynp45bk.code.run"
- npm run version:smoke -- --base ""