### PR TITLE
chore(test): fix memory bloat and Node 25 localStorage compat (#100)

### DIFF
--- a/test/setup-env.js
+++ b/test/setup-env.js
@@ -1,2 +1,21 @@
 process.env.VITEST = '1';
 process.env.NODE_ENV = 'test';
+
+// Node.js 25 provides a built-in `localStorage` stub that requires --localstorage-file
+// to be set with a valid path. Without it, localStorage.clear (and other methods) are
+// undefined. Polyfill with a working in-memory implementation when needed.
+if (typeof localStorage !== 'undefined' && typeof localStorage.clear !== 'function') {
+  const _store = new Map();
+  Object.defineProperty(globalThis, 'localStorage', {
+    value: {
+      getItem: (k) => _store.has(String(k)) ? _store.get(String(k)) : null,
+      setItem: (k, v) => _store.set(String(k), String(v)),
+      removeItem: (k) => _store.delete(String(k)),
+      clear: () => _store.clear(),
+      get length() { return _store.size; },
+      key: (i) => [..._store.keys()][i] ?? null,
+    },
+    writable: true,
+    configurable: true,
+  });
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -34,7 +34,15 @@ export default defineConfig(({ mode }) => {
     test: {
       globals: true,
       environment: 'jsdom',
+      environmentMatchGlobs: [
+        ['test/server/**', 'node'],
+      ],
       setupFiles: ['test/setup-env.js'],
+      pool: 'forks',
+      forks: {
+        maxForks: 3,
+      },
+      testTimeout: 10_000,
       coverage: {
         provider: 'v8',
         reporter: ['text', 'lcov'],


### PR DESCRIPTION
## Summary
- Adds `environmentMatchGlobs` so all 7 server test files run in `node` environment instead of `jsdom` — avoids loading the entire jsdom DOM implementation for pure server-side tests (biggest memory win)
- Sets `pool: 'forks'` explicitly with `maxForks: 3` to cap parallel worker processes
- Adds `testTimeout: 10_000` to prevent hanging tests accumulating heap
- Polyfills `localStorage` in `test/setup-env.js`: Node.js 25 provides a built-in localStorage stub that requires `--localstorage-file` with a valid path; without it `localStorage.clear` and other methods are `undefined`, breaking 42 pre-existing test failures across `Fixtures.test.jsx`, `Standings.test.jsx`, and `api.meta.test.js`

## Test plan
- [x] `npm run verify` → 38 test files, 377 tests, all green
- [x] No new failures introduced; 42 pre-existing Node 25 localStorage failures now fixed
- [x] CI `NODE_OPTIONS: --max-old-space-size=4096` should now be less necessary

Closes #100

🤖 Generated with [Claude Code](https://claude.com/claude-code)