### PR TITLE
fix: re-enable service worker

### DIFF
--- a/src/main.jsx
+++ b/src/main.jsx
@@ -25,11 +25,11 @@ createRoot(document.getElementById('root')).render(
   </React.StrictMode>
 )
 // Register service worker in production builds
-//if ("serviceWorker" in navigator) {
-//  window.addEventListener("load", () => {
-//    const swUrl = `${import.meta.env.BASE_URL}sw.js`;
-//    navigator.serviceWorker.register(swUrl).catch((err) => {
-//      console.warn("SW registration failed", err);
-//    });
-//  });
-//}
+if ("serviceWorker" in navigator) {
+  window.addEventListener("load", () => {
+    const swUrl = `${import.meta.env.BASE_URL}sw.js`;
+    navigator.serviceWorker.register(swUrl).catch((err) => {
+      console.warn("SW registration failed", err);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- Uncomments the service worker registration block in `src/main.jsx` that was previously disabled, re-enabling PWA offline support.
- `sw.js` already exists in `public/` and `manifest.webmanifest` was already configured — this was the only missing piece.

Closes #117

## Changes

`src/main.jsx`: removed `//` comment prefix from the 8-line service worker registration block.

## Test plan

- [ ] `npm run lint` — passes (no lint errors)
- [ ] `npm test` — 244/255 tests pass; the 11 pre-existing failures are in `test/server/` and are caused by untracked `server/mailer.mjs` referencing an uninstalled `nodemailer` package — unrelated to this change (same failures exist on `main`)
- [ ] Build and load app in browser → DevTools → Application → Service Workers shows `sw.js` registered

🤖 Generated with [Claude Code](https://claude.com/claude-code)