### PR TITLE
chore(repo): ignore local .venv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ fs.txt
 # local ingest reports
 reports/
 secrets/
+
+# Local Python virtualenv
+.venv/


### PR DESCRIPTION
Ignore local Python virtualenv folder to prevent VS Code/source control noise. No runtime changes.