### PR TITLE
#94 API security hardening (headers, body limits, sanitised errors)

### DIFF
--- a/server/admin.mjs
+++ b/server/admin.mjs
@@ -1,4 +1,5 @@
 import crypto from "node:crypto";
+import { readBodyLimited } from "./security.mjs";
 
 function hashString(value) {
   return crypto.createHash("sha256").update(value).digest("hex");
@@ -505,16 +506,11 @@ export async function handleAdminRequest(req, res, { url, pool, sendJson }) {
 }
 
 function readBody(req) {
-  return new Promise((resolve, reject) => {
-    let body = "";
-    req.on("data", (chunk) => (body += chunk));
-    req.on("end", () => {
-      try {
-        resolve(body ? JSON.parse(body) : {});
-      } catch (e) {
-        reject(e);
-      }
-    });
-    req.on("error", reject);
+  return readBodyLimited(req).then((raw) => {
+    try {
+      return raw ? JSON.parse(raw) : {};
+    } catch (e) {
+      throw e;
+    }
   });
 }

--- a/server/index.mjs
+++ b/server/index.mjs
@@ -5,6 +5,7 @@ import { Pool } from "pg";
 import { handleAdminRequest } from "./admin.mjs";
 import { handleMagicLinkRequest, handleVerifyRequest } from "./auth-routes.mjs";
 import { verifySession } from "./auth.mjs";
+import { applySecurityHeaders, safeErrorMessage } from "./security.mjs";
 
 const PORT = Number(process.env.PORT) || 8787;
 const API_PATH = "/api";
@@ -427,6 +428,9 @@ async function handleDbGet(req, res, query, params = [], cache = {}) {
 }
 
 export const requestHandler = async (req, res) => {
+  // Always apply basic security headers
+  applySecurityHeaders(res);
+
   try {
     const isHead = req.method === "HEAD";
     const url = new URL(req.url, `http://${req.headers.host}`);
@@ -788,8 +792,11 @@ export const requestHandler = async (req, res) => {
       { head: isHead }
     );
   } catch (err) {
+    // Log server-side details, return sanitised errors to clients
     console.error(err);
-    sendJson(req, res, 500, { ok: false, error: "Server error" });
+    const status = err?.statusCode || 500;
+    const msg = safeErrorMessage(err);
+    sendJson(req, res, status, { ok: false, error: msg });
   }
 };
 

--- a/server/security.mjs
+++ b/server/security.mjs
@@ -1,0 +1,44 @@
+// server/security.mjs
+
+const DEFAULT_MAX_BODY_BYTES = 256 * 1024; // 256KB
+
+export function applySecurityHeaders(res) {
+  res.setHeader("X-Content-Type-Options", "nosniff");
+  res.setHeader("Referrer-Policy", "no-referrer");
+  res.setHeader("X-Frame-Options", "DENY");
+  res.setHeader("Cross-Origin-Resource-Policy", "same-site");
+  // Basic CSP: allow self; allow inline styles (token-based CSS), disallow framing
+  res.setHeader(
+    "Content-Security-Policy",
+    "default-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self';"
+  );
+}
+
+export async function readBodyLimited(req, { maxBytes = DEFAULT_MAX_BODY_BYTES } = {}) {
+  return new Promise((resolve, reject) => {
+    let size = 0;
+    const chunks = [];
+
+    req.on("data", (chunk) => {
+      const buf = Buffer.isBuffer(chunk) ? chunk : Buffer.from(String(chunk));
+      size += buf.length;
+      if (size > maxBytes) {
+        reject(Object.assign(new Error("payload_too_large"), { statusCode: 413 }));
+        req.destroy();
+        return;
+      }
+      chunks.push(buf);
+    });
+    req.on("end", () => {
+      resolve(Buffer.concat(chunks).toString("utf8"));
+    });
+    req.on("error", (err) => reject(err));
+  });
+}
+
+export function safeErrorMessage(err) {
+  if (!err) return "Server error";
+  // Explicitly allow our own small sentinel errors
+  if (err.message === "payload_too_large") return "payload_too_large";
+  return "Server error";
+}


### PR DESCRIPTION
Implements Issue #94.

Changes:
- Apply basic security headers on all responses
- Add request body size limiter (256KB) for admin JSON bodies
- Sanitise error responses (avoid leaking internals)

Notes:
- Uses new helper module server/security.mjs
- Keeps existing behaviour where possible

Testing:
- npm test

Closes #94