### PR TITLE
feat(admin): overdue fixture detection + staff alert (#148)

### DIFF
--- a/src/lib/fixtureOverdue.js
+++ b/src/lib/fixtureOverdue.js
@@ -1,0 +1,17 @@
+const OVERDUE_THRESHOLD_MS = 60 * 60 * 1000; // 60 minutes
+
+/**
+ * Returns true if the fixture is past its scheduled time by more than
+ * OVERDUE_THRESHOLD_MS and has no scores recorded yet.
+ *
+ * @param {object} row - fixture row with date, time, score1, score2
+ * @param {number} [now] - current timestamp in ms (injectable for testing)
+ */
+export function isOverdue(row, now = Date.now()) {
+  if (row.score1 !== '' && row.score1 != null) return false;
+  if (row.score2 !== '' && row.score2 != null) return false;
+  if (!row.date || !row.time || row.time === 'TBD') return false;
+  const scheduled = new Date(`${row.date}T${row.time}`);
+  if (Number.isNaN(scheduled.getTime())) return false;
+  return now - scheduled.getTime() > OVERDUE_THRESHOLD_MS;
+}

--- a/src/views/admin/FixturesPage.jsx
+++ b/src/views/admin/FixturesPage.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useMemo, useState } from 'react';
 import { getGroups } from '../../lib/api';
 import { adminFetch } from '../../lib/adminAuth';
 import { useTournament } from '../../context/TournamentContext';
+import { isOverdue } from '../../lib/fixtureOverdue';
 
 function normaliseScoreInput(value) {
   if (value === '' || value == null) return '';
@@ -23,6 +24,11 @@ export default function FixturesPage() {
   const groupOptions = useMemo(
     () => (groups || []).filter((g) => g?.id && g.id !== 'all'),
     [groups]
+  );
+
+  const overdueCount = useMemo(
+    () => fixtures.filter((f) => isOverdue(f)).length,
+    [fixtures]
   );
 
   useEffect(() => {
@@ -143,6 +149,16 @@ export default function FixturesPage() {
         </div>
       )}
 
+      {overdueCount > 0 && (
+        <div
+          role="alert"
+          aria-label="Overdue fixtures"
+          style={{ marginTop: '0.75rem', padding: '0.75rem', border: '1px solid #b45309', background: '#fef3c7', color: '#92400e' }}
+        >
+          ⚠ {overdueCount} fixture{overdueCount > 1 ? 's' : ''} overdue — score{overdueCount > 1 ? 's' : ''} missing
+        </div>
+      )}
+
       <div style={{ marginTop: '1rem', display: 'flex', gap: '1rem', alignItems: 'center' }}>
         <label>
           Group:{' '}
@@ -187,13 +203,26 @@ export default function FixturesPage() {
             {fixtures.map((row) => {
               const status = saveState[row.fixture_id] || '';
               const disabled = status === 'saving' || !tournamentId;
+              const overdue = isOverdue(row);
 
               return (
-                <tr key={row.fixture_id}>
+                <tr
+                  key={row.fixture_id}
+                  data-overdue={overdue ? 'true' : undefined}
+                  style={overdue ? { background: '#fef9c3' } : undefined}
+                >
                   <td style={{ padding: '0.5rem', borderBottom: '1px solid #f0f0f0' }}>{row.date}</td>
                   <td style={{ padding: '0.5rem', borderBottom: '1px solid #f0f0f0' }}>{row.time}</td>
                   <td style={{ padding: '0.5rem', borderBottom: '1px solid #f0f0f0' }}>
                     {row.team1} vs {row.team2}
+                    {overdue && (
+                      <span
+                        aria-label="Overdue"
+                        style={{ marginLeft: '0.5rem', fontSize: '11px', color: '#92400e', fontWeight: 600 }}
+                      >
+                        OVERDUE
+                      </span>
+                    )}
                   </td>
                   <td style={{ padding: '0.5rem', borderBottom: '1px solid #f0f0f0' }}>
                     <input

--- a/src/views/admin/FixturesPage.test.jsx
+++ b/src/views/admin/FixturesPage.test.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { isOverdue } from '../../lib/fixtureOverdue';
 
 vi.mock('../../context/TournamentContext', () => ({
   useTournament: () => ({ activeTournament: { id: 't1', name: 'T1' } }),
@@ -156,5 +157,88 @@ describe('FixturesPage', () => {
     expect(parsed.score2).toBeNull();
   });
 
+  it('shows overdue banner for fixtures >60 min past with no scores', async () => {
+    vi.useFakeTimers({ toFake: ['Date'] });
+    // Set "now" to 12:00; fixture at 09:00 (3h ago) with no scores → overdue
+    vi.setSystemTime(new Date('2026-03-15T12:00:00'));
+    adminFetchMock.mockImplementationOnce((url) => {
+      if (String(url).startsWith('/admin/fixtures')) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({
+            ok: true,
+            data: [{ fixture_id: 'fx_od', date: '2026-03-15', time: '09:00', team1: 'X', team2: 'Y', score1: null, score2: null }],
+          }),
+        });
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({ ok: true }) });
+    });
+
+    const { default: FixturesPage } = await import('./FixturesPage');
+    render(<FixturesPage />);
+
+    await waitFor(() => screen.getByLabelText('Overdue fixtures'), { timeout: 3000 });
+    expect(screen.getByLabelText('Overdue fixtures')).toBeDefined();
+    vi.useRealTimers();
+  });
+
+  it('does not show overdue banner when scored fixtures exist', async () => {
+    vi.useFakeTimers({ toFake: ['Date'] });
+    vi.setSystemTime(new Date('2026-03-15T12:00:00'));
+    adminFetchMock.mockImplementationOnce((url) => {
+      if (String(url).startsWith('/admin/fixtures')) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({
+            ok: true,
+            // 09:00 → overdue time, but has scores → not flagged
+            data: [{ fixture_id: 'fx_sc', date: '2026-03-15', time: '09:00', team1: 'P', team2: 'Q', score1: 2, score2: 1 }],
+          }),
+        });
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({ ok: true }) });
+    });
+
+    const { default: FixturesPage } = await import('./FixturesPage');
+    render(<FixturesPage />);
+
+    await waitFor(() => screen.getByText(/P vs Q/));
+    expect(screen.queryByLabelText('Overdue fixtures')).toBeNull();
+    vi.useRealTimers();
+  });
+
   // Note: we intentionally do not unit test the 1200ms UI timeout; it is a presentational detail.
 });
+
+describe('isOverdue', () => {
+  const now = new Date('2026-03-15T12:00:00').getTime();
+
+  it('returns false when scores are present', () => {
+    expect(isOverdue({ date: '2026-03-15', time: '09:00', score1: '2', score2: '1' }, now)).toBe(false);
+    expect(isOverdue({ date: '2026-03-15', time: '09:00', score1: '0', score2: null }, now)).toBe(false);
+  });
+
+  it('returns false when fixture is recent (within 60 min)', () => {
+    // 30 minutes ago — not overdue
+    expect(isOverdue({ date: '2026-03-15', time: '11:30', score1: '', score2: '' }, now)).toBe(false);
+  });
+
+  it('returns true when fixture is >60 min ago with no scores', () => {
+    // 2 hours ago
+    expect(isOverdue({ date: '2026-03-15', time: '10:00', score1: '', score2: '' }, now)).toBe(true);
+  });
+
+  it('returns false for future fixtures', () => {
+    expect(isOverdue({ date: '2026-03-15', time: '14:00', score1: '', score2: '' }, now)).toBe(false);
+  });
+
+  it('returns false when time is TBD', () => {
+    expect(isOverdue({ date: '2026-03-15', time: 'TBD', score1: '', score2: '' }, now)).toBe(false);
+  });
+
+  it('returns false when date or time is missing', () => {
+    expect(isOverdue({ date: '', time: '09:00', score1: '', score2: '' }, now)).toBe(false);
+    expect(isOverdue({ date: '2026-03-15', time: '', score1: '', score2: '' }, now)).toBe(false);
+  });
+});
+


### PR DESCRIPTION
## Summary
- New `src/lib/fixtureOverdue.js`: pure `isOverdue(row, now?)` function — fixture is overdue if scheduled >60 min ago with no scores
- `FixturesPage.jsx`: amber alert banner at top when any fixtures are overdue; individual row highlight + "OVERDUE" badge per affected row
- No backend changes required — purely client-side computation on the already-loaded fixtures list

## Test plan
- [ ] CI: lint + tests green (403 passing)
- [ ] SonarCloud: A rating, coverage ≥ 80% new code, duplication ≤ 3%
- [ ] 6 unit tests for `isOverdue` edge cases (with scores, recent, future, TBD, missing date/time)
- [ ] 2 UI tests: banner appears for overdue fixture, banner absent when all scored

🤖 Generated with [Claude Code](https://claude.com/claude-code)