### PR TITLE
refactor(scripts): dedupe smoke helpers and standardise burst output

### DIFF
--- a/scripts/burst-lib.mjs
+++ b/scripts/burst-lib.mjs
@@ -1,0 +1,68 @@
+export const DEFAULT_AGE_IDS = [
+  "U11B",
+  "U11G",
+  "U13B",
+  "U13G",
+  "U14B",
+  "U14G",
+  "U16B",
+  "U16G",
+  "U18G",
+];
+
+export function normalizeApiBase(raw) {
+  const base = String(raw || "").trim().replace(/\/$/, "");
+  if (!base) return "";
+  if (base.endsWith("/api")) return base;
+  return `${base}/api`;
+}
+
+export function resolveApiBase(args, env) {
+  const rawBase = args["api-base"] || env.PROD_API_BASE || "";
+  const apiBase = normalizeApiBase(rawBase);
+  if (!apiBase) {
+    throw new Error("Missing API base URL. Provide --api-base or set PROD_API_BASE.");
+  }
+  return apiBase;
+}
+
+export async function fetchStatus(url) {
+  try {
+    const res = await fetch(url);
+    await res.text().catch(() => "");
+    return { status: res.status };
+  } catch (err) {
+    return {
+      error: err && err.message ? err.message : String(err),
+      name: err && err.name ? err.name : "Error",
+    };
+  }
+}
+
+export async function runSheetBurst({ apiBase, sheet, ages }) {
+  const requests = ages.map((ageId) => {
+    const url = `${apiBase}?sheet=${sheet}&age=${encodeURIComponent(ageId)}`;
+    return fetchStatus(url).then((result) => ({ ageId, result }));
+  });
+
+  const results = await Promise.all(requests);
+  let okCount = 0;
+  let failCount = 0;
+
+  for (const { ageId, result } of results) {
+    if (result.error) {
+      console.log(`${ageId}: error=${result.error} name=${result.name}`);
+      failCount += 1;
+      continue;
+    }
+    console.log(`${ageId}: status=${result.status}`);
+    if (result.status === 200) {
+      okCount += 1;
+    } else {
+      failCount += 1;
+    }
+  }
+
+  console.log(`burst=done ok=${okCount} failed=${failCount} total=${results.length}`);
+  return { ok: okCount, failed: failCount, total: results.length };
+}

--- a/scripts/fixtures-burst.mjs
+++ b/scripts/fixtures-burst.mjs
@@ -1,70 +1,15 @@
 import { parseArgs } from "./_devtools.mjs";
-
-const AGE_IDS = [
-  "U11B",
-  "U11G",
-  "U13B",
-  "U13G",
-  "U14B",
-  "U14G",
-  "U16B",
-  "U16G",
-  "U18G",
-];
-
-function normalizeApiBase(raw) {
-  const base = String(raw || "").trim();
-  if (!base) return "";
-  if (base.endsWith("/api")) return base;
-  if (base.endsWith("/")) return `${base}api`;
-  return `${base}/api`;
-}
-
-async function fetchStatus(url) {
-  try {
-    const res = await fetch(url);
-    await res.text().catch(() => "");
-    return { status: res.status };
-  } catch (err) {
-    return { error: err && err.message ? err.message : String(err) };
-  }
-}
+import { DEFAULT_AGE_IDS, resolveApiBase, runSheetBurst } from "./burst-lib.mjs";
 
 async function main() {
   const args = parseArgs(process.argv.slice(2));
-  const rawBase = args["api-base"] || process.env.PROD_API_BASE || "";
-  const apiBase = normalizeApiBase(rawBase);
-
-  if (!apiBase) {
-    console.error("Missing API base URL. Provide --api-base or set PROD_API_BASE.");
-    process.exit(1);
-  }
-
-  const requests = AGE_IDS.map((ageId) => {
-    const url = `${apiBase}?sheet=Fixtures&age=${encodeURIComponent(ageId)}`;
-    return fetchStatus(url).then((result) => ({ ageId, result }));
+  const apiBase = resolveApiBase(args, process.env);
+  const result = await runSheetBurst({
+    apiBase,
+    sheet: "Fixtures",
+    ages: DEFAULT_AGE_IDS,
   });
-
-  const results = await Promise.all(requests);
-  let okCount = 0;
-  let failCount = 0;
-
-  for (const { ageId, result } of results) {
-    if (result.error) {
-      console.log(`${ageId}: error=${result.error}`);
-      failCount += 1;
-      continue;
-    }
-    console.log(`${ageId}: status=${result.status}`);
-    if (result.status === 200) {
-      okCount += 1;
-    } else {
-      failCount += 1;
-    }
-  }
-
-  console.log(`burst=done ok=${okCount} failed=${failCount} total=${results.length}`);
-  if (failCount > 0) process.exit(1);
+  if (result.failed > 0) process.exit(1);
 }
 
 main().catch((err) => {

--- a/scripts/postrelease-smoke.mjs
+++ b/scripts/postrelease-smoke.mjs
@@ -1,20 +1,5 @@
 import { parseArgs } from "./_devtools.mjs";
-import { spawn } from "node:child_process";
-
-function runNodeScript(label, args, env) {
-  return new Promise((resolve) => {
-    const child = spawn(process.execPath, args, {
-      stdio: "inherit",
-      env,
-    });
-    child.on("close", (code) => resolve({ label, code }));
-  });
-}
-
-function fail(message) {
-  console.error(`FAIL: ${message}`);
-  process.exit(1);
-}
+import { deriveBases, fail, runNodeScript } from "./smoke-lib.mjs";
 
 async function main() {
   const args = parseArgs(process.argv.slice(2));
@@ -22,8 +7,7 @@ async function main() {
 
   if (!rawBase) fail("Missing base URL. Set PROD_API_BASE or pass --base.");
 
-  const rootBase = rawBase.replace(/\/$/, "");
-  const apiBase = `${rootBase}/api`;
+  const { rootBase, apiBase } = deriveBases(rawBase);
   const env = { ...process.env, PROD_API_BASE: rootBase };
 
   const versionResult = await runNodeScript(

--- a/scripts/smoke-lib.mjs
+++ b/scripts/smoke-lib.mjs
@@ -1,0 +1,26 @@
+import { spawn } from "node:child_process";
+
+export function stripTrailingSlash(url) {
+  return String(url || "").replace(/\/$/, "");
+}
+
+export function deriveBases(rawBase) {
+  const rootBase = stripTrailingSlash(rawBase);
+  const apiBase = `${rootBase}/api`;
+  return { rootBase, apiBase };
+}
+
+export function runNodeScript(label, args, env) {
+  return new Promise((resolve) => {
+    const child = spawn(process.execPath, args, {
+      stdio: "inherit",
+      env,
+    });
+    child.on("close", (code) => resolve({ label, code }));
+  });
+}
+
+export function fail(message) {
+  console.error(`FAIL: ${message}`);
+  process.exit(1);
+}

--- a/scripts/standings-burst.mjs
+++ b/scripts/standings-burst.mjs
@@ -1,35 +1,9 @@
 import { fetchJsonFollow, parseArgs } from "./_devtools.mjs";
-
-function normalizeApiBase(raw) {
-  const base = String(raw || "").trim();
-  if (!base) return "";
-  if (base.endsWith("/api")) return base;
-  if (base.endsWith("/")) return `${base}api`;
-  return `${base}/api`;
-}
-
-async function fetchStatus(url) {
-  try {
-    const res = await fetch(url);
-    await res.text().catch(() => "");
-    return { status: res.status };
-  } catch (err) {
-    return {
-      error: err && err.message ? err.message : String(err),
-      name: err && err.name ? err.name : "Error",
-    };
-  }
-}
+import { resolveApiBase, runSheetBurst } from "./burst-lib.mjs";
 
 async function main() {
   const args = parseArgs(process.argv.slice(2));
-  const rawBase = args["api-base"] || process.env.PROD_API_BASE || "";
-  const apiBase = normalizeApiBase(rawBase);
-
-  if (!apiBase) {
-    console.error("Missing API base URL. Provide --api-base or set PROD_API_BASE.");
-    process.exit(1);
-  }
+  const apiBase = resolveApiBase(args, process.env);
 
   const groups = await fetchJsonFollow(`${apiBase}?groups=1`);
   const ages = (groups && groups.groups ? groups.groups : [])
@@ -41,31 +15,12 @@ async function main() {
     process.exit(1);
   }
 
-  const requests = ages.map((ageId) => {
-    const url = `${apiBase}?sheet=Standings&age=${encodeURIComponent(ageId)}`;
-    return fetchStatus(url).then((result) => ({ ageId, result }));
+  const result = await runSheetBurst({
+    apiBase,
+    sheet: "Standings",
+    ages,
   });
-
-  const results = await Promise.all(requests);
-  let okCount = 0;
-  let failCount = 0;
-
-  for (const { ageId, result } of results) {
-    if (result.error) {
-      console.log(`${ageId}: error=${result.error} name=${result.name}`);
-      failCount += 1;
-      continue;
-    }
-    console.log(`${ageId}: status=${result.status}`);
-    if (result.status === 200) {
-      okCount += 1;
-    } else {
-      failCount += 1;
-    }
-  }
-
-  console.log(`burst=done ok=${okCount} failed=${failCount} total=${results.length}`);
-  if (failCount > 0) process.exit(1);
+  if (result.failed > 0) process.exit(1);
 }
 
 main().catch((err) => {


### PR DESCRIPTION
## Summary
- Extract shared burst logic into scripts/burst-lib.mjs
- Extract shared smoke runner helpers into scripts/smoke-lib.mjs
- Refactor fixtures/standings burst + postrelease smoke to use shared helpers
- Standardize burst output format (matches standings format)

## Testing
- npm ci
- npm run lint
- npm run build
- npm test
- export PROD_API_BASE="https://p01--hj-api--wlt9xynp45bk.code.run"
- npm run postrelease:smoke -- --base "$PROD_API_BASE"

## Verify after deploy
- export PROD_API_BASE="https://p01--hj-api--wlt9xynp45bk.code.run"
- npm run postrelease:smoke -- --base "$PROD_API_BASE"
