### PR TITLE
chore(ci): add Dependabot for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## Change type

- [ ] Feature
- [ ] Fix
- [x] Docs/Chore
- [ ] Refactor

## Checklist (definition of done)

- [x] `npm ci`
- [x] `npm run lint`
- [x] `npm run build`
- [ ] Screenshots attached (UI changes)
- [x] Notes added for release / stakeholders (if relevant)

## Release / Production changes

- [ ] I ran `docs/release-hygiene-checklist.md` (required if prod/release/cutover)
- [ ] This PR changes production env/provider behaviour (yes/no)
- [ ] Rollback plan included (env toggle + restart)

## Risk

- Risk level: Low / Medium / High
- Rollback plan:
  - [ ] Revert commit
  - [ ] Forward fix

## Validation

Describe what you tested and how:

- Steps:
- Expected:
- Actual:

## Snapshot expectations (main merges)

When this is merged to `main`, the Snapshot workflow will publish a build artefact.

- [x] I’m okay with this being captured in the snapshot artefact.
