### PR TITLE
feat: Tech Desk live scoring UI (#142)

### DIFF
--- a/server/admin.mjs
+++ b/server/admin.mjs
@@ -536,10 +536,51 @@ export async function handleAdminRequest(req, res, { url, pool, sendJson, caches
     if (!requireGetWithDb(method, pool, req, res, sendJson)) return;
     try {
       const tournamentId = normalizeSpaces(url.searchParams.get("tournamentId"));
+      const fixtureId = normalizeSpaces(url.searchParams.get("fixtureId"));
       const groupId = normalizeSpaces(url.searchParams.get("groupId"));
       if (!tournamentId) {
         return sendJson(req, res, 400, { ok: false, error: "Missing tournamentId" });
       }
+
+      // Single-fixture lookup (used by Tech Desk)
+      if (fixtureId) {
+        const row = await pool.query(
+          `SELECT
+             f.id AS fixture_id,
+             f.group_id,
+             to_char(f.date, 'YYYY-MM-DD') AS date,
+             f.time,
+             f.pool,
+             f.venue,
+             f.round,
+             t1.name AS team1,
+             t2.name AS team2,
+             r.score1,
+             r.score2,
+             COALESCE(r.match_events, '[]'::jsonb) AS match_events,
+             COALESCE(r.is_signed_off, false) AS is_signed_off,
+             r.coach_signature,
+             r.updated_at AS result_updated_at
+           FROM fixture f
+           JOIN team t1
+             ON t1.tournament_id = f.tournament_id
+            AND t1.id = f.team1_id
+           JOIN team t2
+             ON t2.tournament_id = f.tournament_id
+            AND t2.id = f.team2_id
+           LEFT JOIN result r
+             ON r.tournament_id = f.tournament_id
+            AND r.fixture_id = f.id
+           WHERE f.tournament_id = $1
+             AND f.id = $2`,
+          [tournamentId, fixtureId]
+        );
+        if (!row || row.rowCount === 0) {
+          return sendJson(req, res, 404, { ok: false, error: "Fixture not found" });
+        }
+        return sendJson(req, res, 200, { ok: true, data: row.rows[0] });
+      }
+
       if (!groupId) {
         return sendJson(req, res, 400, { ok: false, error: "Missing groupId" });
       }
@@ -593,6 +634,10 @@ export async function handleAdminRequest(req, res, { url, pool, sendJson, caches
       const fixtureId = normalizeSpaces(body.fixture_id || body.fixtureId);
       const score1 = parseScore(body.score1);
       const score2 = parseScore(body.score2);
+      const matchEvents = Array.isArray(body.match_events) ? body.match_events : undefined;
+      const isSignedOff = body.is_signed_off === true;
+      const coachSignature = body.coach_signature && typeof body.coach_signature === 'object'
+        ? body.coach_signature : undefined;
 
       if (!tournamentId) {
         return sendJson(req, res, 400, { ok: false, error: "tournament_id is required" });
@@ -614,17 +659,27 @@ export async function handleAdminRequest(req, res, { url, pool, sendJson, caches
       }
 
       const upsert = await pool.query(
-        `INSERT INTO result (tournament_id, fixture_id, score1, score2, status, updated_at, source)
-         VALUES ($1, $2, $3, $4, $5, NOW(), $6)
+        `INSERT INTO result (tournament_id, fixture_id, score1, score2, status, updated_at, source,
+           match_events, is_signed_off, coach_signature)
+         VALUES ($1, $2, $3, $4, $5, NOW(), $6, $7, $8, $9)
          ON CONFLICT (tournament_id, fixture_id)
          DO UPDATE SET
            score1 = EXCLUDED.score1,
            score2 = EXCLUDED.score2,
            status = EXCLUDED.status,
            updated_at = NOW(),
-           source = EXCLUDED.source
-         RETURNING tournament_id, fixture_id, score1, score2, status, updated_at`,
-        [tournamentId, fixtureId, score1, score2, "Final", "admin"]
+           source = EXCLUDED.source,
+           match_events = COALESCE(EXCLUDED.match_events, result.match_events),
+           is_signed_off = CASE WHEN EXCLUDED.is_signed_off THEN true ELSE result.is_signed_off END,
+           coach_signature = COALESCE(EXCLUDED.coach_signature, result.coach_signature)
+         RETURNING tournament_id, fixture_id, score1, score2, status, updated_at,
+           match_events, is_signed_off, coach_signature`,
+        [
+          tournamentId, fixtureId, score1, score2, "Final", "tech-desk",
+          matchEvents ? JSON.stringify(matchEvents) : null,
+          isSignedOff,
+          coachSignature ? JSON.stringify(coachSignature) : null,
+        ]
       );
 
       // Invalidate caches for fixtures/standings (best-effort)
@@ -639,7 +694,7 @@ export async function handleAdminRequest(req, res, { url, pool, sendJson, caches
         tournament_id: tournamentId,
         entity_type: "result",
         entity_id: fixtureId,
-        meta: { score1, score2 },
+        meta: { score1, score2, is_signed_off: isSignedOff },
       });
 
       return sendJson(req, res, 200, { ok: true, data: upsert.rows?.[0] || null });

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -37,6 +37,7 @@ import AdminLoginCallback from "./views/admin/AdminLoginCallback";
 import AnnouncementsPage from "./views/admin/AnnouncementsPage";
 import TournamentWizard from "./views/admin/TournamentWizard";
 import FixturesPage from "./views/admin/FixturesPage";
+import TechDesk from "./views/admin/TechDesk";
 
 // Filter out placeholder “teams” like 1st Place, Loser SF1, A1, etc.
 function isRealTeamName(name) {
@@ -522,6 +523,7 @@ export default function App() {
               <Route path="tournaments" element={<TournamentWizard />} />
               <Route path="announcements" element={<AnnouncementsPage />} />
               <Route path="fixtures" element={<FixturesPage />} />
+              <Route path="tech-desk/:matchId" element={<TechDesk />} />
               <Route
                 path="*"
                 element={<div style={{ padding: '2rem' }}>Page under construction</div>}

--- a/src/views/admin/TechDesk.jsx
+++ b/src/views/admin/TechDesk.jsx
@@ -1,0 +1,480 @@
+import React, { useEffect, useReducer, useRef, useState } from 'react';
+import PropTypes from 'prop-types';
+import { useParams } from 'react-router-dom';
+import { adminFetch } from '../../lib/adminAuth';
+import { useTournament } from '../../context/TournamentContext';
+
+// ─── reducer ─────────────────────────────────────────────────────────────────
+
+const INITIAL_STATE = { score1: 0, score2: 0, matchEvents: [], isSignedOff: false, coachSignature: null };
+
+function initFromFixture(fixture) {
+  return {
+    score1: fixture.score1 ?? 0,
+    score2: fixture.score2 ?? 0,
+    matchEvents: Array.isArray(fixture.match_events) ? fixture.match_events : [],
+    isSignedOff: !!fixture.is_signed_off,
+    coachSignature: fixture.coach_signature ?? null,
+  };
+}
+
+function reducer(state, action) {
+  switch (action.type) {
+    case 'INIT':
+      return initFromFixture(action.fixture);
+    case 'GOAL':
+      return {
+        ...state,
+        score1: action.team === 1 ? state.score1 + 1 : state.score1,
+        score2: action.team === 2 ? state.score2 + 1 : state.score2,
+        matchEvents: [
+          ...state.matchEvents,
+          { type: 'goal', team: action.team, minute: action.minute, scorer: action.scorer },
+        ],
+      };
+    case 'REMOVE_EVENT':
+      return { ...state, matchEvents: state.matchEvents.filter((_, i) => i !== action.index) };
+    case 'ADJUST_SCORE':
+      return {
+        ...state,
+        score1: Math.max(0, state.score1 + (action.team === 1 ? action.delta : 0)),
+        score2: Math.max(0, state.score2 + (action.team === 2 ? action.delta : 0)),
+      };
+    case 'SIGN_OFF':
+      return { ...state, isSignedOff: true, coachSignature: action.signature };
+    default:
+      return state;
+  }
+}
+
+// ─── sub-components ──────────────────────────────────────────────────────────
+
+function TeamScore({ label, score, team, dispatch, locked }) {
+  return (
+    <div style={{ textAlign: 'center' }}>
+      <div style={{ fontWeight: 'bold', marginBottom: '0.25rem' }}>{label}</div>
+      <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+        <button
+          type="button"
+          aria-label={`Decrease score ${label}`}
+          onClick={() => dispatch({ type: 'ADJUST_SCORE', team, delta: -1 })}
+          disabled={locked || score <= 0}
+          style={{ fontSize: '1.25rem', width: 36, height: 36 }}
+        >
+          −
+        </button>
+        <span aria-label={`Score ${label}`} style={{ fontSize: '2rem', minWidth: '2ch', textAlign: 'center' }}>
+          {score}
+        </span>
+        <button
+          type="button"
+          aria-label={`Increase score ${label}`}
+          onClick={() => dispatch({ type: 'ADJUST_SCORE', team, delta: 1 })}
+          disabled={locked}
+          style={{ fontSize: '1.25rem', width: 36, height: 36 }}
+        >
+          +
+        </button>
+      </div>
+    </div>
+  );
+}
+
+TeamScore.propTypes = {
+  label: PropTypes.string.isRequired,
+  score: PropTypes.number.isRequired,
+  team: PropTypes.number.isRequired,
+  dispatch: PropTypes.func.isRequired,
+  locked: PropTypes.bool,
+};
+
+function AddGoalForm({ team1, team2, dispatch, locked }) {
+  const [goalTeam, setGoalTeam] = useState(1);
+  const [minute, setMinute] = useState('');
+  const [scorer, setScorer] = useState('');
+  const minuteRef = useRef(null);
+
+  const submit = (e) => {
+    e.preventDefault();
+    const min = minute.trim() ? Number(minute) : null;
+    dispatch({ type: 'GOAL', team: goalTeam, minute: min, scorer: scorer.trim() || null });
+    setMinute('');
+    setScorer('');
+    minuteRef.current?.focus();
+  };
+
+  return (
+    <form
+      onSubmit={submit}
+      aria-label="Add goal"
+      style={{ display: 'flex', gap: '0.5rem', flexWrap: 'wrap', alignItems: 'flex-end', margin: '0.75rem 0' }}
+    >
+      <label>
+        Team{' '}
+        <select
+          value={goalTeam}
+          onChange={(e) => setGoalTeam(Number(e.target.value))}
+          aria-label="Goal team"
+          disabled={locked}
+        >
+          <option value={1}>{team1}</option>
+          <option value={2}>{team2}</option>
+        </select>
+      </label>
+      <label>
+        Minute{' '}
+        <input
+          ref={minuteRef}
+          type="number"
+          min={1}
+          max={120}
+          value={minute}
+          onChange={(e) => setMinute(e.target.value)}
+          placeholder="—"
+          aria-label="Goal minute"
+          style={{ width: 60 }}
+          disabled={locked}
+        />
+      </label>
+      <label>
+        Scorer{' '}
+        <input
+          value={scorer}
+          onChange={(e) => setScorer(e.target.value)}
+          placeholder="Name (optional)"
+          aria-label="Goal scorer"
+          style={{ width: 140 }}
+          disabled={locked}
+        />
+      </label>
+      <button type="submit" disabled={locked}>
+        Add goal
+      </button>
+    </form>
+  );
+}
+
+AddGoalForm.propTypes = {
+  team1: PropTypes.string.isRequired,
+  team2: PropTypes.string.isRequired,
+  dispatch: PropTypes.func.isRequired,
+  locked: PropTypes.bool,
+};
+
+function EventTimeline({ events, team1, team2, dispatch, locked }) {
+  if (!events.length) {
+    return <p style={{ color: '#888', margin: '0.5rem 0' }}>No events recorded yet.</p>;
+  }
+  return (
+    <ol aria-label="Match events" style={{ paddingLeft: '1.25rem', margin: '0.5rem 0' }}>
+      {events.map((ev, i) => (
+        <li key={i} style={{ marginBottom: '0.25rem' }}>
+          {ev.type === 'goal' ? 'Goal' : ev.type} —{' '}
+          {ev.team === 1 ? team1 : team2}
+          {ev.minute != null ? ` (${ev.minute}')` : ''}
+          {ev.scorer ? ` — ${ev.scorer}` : ''}
+          {!locked && (
+            <>
+              {' '}
+              <button
+                type="button"
+                aria-label={`Remove event ${i + 1}`}
+                onClick={() => dispatch({ type: 'REMOVE_EVENT', index: i })}
+                style={{ fontSize: '0.75rem', padding: '0 4px' }}
+              >
+                ✕
+              </button>
+            </>
+          )}
+        </li>
+      ))}
+    </ol>
+  );
+}
+
+EventTimeline.propTypes = {
+  events: PropTypes.arrayOf(PropTypes.object).isRequired,
+  team1: PropTypes.string.isRequired,
+  team2: PropTypes.string.isRequired,
+  dispatch: PropTypes.func.isRequired,
+  locked: PropTypes.bool,
+};
+
+function SignOffForm({ isSignedOff, coachSignature, dispatch, saving }) {
+  const [coachName, setCoachName] = useState(coachSignature?.name ?? '');
+
+  if (isSignedOff) {
+    return (
+      <p
+        role="status"
+        aria-label="Sign-off status"
+        style={{ color: '#15803d', fontWeight: 'bold', margin: '0.5rem 0' }}
+      >
+        Signed off{coachSignature?.name ? ` by ${coachSignature.name}` : ''}
+      </p>
+    );
+  }
+
+  const submit = (e) => {
+    e.preventDefault();
+    if (!coachName.trim()) return;
+    dispatch({
+      type: 'SIGN_OFF',
+      signature: { name: coachName.trim(), signed_at: new Date().toISOString() },
+    });
+  };
+
+  return (
+    <form
+      onSubmit={submit}
+      aria-label="Coach sign-off"
+      style={{ display: 'flex', gap: '0.5rem', alignItems: 'flex-end', margin: '0.5rem 0' }}
+    >
+      <label>
+        Coach name{' '}
+        <input
+          value={coachName}
+          onChange={(e) => setCoachName(e.target.value)}
+          placeholder="Coach name"
+          aria-label="Coach name"
+          required
+          style={{ width: 180 }}
+          disabled={saving}
+        />
+      </label>
+      <button type="submit" disabled={saving || !coachName.trim()}>
+        Confirm sign-off
+      </button>
+    </form>
+  );
+}
+
+SignOffForm.propTypes = {
+  isSignedOff: PropTypes.bool.isRequired,
+  coachSignature: PropTypes.shape({ name: PropTypes.string }),
+  dispatch: PropTypes.func.isRequired,
+  saving: PropTypes.bool,
+};
+
+// ─── main component ───────────────────────────────────────────────────────────
+
+export default function TechDesk() {
+  const { matchId } = useParams();
+  const { activeTournament } = useTournament();
+  const tournamentId = activeTournament?.id || '';
+
+  const [fixture, setFixture] = useState(null);
+  const [loadingFixture, setLoadingFixture] = useState(false);
+  const [err, setErr] = useState('');
+
+  const [liveState, dispatch] = useReducer(reducer, INITIAL_STATE);
+  const initialisedFor = useRef(null);
+
+  const [saving, setSaving] = useState(false);
+  const [saveStatus, setSaveStatus] = useState(''); // ''|'saving'|'saved'|'error'
+
+  // Load fixture
+  useEffect(() => {
+    let alive = true;
+    (async () => {
+      if (!tournamentId || !matchId) return;
+      setLoadingFixture(true);
+      setErr('');
+      try {
+        const url = `/admin/fixtures?tournamentId=${encodeURIComponent(tournamentId)}&fixtureId=${encodeURIComponent(matchId)}`;
+        const res = await adminFetch(url);
+        const json = await res.json().catch(() => ({}));
+        if (!res.ok || json.ok === false) throw new Error(json.error || `HTTP ${res.status}`);
+        if (!alive) return;
+        setFixture(json.data);
+      } catch (e) {
+        if (!alive) return;
+        setErr(e?.message || 'Failed to load fixture');
+      } finally {
+        if (alive) setLoadingFixture(false);
+      }
+    })();
+    return () => { alive = false; };
+  }, [tournamentId, matchId]);
+
+  // Initialise reducer once when fixture loads (or reloads for a different matchId)
+  useEffect(() => {
+    if (fixture && fixture.fixture_id !== initialisedFor.current) {
+      initialisedFor.current = fixture.fixture_id;
+      dispatch({ type: 'INIT', fixture });
+    }
+  }, [fixture]);
+
+  const save = async () => {
+    if (!tournamentId || !matchId) return;
+    setSaving(true);
+    setSaveStatus('saving');
+    setErr('');
+    try {
+      const res = await adminFetch('/admin/results', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          tournament_id: tournamentId,
+          fixture_id: matchId,
+          score1: liveState.score1,
+          score2: liveState.score2,
+          match_events: liveState.matchEvents,
+          is_signed_off: liveState.isSignedOff,
+          coach_signature: liveState.coachSignature,
+        }),
+      });
+      const json = await res.json().catch(() => ({}));
+      if (!res.ok || json.ok === false) throw new Error(json.error || `HTTP ${res.status}`);
+      setSaveStatus('saved');
+      setTimeout(() => setSaveStatus(''), 2000);
+    } catch (e) {
+      setSaveStatus('error');
+      setErr(e?.message || 'Failed to save');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const locked = saving || liveState.isSignedOff;
+
+  // ─── render guards ───
+
+  if (!tournamentId) {
+    return (
+      <div style={{ padding: '1rem' }}>
+        <h1>Tech Desk</h1>
+        <div role="alert">No active tournament. Select one first.</div>
+      </div>
+    );
+  }
+
+  if (!matchId) {
+    return (
+      <div style={{ padding: '1rem' }}>
+        <h1>Tech Desk</h1>
+        <div role="alert">No match ID provided in URL.</div>
+      </div>
+    );
+  }
+
+  if (loadingFixture) {
+    return (
+      <div style={{ padding: '1rem' }}>
+        <h1>Tech Desk</h1>
+        <span>Loading…</span>
+      </div>
+    );
+  }
+
+  if (err && !fixture) {
+    return (
+      <div style={{ padding: '1rem' }}>
+        <h1>Tech Desk</h1>
+        <div role="alert">{err}</div>
+      </div>
+    );
+  }
+
+  if (!fixture) {
+    return (
+      <div style={{ padding: '1rem' }}>
+        <h1>Tech Desk</h1>
+        <div role="alert">Fixture not found.</div>
+      </div>
+    );
+  }
+
+  // ─── main render ───
+
+  return (
+    <div style={{ padding: '1rem', maxWidth: 640 }}>
+      <h1>Tech Desk</h1>
+      <p style={{ color: '#666', margin: '0.25rem 0 0.75rem' }}>
+        {fixture.date} {fixture.time}
+        {fixture.venue ? ` — ${fixture.venue}` : ''}
+        {fixture.pool ? ` · Pool ${fixture.pool}` : ''}
+        {fixture.round ? ` · ${fixture.round}` : ''}
+      </p>
+
+      {err && (
+        <div role="alert" style={{ padding: '0.75rem', border: '1px solid #cc0000', marginBottom: '0.75rem' }}>
+          {err}
+        </div>
+      )}
+
+      {liveState.isSignedOff && (
+        <div
+          role="status"
+          aria-label="Match locked"
+          style={{
+            padding: '0.5rem 0.75rem',
+            background: '#f0fdf4',
+            border: '1px solid #16a34a',
+            color: '#15803d',
+            marginBottom: '0.75rem',
+          }}
+        >
+          Match signed off — result is locked.
+        </div>
+      )}
+
+      <section aria-label="Live score">
+        <div style={{ display: 'flex', gap: '2rem', alignItems: 'center', margin: '1rem 0' }}>
+          <TeamScore
+            label={fixture.team1}
+            score={liveState.score1}
+            team={1}
+            dispatch={dispatch}
+            locked={locked}
+          />
+          <span style={{ fontSize: '1.5rem', fontWeight: 'bold' }}>–</span>
+          <TeamScore
+            label={fixture.team2}
+            score={liveState.score2}
+            team={2}
+            dispatch={dispatch}
+            locked={locked}
+          />
+        </div>
+      </section>
+
+      <section style={{ marginTop: '1.5rem' }}>
+        <h2 style={{ fontSize: '1rem', marginBottom: '0.5rem' }}>Events</h2>
+        <EventTimeline
+          events={liveState.matchEvents}
+          team1={fixture.team1}
+          team2={fixture.team2}
+          dispatch={dispatch}
+          locked={locked}
+        />
+        {!liveState.isSignedOff && (
+          <AddGoalForm
+            team1={fixture.team1}
+            team2={fixture.team2}
+            dispatch={dispatch}
+            locked={saving}
+          />
+        )}
+      </section>
+
+      <section style={{ marginTop: '1.5rem' }}>
+        <h2 style={{ fontSize: '1rem', marginBottom: '0.5rem' }}>Coach Sign-off</h2>
+        <SignOffForm
+          isSignedOff={liveState.isSignedOff}
+          coachSignature={liveState.coachSignature}
+          dispatch={dispatch}
+          saving={saving}
+        />
+      </section>
+
+      <div style={{ marginTop: '1.5rem', display: 'flex', gap: '1rem', alignItems: 'center' }}>
+        <button type="button" onClick={save} disabled={saving} aria-label="Save result">
+          {saving ? 'Saving…' : 'Save result'}
+        </button>
+        {saveStatus === 'saved' && <span role="status">Saved</span>}
+        {saveStatus === 'error' && <span role="status">Error saving</span>}
+      </div>
+    </div>
+  );
+}

--- a/src/views/admin/TechDesk.test.jsx
+++ b/src/views/admin/TechDesk.test.jsx
@@ -1,0 +1,335 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+
+vi.mock('react-router-dom', () => ({
+  useParams: () => ({ matchId: 'fx1' }),
+}));
+
+vi.mock('../../context/TournamentContext', () => ({
+  useTournament: () => ({ activeTournament: { id: 't1', name: 'T1' } }),
+}));
+
+const adminFetchMock = vi.fn();
+vi.mock('../../lib/adminAuth', () => ({
+  adminFetch: (...args) => adminFetchMock(...args),
+}));
+
+const FIXTURE = {
+  fixture_id: 'fx1',
+  date: '2026-01-15',
+  time: '10:00',
+  venue: 'Rink A',
+  pool: 'A',
+  round: 'Prelim',
+  team1: 'Eagles',
+  team2: 'Hawks',
+  score1: null,
+  score2: null,
+  match_events: [],
+  is_signed_off: false,
+  coach_signature: null,
+};
+
+function fixtureResponse(overrides = {}) {
+  return {
+    ok: true,
+    json: () => Promise.resolve({ ok: true, data: { ...FIXTURE, ...overrides } }),
+  };
+}
+
+function saveOkResponse() {
+  return {
+    ok: true,
+    json: () =>
+      Promise.resolve({
+        ok: true,
+        data: { fixture_id: 'fx1', score1: 2, score2: 1, match_events: [], is_signed_off: false },
+      }),
+  };
+}
+
+describe('TechDesk', () => {
+  beforeEach(() => {
+    adminFetchMock.mockReset();
+    // Default: fixture load + save both succeed
+    adminFetchMock.mockImplementation((url, opts) => {
+      if (typeof url === 'string' && url.includes('/admin/fixtures')) {
+        return Promise.resolve(fixtureResponse());
+      }
+      if (typeof url === 'string' && url === '/admin/results' && opts?.method === 'PUT') {
+        return Promise.resolve(saveOkResponse());
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({ ok: true }) });
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('renders fixture info after loading', async () => {
+    const { default: TechDesk } = await import('./TechDesk');
+    render(<TechDesk />);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Score Eagles')).toBeDefined();
+    });
+
+    expect(screen.getByLabelText('Score Hawks')).toBeDefined();
+    expect(screen.getByText(/2026-01-15/)).toBeDefined();
+    expect(screen.getByText(/Rink A/)).toBeDefined();
+  });
+
+  it('shows loading state then renders', async () => {
+    const { default: TechDesk } = await import('./TechDesk');
+    render(<TechDesk />);
+
+    // Loading appears initially
+    expect(screen.getByText('Loading…')).toBeDefined();
+
+    await waitFor(() => {
+      expect(screen.queryByText('Loading…')).toBeNull();
+    });
+  });
+
+  it('shows error when fixture load fails', async () => {
+    adminFetchMock.mockImplementationOnce(() =>
+      Promise.resolve({
+        ok: false,
+        status: 500,
+        json: () => Promise.resolve({ ok: false, error: 'db_error' }),
+      })
+    );
+
+    const { default: TechDesk } = await import('./TechDesk');
+    render(<TechDesk />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toBeDefined();
+    });
+    expect(screen.getByText(/db_error/i)).toBeDefined();
+  });
+
+  it('increments team1 score with + button', async () => {
+    const { default: TechDesk } = await import('./TechDesk');
+    render(<TechDesk />);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Score Eagles')).toBeDefined();
+    });
+
+    const increaseBtn = screen.getByLabelText('Increase score Eagles');
+    fireEvent.click(increaseBtn);
+
+    expect(screen.getByLabelText('Score Eagles').textContent).toBe('1');
+    expect(screen.getByLabelText('Score Hawks').textContent).toBe('0');
+  });
+
+  it('decrements team2 score with − button (floor at 0)', async () => {
+    const { default: TechDesk } = await import('./TechDesk');
+    render(<TechDesk />);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Decrease score Hawks')).toBeDefined();
+    });
+
+    // Increase then decrease
+    fireEvent.click(screen.getByLabelText('Increase score Hawks'));
+    fireEvent.click(screen.getByLabelText('Decrease score Hawks'));
+    fireEvent.click(screen.getByLabelText('Decrease score Hawks')); // no-op below 0
+
+    expect(screen.getByLabelText('Score Hawks').textContent).toBe('0');
+  });
+
+  it('adds a goal event and bumps score', async () => {
+    const { default: TechDesk } = await import('./TechDesk');
+    render(<TechDesk />);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Add goal')).toBeDefined();
+    });
+
+    fireEvent.change(screen.getByLabelText('Goal minute'), { target: { value: '12' } });
+    fireEvent.change(screen.getByLabelText('Goal scorer'), { target: { value: 'Jones' } });
+    fireEvent.submit(screen.getByLabelText('Add goal'));
+
+    expect(screen.getByLabelText('Score Eagles').textContent).toBe('1');
+    expect(screen.getByText(/Goal — Eagles \(12'\) — Jones/)).toBeDefined();
+  });
+
+  it('removes an event when ✕ is clicked', async () => {
+    const { default: TechDesk } = await import('./TechDesk');
+    render(<TechDesk />);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Add goal')).toBeDefined();
+    });
+
+    fireEvent.submit(screen.getByLabelText('Add goal'));
+    expect(screen.getByRole('list', { name: 'Match events' }).querySelector('li')).toBeDefined();
+
+    fireEvent.click(screen.getByLabelText('Remove event 1'));
+    expect(screen.getByText(/No events recorded/)).toBeDefined();
+  });
+
+  it('signs off and locks score editing', async () => {
+    const { default: TechDesk } = await import('./TechDesk');
+    render(<TechDesk />);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Coach sign-off')).toBeDefined();
+    });
+
+    fireEvent.change(screen.getByLabelText('Coach name'), { target: { value: 'Smith' } });
+    fireEvent.submit(screen.getByLabelText('Coach sign-off'));
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Match locked')).toBeDefined();
+    });
+
+    expect(screen.getByLabelText('Increase score Eagles')).toHaveProperty('disabled', true);
+    expect(screen.getByText(/Signed off by Smith/)).toBeDefined();
+  });
+
+  it('saves result with correct payload', async () => {
+    const { default: TechDesk } = await import('./TechDesk');
+    render(<TechDesk />);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Score Eagles')).toBeDefined();
+    });
+
+    fireEvent.click(screen.getByLabelText('Increase score Eagles'));
+    fireEvent.click(screen.getByLabelText('Increase score Eagles'));
+    fireEvent.click(screen.getByLabelText('Increase score Hawks'));
+
+    fireEvent.click(screen.getByLabelText('Save result'));
+
+    await waitFor(() => {
+      expect(adminFetchMock).toHaveBeenCalledWith(
+        '/admin/results',
+        expect.objectContaining({ method: 'PUT' })
+      );
+    });
+
+    const call = adminFetchMock.mock.calls.find((c) => c[0] === '/admin/results');
+    const payload = JSON.parse(call[1].body);
+    expect(payload.tournament_id).toBe('t1');
+    expect(payload.fixture_id).toBe('fx1');
+    expect(payload.score1).toBe(2);
+    expect(payload.score2).toBe(1);
+    expect(Array.isArray(payload.match_events)).toBe(true);
+  });
+
+  it('shows "Saved" status after successful save', async () => {
+    const { default: TechDesk } = await import('./TechDesk');
+    render(<TechDesk />);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Save result')).toBeDefined();
+    });
+
+    fireEvent.click(screen.getByLabelText('Save result'));
+
+    await waitFor(() => {
+      expect(screen.getByText('Saved')).toBeDefined();
+    });
+  });
+
+  it('shows error status when save fails', async () => {
+    // First call = fixture load (ok), second call = save (fail)
+    adminFetchMock
+      .mockImplementationOnce(() => Promise.resolve(fixtureResponse()))
+      .mockImplementationOnce(() =>
+        Promise.resolve({
+          ok: false,
+          status: 400,
+          json: () => Promise.resolve({ ok: false, error: 'invalid_scores' }),
+        })
+      );
+
+    const { default: TechDesk } = await import('./TechDesk');
+    render(<TechDesk />);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Save result')).toBeDefined();
+    });
+
+    fireEvent.click(screen.getByLabelText('Save result'));
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toBeDefined();
+    });
+    expect(screen.getByText(/invalid_scores/i)).toBeDefined();
+    expect(screen.getByText(/Error saving/)).toBeDefined();
+  });
+
+  it('loads pre-existing scores and events from fixture', async () => {
+    adminFetchMock.mockImplementation((url) => {
+      if (typeof url === 'string' && url.includes('/admin/fixtures')) {
+        return Promise.resolve(
+          fixtureResponse({
+            score1: 3,
+            score2: 1,
+            match_events: [{ type: 'goal', team: 1, minute: 5, scorer: 'Ali' }],
+          })
+        );
+      }
+      return Promise.resolve(saveOkResponse());
+    });
+
+    const { default: TechDesk } = await import('./TechDesk');
+    render(<TechDesk />);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Score Eagles').textContent).toBe('3');
+    });
+    expect(screen.getByLabelText('Score Hawks').textContent).toBe('1');
+    expect(screen.getByText(/Goal — Eagles \(5'\) — Ali/)).toBeDefined();
+  });
+
+  it('includes match_events in save payload after adding goal', async () => {
+    const { default: TechDesk } = await import('./TechDesk');
+    render(<TechDesk />);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Add goal')).toBeDefined();
+    });
+
+    fireEvent.change(screen.getByLabelText('Goal minute'), { target: { value: '7' } });
+    fireEvent.submit(screen.getByLabelText('Add goal'));
+
+    fireEvent.click(screen.getByLabelText('Save result'));
+
+    await waitFor(() => {
+      expect(adminFetchMock).toHaveBeenCalledWith('/admin/results', expect.objectContaining({ method: 'PUT' }));
+    });
+
+    const call = adminFetchMock.mock.calls.find((c) => c[0] === '/admin/results');
+    const payload = JSON.parse(call[1].body);
+    expect(payload.match_events).toHaveLength(1);
+    expect(payload.match_events[0].minute).toBe(7);
+    expect(payload.match_events[0].team).toBe(1);
+  });
+
+});
+
+describe('TechDesk — no active tournament', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it('renders alert when no active tournament', async () => {
+    vi.doMock('react-router-dom', () => ({ useParams: () => ({ matchId: 'fx1' }) }));
+    vi.doMock('../../context/TournamentContext', () => ({
+      useTournament: () => ({ activeTournament: null }),
+    }));
+    vi.doMock('../../lib/adminAuth', () => ({ adminFetch: vi.fn() }));
+
+    const { default: TechDesk } = await import('./TechDesk');
+    render(<TechDesk />);
+
+    expect(screen.getByRole('alert').textContent).toMatch(/no active tournament/i);
+  });
+});


### PR DESCRIPTION
## Summary

- **Server**: Extended `GET /admin/fixtures` to support optional `fixtureId` param, returning `match_events`, `is_signed_off`, and `coach_signature` for single-fixture lookup (used by Tech Desk)
- **Server**: Extended `PUT /admin/results` to persist `match_events` (JSONB array), `is_signed_off` (boolean), and `coach_signature` (JSONB) via upsert with COALESCE/CASE merge semantics
- **UI**: New `TechDesk.jsx` admin page at `/admin/tech-desk/:matchId` with:
  - Live score panel with +/− buttons per team (score floored at 0)
  - Match events timeline with add-goal form (team, minute, scorer) and per-event remove
  - Coach sign-off section (locks score editing once confirmed)
  - Save result button posting all fields to `PUT /admin/results`
  - Pre-loads existing scores/events/sign-off state from fixture fetch
- **Route**: Added `<Route path="tech-desk/:matchId" element={<TechDesk />} />` inside the protected `AdminRoute`/`AdminLayout`

## Test plan

- [ ] All 14 unit tests pass: `npx vitest run src/views/admin/TechDesk.test.jsx`
- [ ] Full suite green: `npm run verify` (416 tests)
- [ ] Navigate to `/admin/tech-desk/<fixture-id>?` — fixture loads, score +/− works, goal events appear in timeline, sign-off locks editing, Save posts correct JSON to API
- [ ] Existing FixturesPage and server tests unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)