### PR TITLE
fix(ui): fit standings on mobile and remove feedback route debug

### DIFF
--- a/src/styles/hj-tokens.css
+++ b/src/styles/hj-tokens.css
@@ -1280,12 +1280,24 @@ select {
   margin: 0;
 }
 
+.standings-page {
+  overflow-x: hidden;
+}
+
+.stand-card-scroll {
+  max-width: 100%;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
 .stand-card {
   background: var(--hj-color-surface);
   border-radius: var(--hj-radius-md);
   border: 1px solid var(--hj-color-border-subtle);
   box-shadow: var(--hj-shadow-sm);
   padding: 10px 16px;
+  min-width: 100%;
+  width: max-content;
 }
 
 .stand-pool-block + .stand-pool-block {

--- a/src/views/Feedback.jsx
+++ b/src/views/Feedback.jsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { useLocation, useNavigate, useParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router-dom";
 import Card from "../components/Card";
 import { sendFeedback } from "../lib/api";
 
@@ -11,7 +11,6 @@ export default function Feedback() {
   const [done, setDone]       = useState(false);
   const [err, setErr]         = useState("");
 
-  const location = useLocation();
   const navigate = useNavigate();
   const params   = useParams();
   const ageId    = params.ageId || "";
@@ -102,9 +101,6 @@ export default function Feedback() {
           </button>
         </div>
 
-        <div className="hj-form-footnote">
-          Route: {location.pathname}{ageId ? ` • Age: ${ageId}` : ""}
-        </div>
       </form>
     </Card>
   );

--- a/src/views/Standings.jsx
+++ b/src/views/Standings.jsx
@@ -208,29 +208,31 @@ function StandingsSection({
     <Card className="standings-age-card">
       {heading ? <h3 className="section-title pool-head">{heading}</h3> : null}
       <section style={{ marginBottom: "var(--hj-space-6)" }}>
-        <div className="stand-card">
-          {pools.map((pool) => (
-            <div key={pool.poolKey || pool.poolLabel} className="stand-pool-block">
-              {pool.poolLabel ? (
-                <div className="stand-card-header">
-                  <span className="stand-pool-label">{pool.poolLabel}</span>
-                  <div className="stand-header-stats" aria-hidden="true">
-                    <span className="lbl">P</span>
-                    <span className="lbl">W</span>
-                    <span className="lbl">D</span>
-                    <span className="lbl">L</span>
-                    <span className="lbl">GF</span>
-                    <span className="lbl">GA</span>
-                    <span className="lbl">GD</span>
-                    <span className="lbl lbl--points">Pts</span>
+        <div className="stand-card-scroll">
+          <div className="stand-card">
+            {pools.map((pool) => (
+              <div key={pool.poolKey || pool.poolLabel} className="stand-pool-block">
+                {pool.poolLabel ? (
+                  <div className="stand-card-header">
+                    <span className="stand-pool-label">{pool.poolLabel}</span>
+                    <div className="stand-header-stats" aria-hidden="true">
+                      <span className="lbl">P</span>
+                      <span className="lbl">W</span>
+                      <span className="lbl">D</span>
+                      <span className="lbl">L</span>
+                      <span className="lbl">GF</span>
+                      <span className="lbl">GA</span>
+                      <span className="lbl">GD</span>
+                      <span className="lbl lbl--points">Pts</span>
+                    </div>
                   </div>
+                ) : null}
+                <div className="stand-card-body">
+                  {pool.rows.map((r, idx) => renderRow(r, idx, pool.poolKey))}
                 </div>
-              ) : null}
-              <div className="stand-card-body">
-                {pool.rows.map((r, idx) => renderRow(r, idx, pool.poolKey))}
               </div>
-            </div>
-          ))}
+            ))}
+          </div>
         </div>
       </section>
     </Card>


### PR DESCRIPTION
Summary: Confine standings horizontal overflow to the standings card and remove Feedback route debug text.\n\nRisk: Low (UI/CSS only).\nRollback: Revert squash merge commit.\nValidation: npm ci, npm run lint, npm run build.