### PR TITLE
fix: allow admin CORS and preflight

### DIFF
--- a/server/index.mjs
+++ b/server/index.mjs
@@ -158,7 +158,7 @@ export function applyCors(req, res) {
 
   res.setHeader("Access-Control-Allow-Origin", allowedOrigin);
   res.setHeader("Vary", "Origin");
-  res.setHeader("Access-Control-Allow-Methods", "GET,HEAD,OPTIONS");
+  res.setHeader("Access-Control-Allow-Methods", "GET,HEAD,OPTIONS,POST,PUT,DELETE");
   res.setHeader("Access-Control-Allow-Headers", "Content-Type");
 }
 
@@ -484,10 +484,22 @@ export const requestHandler = async (req, res) => {
     }
     // Admin Routes
     if (url.pathname === "/api/admin/announcements") {
+      applyCors(req, res);
+      if (req.method === "OPTIONS") {
+        res.writeHead(204);
+        res.end();
+        return;
+      }
       await handleAdminRequest(req, res, { url, pool, sendJson });
       return;
     }
     if (url.pathname.startsWith("/api/admin")) {
+      applyCors(req, res);
+      if (req.method === "OPTIONS") {
+        res.writeHead(204);
+        res.end();
+        return;
+      }
       await handleAdminRequest(req, res, { url, pool, sendJson });
       return;
     }

--- a/test/server/index.options.test.js
+++ b/test/server/index.options.test.js
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  query: vi.fn(),
+}));
+
+vi.mock('pg', () => {
+  const Pool = class {
+    constructor() {
+      this.query = mocks.query;
+      this.connect = vi.fn();
+      this.on = vi.fn();
+    }
+  };
+  return { Pool };
+});
+
+const loadServer = async () => {
+  vi.resetModules();
+  process.env.VITEST = '1';
+  return import('../../server/index.mjs');
+};
+
+afterEach(() => {
+  mocks.query.mockReset();
+  vi.restoreAllMocks();
+});
+
+describe('requestHandler OPTIONS handling', () => {
+  it('returns 204 for admin announcements preflight', async () => {
+    const { requestHandler } = await loadServer();
+    const req = {
+      method: 'OPTIONS',
+      url: '/api/admin/announcements',
+      headers: { host: 'localhost', origin: 'http://localhost:5173' },
+      on: vi.fn(),
+    };
+    const res = { setHeader: vi.fn(), writeHead: vi.fn(), end: vi.fn() };
+
+    await requestHandler(req, res);
+
+    expect(res.setHeader).toHaveBeenCalledWith('Access-Control-Allow-Origin', 'http://localhost:5173');
+    expect(res.writeHead).toHaveBeenCalledWith(204);
+    expect(res.end).toHaveBeenCalled();
+  });
+
+  it('returns 204 for admin preflight routes', async () => {
+    const { requestHandler } = await loadServer();
+    const req = {
+      method: 'OPTIONS',
+      url: '/api/admin/users',
+      headers: { host: 'localhost', origin: 'http://localhost:5173' },
+      on: vi.fn(),
+    };
+    const res = { setHeader: vi.fn(), writeHead: vi.fn(), end: vi.fn() };
+
+    await requestHandler(req, res);
+
+    expect(res.setHeader).toHaveBeenCalledWith('Access-Control-Allow-Origin', 'http://localhost:5173');
+    expect(res.writeHead).toHaveBeenCalledWith(204);
+    expect(res.end).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## What changed
- Allow CORS for admin endpoints and include write methods in `Access-Control-Allow-Methods`.
- Handle `OPTIONS` preflight for `/api/admin/*` routes.
- Added coverage for admin preflight handling.

## Why
- Fixes GitHub Pages admin UI failing to call admin announcements API due to missing CORS headers.

## Testing
- npm test
