### PR TITLE
feat(admin): replace CANONICAL_FRANCHISES with API-driven list (#140)

### DIFF
--- a/src/views/admin/TournamentWizard.jsx
+++ b/src/views/admin/TournamentWizard.jsx
@@ -1,29 +1,10 @@
 import React, { useMemo, useRef, useState } from "react";
 import PropTypes from "prop-types";
-import { API_BASE } from "../../lib/api";
+import { API_BASE, getFranchises } from "../../lib/api";
 import { parseFranchiseName, normalizeTeamName } from "../../lib/franchise";
 import { computeFormErrors } from "./tournamentWizardUtils";
 
 const STEP_LABELS = ["Tournament", "Groups", "Teams", "Fixtures"];
-const CANONICAL_FRANCHISES = [
-  "Purple Panthers",
-  "Blue Cranes",
-  "Black Hawks",
-  "BHA",
-  "Gryphons",
-  "Mighty Ducks",
-  "Northern Guardians",
-  "Dragons",
-  "Giants",
-  "Knights",
-  "GS Hockey",
-  "Meta SMS",
-  "Gladiators",
-  "Khosa",
-  "Pink Otters",
-  "Reddam",
-  "Turfwar",
-];
 
 function normalizeId(value) {
   return String(value || "")
@@ -192,6 +173,7 @@ export default function TournamentWizard() {
   const [saveError, setSaveError] = useState("");
   const [saveSuccess, setSaveSuccess] = useState("");
   const [venueOptions, setVenueOptions] = useState([]);
+  const [apiFranchiseNames, setApiFranchiseNames] = useState([]);
 
   const [tournament, setTournament] = useState({
     id: "",
@@ -283,11 +265,11 @@ export default function TournamentWizard() {
 
   const franchiseOptions = useMemo(() => {
     const fromForm = franchises.map((f) => f.name).filter(Boolean);
-    const merged = [...CANONICAL_FRANCHISES, ...fromForm];
+    const merged = [...apiFranchiseNames, ...fromForm];
     return Array.from(new Set(merged.map((n) => n.trim()).filter(Boolean))).sort((a, b) =>
       a.localeCompare(b)
     );
-  }, [franchises]);
+  }, [apiFranchiseNames, franchises]);
 
   function updateTournament(next) {
     setTournament((prev) => ({ ...prev, ...next }));
@@ -650,6 +632,23 @@ export default function TournamentWizard() {
         setVenueOptions(list);
       } catch (err) {
         console.warn("Failed to load venues", err);
+      }
+    })();
+    return () => {
+      alive = false;
+    };
+  }, []);
+
+  React.useEffect(() => {
+    let alive = true;
+    (async () => {
+      try {
+        const rows = await getFranchises();
+        if (!alive) return;
+        const names = rows.map((r) => r.Name || r.name).filter(Boolean);
+        setApiFranchiseNames(names);
+      } catch (err) {
+        console.warn("Failed to load franchises", err);
       }
     })();
     return () => {

--- a/src/views/admin/TournamentWizard.test.jsx
+++ b/src/views/admin/TournamentWizard.test.jsx
@@ -10,6 +10,7 @@ describe("TournamentWizard", () => {
     vi.clearAllMocks();
     vi.stubEnv("VITE_API_BASE", "http://localhost:8787/api");
     vi.resetModules();
+    sessionStorage.clear();
     fetch.mockImplementation((url) => {
       if (typeof url === "string" && url.includes("/admin/venues")) {
         return Promise.resolve({
@@ -352,6 +353,93 @@ describe("TournamentWizard", () => {
     await waitFor(() => {
       expect(screen.getByText(/Save failed/i)).toBeDefined();
     });
+  });
+
+  it("populates franchise datalist from API", async () => {
+    fetch.mockImplementation((url) => {
+      if (typeof url === "string" && url.includes("/admin/venues")) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ ok: true, data: [] }),
+        });
+      }
+      if (typeof url === "string" && url.includes("sheet=Franchises")) {
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({ ok: true, rows: [{ Name: "Gryphons" }, { Name: "Dragons" }] }),
+        });
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({ ok: true }) });
+    });
+
+    await renderWizard();
+    fireEvent.click(screen.getByRole("button", { name: /Teams/i }));
+
+    await waitFor(() => {
+      const datalist = document.querySelector("datalist");
+      const options = datalist ? Array.from(datalist.querySelectorAll("option")).map((o) => o.value) : [];
+      expect(options).toContain("Gryphons");
+      expect(options).toContain("Dragons");
+    });
+  });
+
+  it("merges form-added franchises with API names in datalist", async () => {
+    fetch.mockImplementation((url) => {
+      if (typeof url === "string" && url.includes("/admin/venues")) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ ok: true, data: [] }),
+        });
+      }
+      if (typeof url === "string" && url.includes("sheet=Franchises")) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ ok: true, rows: [{ Name: "Gryphons" }] }),
+        });
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({ ok: true }) });
+    });
+
+    await renderWizard();
+
+    // Navigate to Teams step and add a franchise via the form
+    fireEvent.click(screen.getByRole("button", { name: /Teams/i }));
+
+    // The franchise "Name" input is within the Franchises section
+    const franchisesSection = screen
+      .getByRole("heading", { name: "Franchises" })
+      .closest("section");
+    const nameInput = within(franchisesSection).getAllByPlaceholderText("Purple Panthers")[0];
+    await act(async () => {
+      fireEvent.change(nameInput, { target: { value: "New Club" } });
+    });
+
+    await waitFor(() => {
+      const datalist = document.querySelector("datalist");
+      const options = datalist ? Array.from(datalist.querySelectorAll("option")).map((o) => o.value) : [];
+      expect(options).toContain("Gryphons");
+      expect(options).toContain("New Club");
+    });
+  });
+
+  it("falls back gracefully when franchise API call fails", async () => {
+    fetch.mockImplementation((url) => {
+      if (typeof url === "string" && url.includes("/admin/venues")) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ ok: true, data: [] }),
+        });
+      }
+      if (typeof url === "string" && url.includes("sheet=Franchises")) {
+        return Promise.reject(new Error("Network error"));
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({ ok: true }) });
+    });
+
+    // Should render without throwing even if franchise fetch fails
+    await renderWizard();
+    expect(screen.getByText("Tournament Setup Wizard")).toBeDefined();
   });
 
   it("computes form errors for invalid inputs", () => {


### PR DESCRIPTION
## Summary
- Removes the 17-entry hardcoded `CANONICAL_FRANCHISES` constant from `TournamentWizard.jsx`
- On wizard mount, calls the existing `getFranchises()` API function and populates the team franchise datalist from the database
- Form-added franchises (from the Franchises section) still merge in as before
- Graceful fallback: if the API call fails, logs a warning and continues with an empty list (no crash)

## Test plan
- [ ] CI: lint + tests green
- [ ] SonarCloud: A rating, coverage ≥ 80% on new code
- [ ] 3 new tests: API names appear in datalist, form names merge with API names, network error degrades gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)