### PR TITLE
feat: debug build footer (query-gated)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -26,6 +26,7 @@ import TeamProfile from "./views/TeamProfile";
 import Overview from "./views/Overview";
 import Franchises from "./views/Franchises";
 import { useFilterSlot } from "./components/filterSlotContext";
+import DebugInfo from "./components/DebugInfo";
 
 import AdminLayout from "./views/admin/AdminLayout";
 import AnnouncementsPage from "./views/admin/AnnouncementsPage";
@@ -478,36 +479,39 @@ export default function App() {
   }, []);
 
   return (
-    <Routes>
-      {/* Admin Section */}
-      <Route path="admin" element={<AdminLayout />}>
-        <Route index element={<div style={{ padding: '2rem' }}><h1>Admin Dashboard</h1><p>Welcome to the Hockey Admin Console.</p></div>} />
-        <Route path="announcements" element={<AnnouncementsPage />} />
-        <Route path="*" element={<div style={{ padding: '2rem' }}>Page under construction</div>} />
-      </Route>
+    <>
+      <DebugInfo />
+      <Routes>
+        {/* Admin Section */}
+        <Route path="admin" element={<AdminLayout />}>
+          <Route index element={<div style={{ padding: '2rem' }}><h1>Admin Dashboard</h1><p>Welcome to the Hockey Admin Console.</p></div>} />
+          <Route path="announcements" element={<AnnouncementsPage />} />
+          <Route path="*" element={<div style={{ padding: '2rem' }}>Page under construction</div>} />
+        </Route>
 
-      {/* Public App Section */}
-      <Route element={<AppShell groups={groupsWithAll} />}>
-        <Route
-          index
-          element={
-            <>
-              <InstallPrompt />
-              <Overview groups={groupsWithAll} />
-            </>
-          }
-        />
-        <Route path="feedback" element={<Feedback />} />
-        <Route path="franchises" element={<Franchises />} />
-        <Route path=":ageId/team/:teamId" element={<TeamProfile />} />
-        <Route
-          path=":ageId/*"
-          element={
-            <AgeLayout groups={groupsWithAll} loading={loadingGroups} />
-          }
-        />
-        <Route path="*" element={<Navigate to="/" replace />} />
-      </Route>
-    </Routes>
+        {/* Public App Section */}
+        <Route element={<AppShell groups={groupsWithAll} />}>
+          <Route
+            index
+            element={
+              <>
+                <InstallPrompt />
+                <Overview groups={groupsWithAll} />
+              </>
+            }
+          />
+          <Route path="feedback" element={<Feedback />} />
+          <Route path="franchises" element={<Franchises />} />
+          <Route path=":ageId/team/:teamId" element={<TeamProfile />} />
+          <Route
+            path=":ageId/*"
+            element={
+              <AgeLayout groups={groupsWithAll} loading={loadingGroups} />
+            }
+          />
+          <Route path="*" element={<Navigate to="/" replace />} />
+        </Route>
+      </Routes>
+    </>
   );
 }

--- a/src/components/DebugInfo.jsx
+++ b/src/components/DebugInfo.jsx
@@ -1,0 +1,30 @@
+import { API_BASE, tournamentsEndpoint } from '../lib/api';
+
+export default function DebugInfo() {
+  const params = new URLSearchParams(window.location.search);
+  if (params.get('debug') !== '1') return null;
+
+  const buildId = import.meta.env.VITE_BUILD_ID;
+  const apiBase = API_BASE || 'unknown';
+  const tournamentsUrl = tournamentsEndpoint() || 'disabled';
+  const timestamp = new Date().toISOString();
+
+  const style = {
+    position: 'fixed',
+    bottom: 0,
+    left: 0,
+    right: 0,
+    fontSize: '12px',
+    background: 'rgba(0,0,0,0.85)',
+    color: '#fff',
+    padding: '6px 10px',
+    zIndex: 9999,
+    fontFamily: 'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace',
+  };
+
+  return (
+    <div style={style}>
+      HJ build: {buildId} | API base: {apiBase} | Tournaments: {tournamentsUrl} | Time: {timestamp}
+    </div>
+  );
+}


### PR DESCRIPTION
Why: make debugging prod issues faster with build + endpoint visibility.\nHow: add ?debug=1 to show footer with build, API base, tournaments endpoint, and timestamp.\nRisk: none (read-only, gated).