### PR TITLE
Enable RLS for Supabase-linted public tables

### DIFF
--- a/db/migrations/008_enable_rls_on_public_reference_tables.sql
+++ b/db/migrations/008_enable_rls_on_public_reference_tables.sql
@@ -1,0 +1,32 @@
+-- Security hardening: ensure RLS is enabled on additional public tables flagged by Supabase linter.
+BEGIN;
+
+DO $$
+DECLARE
+  table_name TEXT;
+BEGIN
+  FOREACH table_name IN ARRAY ARRAY[
+    'fixture_date_fix_backup_allstars',
+    'venue_directory',
+    'franchise',
+    'time_slot',
+    'venue',
+    'group_venue',
+    'group_directory'
+  ]
+  LOOP
+    IF EXISTS (
+      SELECT 1
+      FROM pg_class c
+      JOIN pg_namespace n ON n.oid = c.relnamespace
+      WHERE n.nspname = 'public'
+        AND c.relname = table_name
+        AND c.relkind = 'r'
+    ) THEN
+      EXECUTE format('ALTER TABLE public.%I ENABLE ROW LEVEL SECURITY', table_name);
+      EXECUTE format('REVOKE ALL ON TABLE public.%I FROM anon, authenticated', table_name);
+    END IF;
+  END LOOP;
+END $$;
+
+COMMIT;


### PR DESCRIPTION
### Motivation
- Address Supabase linter `rls_disabled_in_public` errors by enabling Row Level Security (RLS) on public reference tables exposed to PostgREST.

### Description
- Add new migration `db/migrations/008_enable_rls_on_public_reference_tables.sql` that iterates a list of flagged tables and enables RLS for each one.
- Migration performs catalog existence checks against `pg_class`/`pg_namespace` so it safely skips missing tables and won't fail in environments where some tables are absent.
- For each existing table the migration also revokes `anon` and `authenticated` privileges to match the repository's Option B lockdown pattern.

### Testing
- Ran `npm run verify` (which runs `eslint` and the test suite) and it completed successfully without failures.
- The test run included the project's vitest suite and reported all tests passing (lint + automated tests).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f67d66b50832d829f5f95e939fcf3)