### PR TITLE
feat(auth): DB-managed admin allowlist + Resend SMTP docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,14 +3,21 @@ VITE_PROVIDER=db
 VITE_DB_API_BASE=http://localhost:8787/api
 
 # Admin auth — magic link
-# Comma-separated list of allowed admin emails (case-insensitive)
-ADMIN_ALLOWLIST=leroybarnes@me.com
+# Allowed admin emails are now managed in the admin_allowlist DB table.
+# ADMIN_ALLOWLIST env var is no longer used (see migration 011_admin_allowlist.sql).
 # How long a magic link is valid (minutes, default 15)
 MAGIC_LINK_TTL_MINUTES=15
 # How long a session lasts (hours, default 8)
 ADMIN_SESSION_TTL_HOURS=8
 
-# SMTP — leave blank in dev (magic link URL is logged to stdout instead)
+# SMTP — leave blank in dev (magic link URL is logged to stdout instead).
+# For production use Resend's SMTP relay (https://resend.com):
+#   1. Create a free Resend account and verify your sending domain (skippies.io).
+#   2. Generate an API key and set it as SMTP_PASS.
+#   SMTP_HOST=smtp.resend.com
+#   SMTP_PORT=465
+#   SMTP_USER=resend
+#   SMTP_PASS=re_xxxxxxxxxxxxxxxxxxxx
 SMTP_HOST=
 SMTP_PORT=587
 SMTP_USER=

--- a/db/migrations/011_admin_allowlist.sql
+++ b/db/migrations/011_admin_allowlist.sql
@@ -1,0 +1,17 @@
+-- Admin email allowlist.
+-- Replaces the compile-time ADMIN_ALLOWLIST env-var with a DB-managed table
+-- so entries can be added/removed at runtime without a redeployment.
+
+CREATE TABLE IF NOT EXISTS admin_allowlist (
+  id        UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  email     TEXT        NOT NULL UNIQUE,
+  added_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  note      TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_admin_allowlist_email ON admin_allowlist (email);
+
+-- Seed the initial entry so existing deployments keep working immediately.
+INSERT INTO admin_allowlist (email, note)
+VALUES ('leroybarnes@me.com', 'Initial test account')
+ON CONFLICT (email) DO NOTHING;

--- a/server/admin.mjs
+++ b/server/admin.mjs
@@ -733,6 +733,61 @@ export async function handleAdminRequest(req, res, { url, pool, sendJson, caches
     }
   }
 
+  if (path === "/allowlist") {
+    if (method === "GET") {
+      if (!requireGetWithDb(method, pool, req, res, sendJson)) return;
+      try {
+        const result = await pool.query(
+          `SELECT email, note, added_at FROM admin_allowlist ORDER BY added_at ASC`
+        );
+        return sendJson(req, res, 200, { ok: true, data: result.rows });
+      } catch (err) {
+        console.error("Admin allowlist GET error:", err);
+        return sendJson(req, res, 500, { ok: false, error: "Failed to load allowlist" });
+      }
+    }
+    if (method === "POST") {
+      try {
+        if (!pool) return sendJson(req, res, 501, { ok: false, error: "DB not configured" });
+        const body = await readBody(req);
+        const email = normalizeSpaces(body?.email).toLowerCase();
+        if (!email) return sendJson(req, res, 400, { ok: false, error: "email is required" });
+        const note = normalizeSpaces(body?.note) || null;
+        await pool.query(
+          `INSERT INTO admin_allowlist (email, note) VALUES ($1, $2) ON CONFLICT (email) DO UPDATE SET note = EXCLUDED.note`,
+          [email, note]
+        );
+        return sendJson(req, res, 201, { ok: true, email });
+      } catch (err) {
+        console.error("Admin allowlist POST error:", err);
+        return sendJson(req, res, 500, { ok: false, error: "Failed to update allowlist" });
+      }
+    }
+    return sendJson(req, res, 405, { ok: false, error: "Method not allowed" });
+  }
+
+  const allowlistMatch = path.match(/^\/allowlist\/([^/]+)$/);
+  if (allowlistMatch) {
+    if (method !== "DELETE") {
+      return sendJson(req, res, 405, { ok: false, error: "Method not allowed" });
+    }
+    try {
+      if (!pool) return sendJson(req, res, 501, { ok: false, error: "DB not configured" });
+      const email = decodeURIComponent(allowlistMatch[1]).toLowerCase();
+      const result = await pool.query(
+        `DELETE FROM admin_allowlist WHERE email = $1 RETURNING email`,
+        [email]
+      );
+      if (result.rowCount === 0) {
+        return sendJson(req, res, 404, { ok: false, error: "Email not found in allowlist" });
+      }
+      return sendJson(req, res, 200, { ok: true, deleted: email });
+    } catch (err) {
+      console.error("Admin allowlist DELETE error:", err);
+      return sendJson(req, res, 500, { ok: false, error: "Failed to update allowlist" });
+    }
+  }
+
   // Fallback for unknown admin routes
   return sendJson(req, res, 404, { ok: false, error: "Admin route not found" });
 }

--- a/server/auth-routes.mjs
+++ b/server/auth-routes.mjs
@@ -33,7 +33,7 @@ export async function handleMagicLinkRequest(req, res, { pool, sendJson }) {
     }
 
     // Issue + send only for allowlisted addresses; always return the same response.
-    if (isAllowedEmail(email)) {
+    if (await isAllowedEmail(pool, email)) {
       try {
         const { token } = await issueMagicToken(pool, email);
         await sendMagicLink(email, token);

--- a/server/auth.mjs
+++ b/server/auth.mjs
@@ -4,16 +4,19 @@ import crypto from "node:crypto";
 const MAGIC_TTL_MINUTES = Number(process.env.MAGIC_LINK_TTL_MINUTES) || 15;
 const SESSION_TTL_HOURS = Number(process.env.ADMIN_SESSION_TTL_HOURS) || 8;
 
-// Allowlist is a comma-separated list of lower-cased emails.
-// The env var overrides the default; add emails with ADMIN_ALLOWLIST="a@b.com,c@d.com".
-const ALLOWLIST_RAW = process.env.ADMIN_ALLOWLIST || "leroybarnes@me.com";
-export const ADMIN_ALLOWLIST = ALLOWLIST_RAW
-  .split(",")
-  .map((e) => e.trim().toLowerCase())
-  .filter(Boolean);
-
-export function isAllowedEmail(email) {
-  return ADMIN_ALLOWLIST.includes(String(email || "").trim().toLowerCase());
+/**
+ * Check whether an email is on the DB-managed admin allowlist.
+ * Returns false (rather than throwing) if the pool is unavailable.
+ */
+export async function isAllowedEmail(pool, email) {
+  if (!pool || !email) return false;
+  const normalized = String(email).trim().toLowerCase();
+  if (!normalized) return false;
+  const result = await pool.query(
+    "SELECT 1 FROM admin_allowlist WHERE email = $1",
+    [normalized]
+  );
+  return result.rows.length > 0;
 }
 
 export function generateToken() {

--- a/test/server/admin.test.js
+++ b/test/server/admin.test.js
@@ -699,4 +699,66 @@ describe('handleAdminRequest', () => {
 
         expect(mockSendJson).toHaveBeenCalledWith(mockReq, mockRes, 201, expect.objectContaining({ ok: true }));
     });
+
+    // --- /allowlist endpoint ---
+
+    it('GET /allowlist returns the list of allowed emails', async () => {
+        const url = new URL('http://localhost/api/admin/allowlist');
+        const rows = [{ email: 'leroybarnes@me.com', note: 'Initial test account', added_at: new Date() }];
+        mockPool.query.mockResolvedValueOnce({ rows });
+
+        await handleAdminRequest(mockReq, mockRes, { url, pool: mockPool, sendJson: mockSendJson });
+
+        expect(mockSendJson).toHaveBeenCalledWith(mockReq, mockRes, 200, expect.objectContaining({ ok: true, data: rows }));
+    });
+
+    it('POST /allowlist adds an email', async () => {
+        const url = new URL('http://localhost/api/admin/allowlist');
+        mockReq.method = 'POST';
+        setReqBody(mockReq, JSON.stringify({ email: 'newadmin@example.com', note: 'New admin' }));
+        mockPool.query.mockResolvedValueOnce({ rows: [] });
+
+        await handleAdminRequest(mockReq, mockRes, { url, pool: mockPool, sendJson: mockSendJson });
+
+        expect(mockSendJson).toHaveBeenCalledWith(mockReq, mockRes, 201, expect.objectContaining({ ok: true, email: 'newadmin@example.com' }));
+    });
+
+    it('POST /allowlist returns 400 when email is missing', async () => {
+        const url = new URL('http://localhost/api/admin/allowlist');
+        mockReq.method = 'POST';
+        setReqBody(mockReq, JSON.stringify({ note: 'No email provided' }));
+
+        await handleAdminRequest(mockReq, mockRes, { url, pool: mockPool, sendJson: mockSendJson });
+
+        expect(mockSendJson).toHaveBeenCalledWith(mockReq, mockRes, 400, expect.objectContaining({ ok: false }));
+    });
+
+    it('DELETE /allowlist/:email removes an email', async () => {
+        const url = new URL('http://localhost/api/admin/allowlist/leroybarnes%40me.com');
+        mockReq.method = 'DELETE';
+        mockPool.query.mockResolvedValueOnce({ rows: [{ email: 'leroybarnes@me.com' }], rowCount: 1 });
+
+        await handleAdminRequest(mockReq, mockRes, { url, pool: mockPool, sendJson: mockSendJson });
+
+        expect(mockSendJson).toHaveBeenCalledWith(mockReq, mockRes, 200, expect.objectContaining({ ok: true, deleted: 'leroybarnes@me.com' }));
+    });
+
+    it('DELETE /allowlist/:email returns 404 when email not found', async () => {
+        const url = new URL('http://localhost/api/admin/allowlist/nobody%40nowhere.com');
+        mockReq.method = 'DELETE';
+        mockPool.query.mockResolvedValueOnce({ rows: [], rowCount: 0 });
+
+        await handleAdminRequest(mockReq, mockRes, { url, pool: mockPool, sendJson: mockSendJson });
+
+        expect(mockSendJson).toHaveBeenCalledWith(mockReq, mockRes, 404, expect.objectContaining({ ok: false }));
+    });
+
+    it('PUT /allowlist returns 405', async () => {
+        const url = new URL('http://localhost/api/admin/allowlist');
+        mockReq.method = 'PUT';
+
+        await handleAdminRequest(mockReq, mockRes, { url, pool: mockPool, sendJson: mockSendJson });
+
+        expect(mockSendJson).toHaveBeenCalledWith(mockReq, mockRes, 405, expect.objectContaining({ ok: false }));
+    });
 });

--- a/test/server/auth.test.js
+++ b/test/server/auth.test.js
@@ -4,7 +4,6 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 // Unit tests for server/auth.mjs
 // ---------------------------------------------------------------------------
 import {
-  ADMIN_ALLOWLIST,
   isAllowedEmail,
   generateToken,
   hashToken,
@@ -15,21 +14,28 @@ import {
 } from '../../server/auth.mjs';
 
 describe('auth helpers', () => {
-  it('ADMIN_ALLOWLIST includes the default address', () => {
-    expect(ADMIN_ALLOWLIST).toContain('leroybarnes@me.com');
+  it('isAllowedEmail returns true when DB row exists (case-insensitive)', async () => {
+    const pool = { query: vi.fn().mockResolvedValue({ rows: [{}] }) };
+    expect(await isAllowedEmail(pool, 'LeroyBarnes@me.com')).toBe(true);
+    const [sql, params] = pool.query.mock.calls[0];
+    expect(sql).toMatch(/admin_allowlist/);
+    expect(params[0]).toBe('leroybarnes@me.com');
   });
 
-  it('isAllowedEmail returns true for an allowed address (case-insensitive)', () => {
-    expect(isAllowedEmail('LeroyBarnes@me.com')).toBe(true);
+  it('isAllowedEmail returns false when DB has no matching row', async () => {
+    const pool = { query: vi.fn().mockResolvedValue({ rows: [] }) };
+    expect(await isAllowedEmail(pool, 'hacker@evil.com')).toBe(false);
   });
 
-  it('isAllowedEmail returns false for an unknown address', () => {
-    expect(isAllowedEmail('hacker@evil.com')).toBe(false);
+  it('isAllowedEmail returns false for empty/null input without hitting DB', async () => {
+    const pool = { query: vi.fn() };
+    expect(await isAllowedEmail(pool, '')).toBe(false);
+    expect(await isAllowedEmail(pool, null)).toBe(false);
+    expect(pool.query).not.toHaveBeenCalled();
   });
 
-  it('isAllowedEmail returns false for empty/null input', () => {
-    expect(isAllowedEmail('')).toBe(false);
-    expect(isAllowedEmail(null)).toBe(false);
+  it('isAllowedEmail returns false when pool is null', async () => {
+    expect(await isAllowedEmail(null, 'leroybarnes@me.com')).toBe(false);
   });
 
   it('generateToken returns a 64-character hex string', () => {
@@ -194,7 +200,11 @@ describe('handleMagicLinkRequest', () => {
   });
 
   it('returns 200 generic message for an allowed email', async () => {
-    const pool = makePool(); // issueMagicToken insert succeeds
+    const pool = {
+      query: vi.fn()
+        .mockResolvedValueOnce({ rows: [{}] })  // isAllowedEmail SELECT
+        .mockResolvedValueOnce({ rows: [] }),    // issueMagicToken INSERT
+    };
     const { req, res, sendJson } = makeReqRes('POST', { email: 'leroybarnes@me.com' });
 
     // sendMagicLink will log (no SMTP configured in tests) — no mock needed.
@@ -207,7 +217,7 @@ describe('handleMagicLinkRequest', () => {
   });
 
   it('returns the same 200 generic message for an unknown email (no enumeration)', async () => {
-    const pool = makePool();
+    const pool = { query: vi.fn().mockResolvedValue({ rows: [] }) };
     const { req, res, sendJson } = makeReqRes('POST', { email: 'nobody@nowhere.com' });
     await handleMagicLinkRequest(req, res, { pool, sendJson });
 
@@ -215,12 +225,18 @@ describe('handleMagicLinkRequest', () => {
       req, res, 200,
       expect.objectContaining({ ok: true, message: expect.any(String) })
     );
-    // The DB must NOT be touched for an unknown email.
-    expect(pool.query).not.toHaveBeenCalled();
+    // Allowlist is checked but no token is inserted for an unknown email.
+    expect(pool.query).toHaveBeenCalledOnce();
+    const [sql] = pool.query.mock.calls[0];
+    expect(sql).toMatch(/admin_allowlist/);
   });
 
   it('still returns 200 even when issueMagicToken throws', async () => {
-    const pool = { query: vi.fn().mockRejectedValue(new Error('DB down')) };
+    const pool = {
+      query: vi.fn()
+        .mockResolvedValueOnce({ rows: [{}] })          // isAllowedEmail SELECT
+        .mockRejectedValueOnce(new Error('DB down')),   // issueMagicToken INSERT
+    };
     const { req, res, sendJson } = makeReqRes('POST', { email: 'leroybarnes@me.com' });
     await handleMagicLinkRequest(req, res, { pool, sendJson });
     expect(sendJson).toHaveBeenCalledWith(req, res, 200, expect.objectContaining({ ok: true }));


### PR DESCRIPTION
## Summary

- **Admin allowlist moved to DB** — `admin_allowlist` table (migration `011`) replaces the compile-time `ADMIN_ALLOWLIST` env var. Entries can now be added/removed at runtime via the admin API without a redeployment. Seeded with `leroybarnes@me.com` so existing deployments keep working immediately.
- **Admin API endpoints** (session auth required):
  - `GET /api/admin/allowlist` — list all entries
  - `POST /api/admin/allowlist` — add `{ email, note }`
  - `DELETE /api/admin/allowlist/:email` — remove by email
- **Resend SMTP** — no code changes needed; the existing nodemailer transport already supports Resend's SMTP relay. `.env.example` now documents the vars to set (`SMTP_HOST=smtp.resend.com`, `SMTP_PORT=465`, `SMTP_USER=resend`, `SMTP_PASS=<api-key>`).

## Deployment steps
1. Apply migration: `node scripts/apply-migration.mjs db/migrations/011_admin_allowlist.sql`
2. Set SMTP env vars in Northflank (use Resend API key as `SMTP_PASS`)
3. Verify `skippies.io` domain in Resend dashboard (DNS TXT/CNAME records)
4. Deploy — the magic link email will now be delivered rather than only logged to stdout

## Test plan
- [ ] All auth + admin unit tests pass (127 tests)
- [ ] Request magic link for `leroybarnes@me.com` → email arrives
- [ ] Add a second email via `POST /api/admin/allowlist` → can log in with it
- [ ] Remove an email via `DELETE /api/admin/allowlist/:email` → login blocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)