### PR TITLE
Fix guardrail workflow YAML

### DIFF
--- a/.github/workflows/guardrail-no-action-tags.yml
+++ b/.github/workflows/guardrail-no-action-tags.yml
@@ -1,6 +1,6 @@
 name: Guardrail: no GitHub Action tags
 
-on:
+"on":
   pull_request:
     paths:
       - ".github/workflows/**"


### PR DESCRIPTION
## Summary
- quote the top-level "on" key to avoid YAML parsing ambiguity

## Verification
- workflow should load and run based on guardrail logic