### PR TITLE
docs: add end-user Help page with user guide (#151)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -28,6 +28,7 @@ import TeamProfile from "./views/TeamProfile";
 import Overview from "./views/Overview";
 import Franchises from "./views/Franchises";
 import Tournaments from "./views/Tournaments";
+import Help from "./views/Help";
 import { useFilterSlot } from "./components/filterSlotContext";
 import DebugInfo from "./components/DebugInfo";
 
@@ -360,11 +361,13 @@ function AppShell({ groups }) {
   const isWelcome = segments.length === 0;
   const isFeedback = firstSegment === "feedback";
   const isTournaments = firstSegment === "tournaments";
+  const isHelp = firstSegment === "help";
   const isTeamProfile = secondSegment === "team";
 
   const currentTab = useMemo(() => {
     if (isFeedback) return "feedback";
     if (isTournaments) return "tournaments";
+    if (isHelp) return "help";
     if (isTeamProfile) return "teams";
     if (
       secondSegment === "standings" ||
@@ -375,12 +378,12 @@ function AppShell({ groups }) {
       return secondSegment;
     }
     return "fixtures";
-  }, [isFeedback, isTournaments, isTeamProfile, secondSegment]);
+  }, [isFeedback, isTournaments, isHelp, isTeamProfile, secondSegment]);
 
   const selectedAge = ageId || groups[0]?.id || "";
   const showNav = !isWelcome;
-  const showAgeSelector = Boolean(ageId) && !isFeedback && !isTournaments && !isTeamProfile;
-  const enableFilterSlot = Boolean(ageId) && !isFeedback && !isTournaments && !isTeamProfile;
+  const showAgeSelector = Boolean(ageId) && !isFeedback && !isTournaments && !isHelp && !isTeamProfile;
+  const enableFilterSlot = Boolean(ageId) && !isFeedback && !isTournaments && !isHelp && !isTeamProfile;
 
   const onAgeChange = (nextId) => {
     const tab = currentTab || "fixtures";
@@ -560,6 +563,7 @@ export default function App() {
           <Route path="feedback" element={<Feedback />} />
           <Route path="franchises" element={<Franchises />} />
           <Route path="tournaments" element={<Tournaments />} />
+          <Route path="help" element={<Help />} />
           <Route path=":ageId/team/:teamId" element={<TeamProfile />} />
           <Route
             path=":ageId/*"

--- a/src/components/AppLayout.jsx
+++ b/src/components/AppLayout.jsx
@@ -43,10 +43,12 @@ export default function AppLayout({
         { key: "awards", label: "Awards", to: `/${ageId}/awards` },
         { key: "tournaments", label: "Tournaments", to: "/tournaments" },
         { key: "feedback", label: "Feedback", to: "/feedback" },
+        { key: "help", label: "Help", to: "/help" },
       ]
     : [
         { key: "tournaments", label: "Tournaments", to: "/tournaments" },
         { key: "feedback", label: "Feedback", to: "/feedback" },
+        { key: "help", label: "Help", to: "/help" },
       ];
 
   const [slot, setSlot] = useState(filters);

--- a/src/views/Help.jsx
+++ b/src/views/Help.jsx
@@ -1,0 +1,112 @@
+import Card from "../components/Card";
+
+const sections = [
+  {
+    id: "fixtures",
+    title: "Viewing Fixtures",
+    body: (
+      <>
+        <p>Select your age group from the <strong>Age</strong> dropdown at the top of the screen, then tap <strong>Fixtures</strong> in the navigation bar.</p>
+        <p>Each fixture card shows the date, time, venue, and both teams. Scores appear once a match has been played.</p>
+        <p>Use the pool filter to narrow results to a specific pool within your age group.</p>
+      </>
+    ),
+  },
+  {
+    id: "standings",
+    title: "Standings",
+    body: (
+      <>
+        <p>Tap <strong>Standings</strong> to see the league table for your selected age group and pool.</p>
+        <p>Columns show: Games Played (GP), Wins (W), Draws (D), Losses (L), Goals For (GF), Goals Against (GA), Goal Difference (GD), and Points (Pts).</p>
+      </>
+    ),
+  },
+  {
+    id: "teams",
+    title: "Following Teams",
+    body: (
+      <>
+        <p>Tap <strong>Teams</strong> to see all teams in your age group. Press the <strong>☆</strong> star next to a team name to follow it.</p>
+        <p>Once you follow teams, use the <strong>Show Followed</strong> toggle on the Teams, Fixtures, and Standings views to filter the list to only your starred teams.</p>
+        <p>Followed teams are saved on your device — no account required.</p>
+      </>
+    ),
+  },
+  {
+    id: "awards",
+    title: "Awards",
+    body: (
+      <>
+        <p>Tap <strong>Awards</strong> to see the Top Scorers and Clean Sheets leaderboards for the current tournament.</p>
+        <p>The tables update automatically as results and goalscorers are entered by tournament staff.</p>
+      </>
+    ),
+  },
+  {
+    id: "calendar",
+    title: "Adding Fixtures to Your Calendar",
+    body: (
+      <>
+        <p>Open the <strong>Fixtures</strong> view and look for the <strong>Add to Calendar</strong> button near the top of the page.</p>
+        <p>Tapping it downloads an <strong>.ics file</strong> that you can import into Google Calendar, Apple Calendar, or Outlook. The file includes all fixtures for your selected age group.</p>
+      </>
+    ),
+  },
+  {
+    id: "digest",
+    title: "Digest Share Links",
+    body: (
+      <>
+        <p>Tournament administrators can generate a <strong>Digest link</strong> — a read-only page showing standings and fixtures for a specific age group.</p>
+        <p>If you receive a digest link, simply open it in your browser. No login is required. Links expire after the date shown on the page.</p>
+      </>
+    ),
+  },
+  {
+    id: "tournaments",
+    title: "Switching Tournaments",
+    body: (
+      <>
+        <p>Use the <strong>Tournament</strong> switcher in the top-right corner of the header to move between active tournaments.</p>
+        <p>Tap <strong>Tournaments</strong> in the nav to see a directory of all public tournaments.</p>
+      </>
+    ),
+  },
+  {
+    id: "install",
+    title: "Installing the App",
+    body: (
+      <>
+        <p>Hockey For Juniors works as a Progressive Web App (PWA). You can add it to your home screen for quick access and limited offline support.</p>
+        <ul>
+          <li><strong>Android / Chrome:</strong> Tap the browser menu → <em>Add to Home screen</em>.</li>
+          <li><strong>iPhone / Safari:</strong> Tap the Share icon → <em>Add to Home Screen</em>.</li>
+        </ul>
+        <p>An install prompt may also appear automatically the first time you visit.</p>
+      </>
+    ),
+  },
+];
+
+export default function Help() {
+  return (
+    <div className="page-stack help-page" aria-labelledby="help-heading">
+      <section className="page-section">
+        <Card>
+          <h2 id="help-heading" className="section-title pool-head">User Guide</h2>
+          <p>Everything you need to know about using Hockey For Juniors.</p>
+        </Card>
+      </section>
+
+      {sections.map((s) => (
+        <section key={s.id} className="page-section" aria-labelledby={`help-${s.id}`}>
+          <Card>
+            <h3 id={`help-${s.id}`} className="section-title">{s.title}</h3>
+            {s.body}
+          </Card>
+        </section>
+      ))}
+    </div>
+  );
+}

--- a/src/views/Help.test.jsx
+++ b/src/views/Help.test.jsx
@@ -1,0 +1,59 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import Help from "./Help";
+
+describe("Help page", () => {
+  it("renders the page heading", () => {
+    render(<Help />);
+    expect(screen.getByRole("heading", { name: /User Guide/i })).toBeTruthy();
+  });
+
+  it("renders all section headings", () => {
+    render(<Help />);
+    expect(screen.getByRole("heading", { name: /Viewing Fixtures/i })).toBeTruthy();
+    expect(screen.getByRole("heading", { name: /Standings/i })).toBeTruthy();
+    expect(screen.getByRole("heading", { name: /Following Teams/i })).toBeTruthy();
+    expect(screen.getByRole("heading", { name: /Awards/i })).toBeTruthy();
+    expect(screen.getByRole("heading", { name: /Adding Fixtures to Your Calendar/i })).toBeTruthy();
+    expect(screen.getByRole("heading", { name: /Digest Share Links/i })).toBeTruthy();
+    expect(screen.getByRole("heading", { name: /Switching Tournaments/i })).toBeTruthy();
+    expect(screen.getByRole("heading", { name: /Installing the App/i })).toBeTruthy();
+  });
+
+  it("has aria-labelledby pointing to the page heading", () => {
+    const { container } = render(<Help />);
+    const root = container.querySelector('[aria-labelledby="help-heading"]');
+    expect(root).toBeTruthy();
+  });
+
+  it("renders fixture instructions body text", () => {
+    render(<Help />);
+    expect(screen.getByText(/Age.*dropdown/i)).toBeTruthy();
+  });
+
+  it("renders standings body text", () => {
+    render(<Help />);
+    expect(screen.getByText(/Goals For/i)).toBeTruthy();
+  });
+
+  it("renders follow teams body text", () => {
+    render(<Help />);
+    expect(screen.getByText(/saved on your device/i)).toBeTruthy();
+  });
+
+  it("renders calendar body text", () => {
+    render(<Help />);
+    expect(screen.getByText(/\.ics file/i)).toBeTruthy();
+  });
+
+  it("renders digest body text", () => {
+    render(<Help />);
+    expect(screen.getByText(/No login is required/i)).toBeTruthy();
+  });
+
+  it("renders install instructions for Android and iPhone", () => {
+    render(<Help />);
+    expect(screen.getByText(/Android \/ Chrome/i)).toBeTruthy();
+    expect(screen.getByText(/iPhone \/ Safari/i)).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `/help` route with a static user guide for parents and coaches
- Covers: fixtures, standings, team following, awards, calendar export (ICS), digest share links, tournament switching, and PWA installation
- "Help" nav link added to `AppLayout` — appears in all navigation states
- 9 tests covering all sections and key content nodes

## Test plan
- [ ] `npm run verify` → 571 tests pass, 0 lint errors
- [ ] Navigate to `/help` — all 8 sections render with correct headings
- [ ] "Help" pill highlights as active when on `/help`
- [ ] Age selector hidden on `/help` (same treatment as Feedback/Tournaments)
- [ ] CI + SonarCloud green

Closes #151

🤖 Generated with [Claude Code](https://claude.com/claude-code)