### PR TITLE
fix(prod): derive tournaments endpoint from API_BASE

### DIFF
--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -15,14 +15,19 @@ function sleep(ms) {
 }
 
 export function tournamentsEndpoint() {
-  const base = import.meta.env.VITE_DB_API_BASE;
-  if (base) {
-    return `${base}/tournaments`;
+  const base =
+    API_BASE ||
+    import.meta.env.VITE_API_BASE ||
+    import.meta.env.VITE_DB_API_BASE;
+
+  if (!base) {
+    console.warn("Missing API base; tournaments endpoint disabled.");
+    return null;
   }
-  if (import.meta.env.DEV) {
-    console.warn("Missing VITE_DB_API_BASE; tournaments endpoint disabled.");
-  }
-  return null;
+
+  // Normalize to origin (strip trailing /api if present)
+  const origin = base.replace(/\/api\/?$/, "");
+  return `${origin}/api/tournaments`;
 }
 
 async function fetchWithRetry(url, retryOptions = {}) {


### PR DESCRIPTION
Derive tournaments endpoint from API_BASE/VITE_* envs to avoid missing VITE_DB_API_BASE in production.\n\nValidation:\n- npm run lint\n- npm run build