### PR TITLE
Fix guardrail workflow + admin asset paths

### DIFF
--- a/.github/workflows/guardrail-no-action-tags.yml
+++ b/.github/workflows/guardrail-no-action-tags.yml
@@ -4,6 +4,11 @@ on:
   pull_request:
     paths:
       - ".github/workflows/**"
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/**"
 
 jobs:
   forbid-action-tags:
@@ -16,7 +21,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          if rg -n "uses:\s*[^@]+@v[0-9]+" .github/workflows; then
+          if grep -R -nE "uses:[[:space:]]*[^@]+@v[0-9]+" .github/workflows; then
             echo ""
             echo "ERROR: Detected GitHub Action tag refs (@vX). Pin actions to full commit SHAs."
             exit 1

--- a/index.html
+++ b/index.html
@@ -5,30 +5,30 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
     <!-- PWA Manifest -->
-    <link rel="manifest" href="manifest.webmanifest" />
+    <link rel="manifest" href="%BASE_URL%manifest.webmanifest" />
     <meta name="theme-color" content="#111111" />
 
     <!-- Favicon -->
-    <link rel="icon" type="image/png" href="hj_ico.png" />
+    <link rel="icon" type="image/png" href="%BASE_URL%hj_ico.png" />
 
     <!-- iOS PWA enhancements -->
     <meta name="mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
     <meta name="apple-mobile-web-app-title" content="HJ 2025" />
     <!-- Apple prefers 180x180; 192 works if you don’t have a 180 yet -->
-    <link rel="apple-touch-icon" href="HJ_icon_192.png" />
+    <link rel="apple-touch-icon" href="%BASE_URL%HJ_icon_192.png" />
 
     <!-- SEO / Social -->
     <title>Hockey For Juniors</title>
     <meta name="description" content="Franchise-based Hockey Platform and Sports Entertainment for Juniors." />
     <meta property="og:title" content="Hockey For Juniors" />
     <meta property="og:description" content="Live fixtures and standings for Hockey For Juniors tournaments." />
-    <meta property="og:image" content="hj_ico.png" />
+    <meta property="og:image" content="%BASE_URL%hj_ico.png" />
     <meta property="og:image:width" content="512" />
     <meta property="og:image:height" content="512" />
 
     <meta name="twitter:card" content="summary" />
-    <meta name="twitter:image" content="hj_ico.png" />
+    <meta name="twitter:image" content="%BASE_URL%hj_ico.png" />
 
     <!-- Google tag (gtag.js) -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-3WKWW816P4"></script>


### PR DESCRIPTION
## Summary
- make guardrail workflow run on main pushes and use portable grep
- use Vite base URL for manifest and icon links to avoid /admin/* 404s on GitHub Pages

## Verification
- npm test --silent