### PR TITLE
fix: increase Node heap limit and CI timeout for test suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ concurrency:
 jobs:
   ci:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 25
 
     steps:
       - name: Checkout
@@ -49,6 +49,8 @@ jobs:
 
       - name: Test
         run: npm test
+        env:
+          NODE_OPTIONS: --max-old-space-size=4096
 
       - name: Build
         run: npm run build


### PR DESCRIPTION
Fixes JavaScript heap OOM during test runs.

## Changes
- Increase NODE_OPTIONS max-old-space-size to 4GB (from default ~2GB)
- Extend CI timeout from 15 to 25 minutes (tests take ~12 min)

## Root Cause
Test suite has 240+ tests across 30 files. Running all tests simultaneously accumulates memory in Node.js heap, hitting the default 2GB limit after ~12 minutes. Tests themselves pass (234/240 before crash) but worker exits unexpectedly.

## Solution
Pragmatic fix: allow more heap for CI environment. Also extends timeout to prevent false negatives.