### PR TITLE
feat(ui): offline detection badge in DataFreshness (#141)

### DIFF
--- a/src/components/DataFreshness.jsx
+++ b/src/components/DataFreshness.jsx
@@ -3,6 +3,21 @@ import { getCachedLastSyncAt, getMeta } from '../lib/api';
 
 const STALE_WARN_MS = 15 * 60 * 1000; // 15 minutes
 
+function useOnlineStatus() {
+  const [isOnline, setIsOnline] = useState(() => navigator.onLine);
+  useEffect(() => {
+    const setOnline = () => setIsOnline(true);
+    const setOffline = () => setIsOnline(false);
+    window.addEventListener('online', setOnline);
+    window.addEventListener('offline', setOffline);
+    return () => {
+      window.removeEventListener('online', setOnline);
+      window.removeEventListener('offline', setOffline);
+    };
+  }, []);
+  return isOnline;
+}
+
 function formatRelative(msAgo) {
   if (msAgo < 60_000) return 'just now';
   const mins = Math.round(msAgo / 60_000);
@@ -12,6 +27,7 @@ function formatRelative(msAgo) {
 }
 
 export default function DataFreshness() {
+  const isOnline = useOnlineStatus();
   const [lastSyncAt, setLastSyncAt] = useState(() => getCachedLastSyncAt());
   const [err, setErr] = useState('');
 
@@ -40,22 +56,25 @@ export default function DataFreshness() {
     return { ok: true, date: d };
   }, [lastSyncAt]);
 
-  if (!parsed.ok) return null;
+  if (!parsed.ok && isOnline) return null;
 
-  const ageMs = Date.now() - parsed.date.getTime();
-  const stale = ageMs > STALE_WARN_MS;
+  const ageMs = parsed.ok ? Date.now() - parsed.date.getTime() : null;
+  const stale = ageMs !== null && ageMs > STALE_WARN_MS;
+  const danger = !isOnline || stale;
 
   return (
     <div
       style={{
         marginTop: '6px',
         fontSize: '12px',
-        color: stale ? 'var(--hj-color-danger, #b91c1c)' : 'var(--hj-color-text-secondary, #555)',
+        color: danger ? 'var(--hj-color-danger, #b91c1c)' : 'var(--hj-color-text-secondary, #555)',
       }}
       aria-label="Data freshness"
-      title={err ? `Freshness fetch error: ${err}` : parsed.date.toISOString()}
+      title={err ? `Freshness fetch error: ${err}` : (parsed.ok ? parsed.date.toISOString() : '')}
     >
-      Last updated {formatRelative(ageMs)}
+      {!isOnline && 'Offline'}
+      {!isOnline && parsed.ok && ' • '}
+      {parsed.ok && `Last updated ${formatRelative(ageMs)}`}
       {stale ? ' (stale)' : ''}
     </div>
   );

--- a/src/components/DataFreshness.test.jsx
+++ b/src/components/DataFreshness.test.jsx
@@ -52,4 +52,63 @@ describe('DataFreshness', () => {
     const node = await screen.findByLabelText('Data freshness');
     expect(node.textContent).toMatch(/stale/i);
   });
+
+  it('shows "Offline" badge when navigator.onLine is false', async () => {
+    vi.stubGlobal('navigator', { onLine: false });
+    getCachedLastSyncAtMock.mockReturnValue(new Date(Date.now() - 2 * 60_000).toISOString());
+    getMetaMock.mockResolvedValueOnce({ ok: true, last_sync_at: new Date().toISOString() });
+
+    const { default: DataFreshness } = await import('./DataFreshness');
+    render(<DataFreshness />);
+
+    const node = await screen.findByLabelText('Data freshness');
+    expect(node.textContent).toMatch(/offline/i);
+    vi.unstubAllGlobals();
+  });
+
+  it('shows "Offline" without updated-at when no cached data', async () => {
+    vi.stubGlobal('navigator', { onLine: false });
+    getCachedLastSyncAtMock.mockReturnValue('');
+    getMetaMock.mockRejectedValueOnce(new Error('offline'));
+
+    const { default: DataFreshness } = await import('./DataFreshness');
+    render(<DataFreshness />);
+
+    const node = await screen.findByLabelText('Data freshness');
+    expect(node.textContent).toMatch(/offline/i);
+    expect(node.textContent).not.toMatch(/last updated/i);
+    vi.unstubAllGlobals();
+  });
+
+  it('shows "Offline • Last updated X" when offline with cached sync time', async () => {
+    vi.stubGlobal('navigator', { onLine: false });
+    getCachedLastSyncAtMock.mockReturnValue(new Date(Date.now() - 5 * 60_000).toISOString());
+    getMetaMock.mockRejectedValueOnce(new Error('offline'));
+
+    const { default: DataFreshness } = await import('./DataFreshness');
+    render(<DataFreshness />);
+
+    const node = await screen.findByLabelText('Data freshness');
+    expect(node.textContent).toMatch(/offline/i);
+    expect(node.textContent).toMatch(/last updated/i);
+    vi.unstubAllGlobals();
+  });
+
+  it('responds to window offline event', async () => {
+    vi.stubGlobal('navigator', { onLine: true });
+    getCachedLastSyncAtMock.mockReturnValue(new Date(Date.now() - 2 * 60_000).toISOString());
+    getMetaMock.mockResolvedValueOnce({ ok: true, last_sync_at: new Date().toISOString() });
+
+    const { default: DataFreshness } = await import('./DataFreshness');
+    render(<DataFreshness />);
+
+    const node = await screen.findByLabelText('Data freshness');
+    expect(node.textContent).not.toMatch(/offline/i);
+
+    window.dispatchEvent(new Event('offline'));
+    await waitFor(() => {
+      expect(node.textContent).toMatch(/offline/i);
+    });
+    vi.unstubAllGlobals();
+  });
 });


### PR DESCRIPTION
## Summary
- Adds `useOnlineStatus()` hook to `DataFreshness` that subscribes to `window` `online`/`offline` events (initialised from `navigator.onLine`)
- **Offline + cached sync time**: shows `"Offline • Last updated X min ago"` in danger colour
- **Offline + no cached data**: shows `"Offline"` alone (previously returned `null`)
- **Online + stale**: unchanged — shows `"Last updated X (stale)"` in danger colour
- **Online + fresh**: unchanged

## Test plan
- [ ] CI: lint + tests green (399 passing)
- [ ] SonarCloud: A, coverage ≥ 80%, duplication ≤ 3%
- [ ] 4 new tests added: offline badge display, offline no cache, offline + updated-at, reactive window event

🤖 Generated with [Claude Code](https://claude.com/claude-code)