### PR TITLE
chore(deploy): force Pages rebuild (stamp)

### DIFF
--- a/docs/DEPLOY_STAMP.md
+++ b/docs/DEPLOY_STAMP.md
@@ -1,1 +1,1 @@
-Pages rebuild to bake PROD_API_BASE — 2026-01-18T20:22:25Z
+Pages rebuild stamp — 2026-01-18T21:27:51Z — sha=e9d415d


### PR DESCRIPTION
Docs-only change to force a fresh GitHub Pages build so PROD_API_BASE is baked into VITE_DB_API_BASE.\n\nRisk: none (docs-only).\nValidation: CI + Pages deploy then verify /api/tournaments in Network.