### PR TITLE
chore(deploy): rebuild Pages to bake PROD_API_BASE

### DIFF
--- a/docs/DEPLOY_STAMP.md
+++ b/docs/DEPLOY_STAMP.md
@@ -1,0 +1,1 @@
+Pages rebuild to bake PROD_API_BASE — 2026-01-18T20:22:25Z


### PR DESCRIPTION
Triggers a fresh GitHub Pages build so Vite bakes vars.PROD_API_BASE into VITE_DB_API_BASE for tournaments.\n\nRisk: none (docs-only).\nValidation: CI + Pages deploy.