### PR TITLE
chore(ci): guardrail to forbid @vX action refs in workflows

### DIFF
--- a/.github/workflows/guardrail-no-action-tags.yml
+++ b/.github/workflows/guardrail-no-action-tags.yml
@@ -1,0 +1,24 @@
+name: Guardrail: no GitHub Action tags
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/**"
+
+jobs:
+  forbid-action-tags:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+
+      - name: Fail if any workflow uses @vX tags
+        shell: bash
+        run: |
+          set -euo pipefail
+          if rg -n "uses:\s*[^@]+@v[0-9]+" .github/workflows; then
+            echo ""
+            echo "ERROR: Detected GitHub Action tag refs (@vX). Pin actions to full commit SHAs."
+            exit 1
+          fi
+          echo "OK: No @vX tag refs found in workflows."


### PR DESCRIPTION
## What & Why\n\nAdds a lightweight guardrail workflow that fails PRs if any GitHub Actions in  use tag refs like . This keeps our supply‑chain pinning rule enforced and prevents regressions.\n\n### Changes\n- Add \n\n### Risk\nLow.\n\n### Notes\n- Uses pinned  SHA.