### PR TITLE
test: eliminate React act() warnings in AppLayout and TournamentWizard tests

### DIFF
--- a/src/components/AppLayout.test.jsx
+++ b/src/components/AppLayout.test.jsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, act } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
 import { BrowserRouter } from 'react-router-dom';
 import AppLayout from './AppLayout';
@@ -14,14 +14,16 @@ vi.mock('../context/TournamentContext', () => ({
 }));
 
 describe('AppLayout', () => {
-  it('renders children', () => {
-    render(
-      <BrowserRouter>
-        <AppLayout>
-          <div>Test Child</div>
-        </AppLayout>
-      </BrowserRouter>
-    );
+  it('renders children', async () => {
+    await act(async () => {
+      render(
+        <BrowserRouter>
+          <AppLayout>
+            <div>Test Child</div>
+          </AppLayout>
+        </BrowserRouter>
+      );
+    });
     expect(screen.getByText('Test Child')).toBeDefined();
   });
 });

--- a/src/views/admin/TournamentWizard.test.jsx
+++ b/src/views/admin/TournamentWizard.test.jsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent, waitFor, within } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor, within, act } from "@testing-library/react";
 import React from "react";
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { computeFormErrors } from "./tournamentWizardUtils";
@@ -29,7 +29,11 @@ describe("TournamentWizard", () => {
 
   async function renderWizard() {
     const { default: TournamentWizard } = await import("./TournamentWizard");
-    return render(<TournamentWizard />);
+    let result;
+    await act(async () => {
+      result = render(<TournamentWizard />);
+    });
+    return result;
   }
 
   it("renders and navigates between steps", async () => {


### PR DESCRIPTION
Closes #112

## Summary

- **`AppLayout.test.jsx`**: `AppLayout` calls `getAnnouncements()` inside a `useEffect` and updates state asynchronously. The single test was synchronous, so the `setAnnouncements` call fired outside of `act()`. Fixed by making the test `async` and wrapping `render(...)` with `await act(async () => {...})`.

- **`TournamentWizard.test.jsx`**: The wizard fetches `/admin/venues` in a `useEffect` on mount and calls `setVenueOptions()` when the promise resolves. Tests that lacked a downstream `waitFor()` saw the state update land outside of `act()`. Fixed by wrapping `render(...)` in the shared `renderWizard()` helper with `await act(async () => {...})`, which drains all pending microtasks before returning.

## Before / After

| Metric | Before | After |
|---|---|---|
| `act()` warnings | **4** (2 files) | **0** |
| Tests passing | 291 / 291 | 291 / 291 |
| Lint errors | 0 | 0 |

## Test plan

- [x] `npm run lint` — no errors
- [x] `npm test` — 291/291 pass, 0 act() warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)