### PR TITLE
chore: add post-release smoke command

### DIFF
--- a/docs/release-hygiene-checklist.md
+++ b/docs/release-hygiene-checklist.md
@@ -89,6 +89,7 @@ npm run standings:burst -- --provider db --base "$PROD_API_BASE/api"
 - Verify running build: `curl -sS "$PROD_API_BASE/version"`
 - Note: `HEAD` requests to `/health` and `/api` may return HTTP 200 once merged.
 - /version supports `GET`/`HEAD`/`OPTIONS` and returns SHA from Northflank-injected env (`GIT_SHA`).
+- One-command post-release smoke: `npm run postrelease:smoke -- --base "$PROD_API_BASE"`
 - Monitor logs/errors and note rollout status
 - Record the release in `docs/release-audit-trail.md`
 

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "fixtures:burst": "node scripts/fixtures-burst.mjs",
     "standings:burst": "node scripts/standings-burst.mjs",
     "version:smoke": "node scripts/version-smoke.mjs",
+    "postrelease:smoke": "node scripts/postrelease-smoke.mjs",
     "test": "vitest run",
     "test:app:sheets": "node scripts/test-app.mjs --provider apps",
     "test:app:db": "node scripts/test-app.mjs --provider db",

--- a/scripts/postrelease-smoke.mjs
+++ b/scripts/postrelease-smoke.mjs
@@ -1,0 +1,60 @@
+import { parseArgs } from "./_devtools.mjs";
+import { spawn } from "node:child_process";
+
+function runNodeScript(label, args, env) {
+  return new Promise((resolve) => {
+    const child = spawn(process.execPath, args, {
+      stdio: "inherit",
+      env,
+    });
+    child.on("close", (code) => resolve({ label, code }));
+  });
+}
+
+function fail(message) {
+  console.error(`FAIL: ${message}`);
+  process.exit(1);
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const base = args.base || process.env.PROD_API_BASE || "";
+
+  if (!base) fail("Missing base URL. Set PROD_API_BASE or pass --base.");
+
+  const env = { ...process.env, PROD_API_BASE: base };
+
+  const versionResult = await runNodeScript(
+    "version",
+    ["scripts/version-smoke.mjs", "--base", base],
+    env
+  );
+  if (versionResult.code !== 0) {
+    fail("version smoke failed");
+  }
+
+  const burstResults = await Promise.all([
+    runNodeScript(
+      "fixtures",
+      ["scripts/fixtures-burst.mjs", "--base", base],
+      env
+    ),
+    runNodeScript(
+      "standings",
+      ["scripts/standings-burst.mjs", "--base", base],
+      env
+    ),
+  ]);
+
+  const failed = burstResults.filter((result) => result.code !== 0);
+  if (failed.length) {
+    const names = failed.map((result) => result.label).join(", ");
+    fail(`burst checks failed: ${names}`);
+  }
+
+  console.log("PASS: post-release smoke checks ok");
+}
+
+main().catch((err) => {
+  fail(err && err.message ? err.message : String(err));
+});


### PR DESCRIPTION
## Summary
- Add scripts/postrelease-smoke.mjs to run version smoke + fixtures burst + standings burst
- Add npm script postrelease:smoke
- Update release hygiene checklist with the one-command verification

## Testing
- npm ci
- npm run lint
- npm run build
- npm test
- postrelease:smoke (not run; PROD_API_BASE not set)

## Verify after deploy
- export PROD_API_BASE="https://p01--hj-api--wlt9xynp45bk.code.run"
- npm run postrelease:smoke -- --base ""