### PR TITLE
fix(ui): stabilize header stack so nav pills never jump

### DIFF
--- a/src/components/AppLayout.jsx
+++ b/src/components/AppLayout.jsx
@@ -88,15 +88,13 @@ export default function AppLayout({
             )}
           </header>
 
-          {enableFilterSlot ? (
-            <div className="app-filter-slot" aria-label="Filters">
-              {filterContent ? (
-                <div className="app-filter-slot-inner">
-                  {filterContent}
-                </div>
-              ) : null}
-            </div>
-          ) : null}
+          <div className="app-filter-slot" aria-label="Filters">
+            {enableFilterSlot && filterContent ? (
+              <div className="app-filter-slot-inner">{filterContent}</div>
+            ) : (
+              <div className="filter-slot-placeholder" aria-hidden="true" />
+            )}
+          </div>
 
           <main className="app-main flex-1">{children}</main>
 

--- a/src/styles/hj-tokens.css
+++ b/src/styles/hj-tokens.css
@@ -364,6 +364,10 @@ select {
   align-items: center; /* toolbar feel */
 }
 
+.filter-slot-placeholder {
+  flex: 1;
+}
+
 /* Page layout helpers */
 .page-stack {
   max-width: var(--hj-page-max-width);
@@ -1752,6 +1756,11 @@ select {
 
   .filter-label--compact select {
     min-width: 0;
+  }
+
+  .app-filter-slot,
+  .filter-slot-row {
+    min-height: calc(var(--hj-space-8) + var(--hj-space-2));
   }
 
   .filter-help {


### PR DESCRIPTION
Summary: Keep filter-slot row present with a placeholder + min-height so nav pills do not shift between routes (notably /feedback).\n\nRisk: Low (layout/CSS only).\nRollback: Revert squash merge commit.\nValidation: npm ci, npm run lint, npm run build.