### PR TITLE
fix: preserve admin magic-link callback token on GitHub Pages

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,5 +1,5 @@
 // ----- bump to force update -----
-const VERSION = 'v1.0.5'
+const VERSION = 'v1.0.6'
 const CACHE_NAME = `hj-cache-${VERSION}`
 
 // Derive base path from the SW scope so it works on GitHub Pages subpath

--- a/src/lib/githubPagesRoute.js
+++ b/src/lib/githubPagesRoute.js
@@ -1,0 +1,12 @@
+export function decodeGithubPagesRedirect(search, hash = "") {
+  if (typeof search !== "string" || !search.startsWith("?/")) return null;
+
+  const encoded = search.slice(2);
+  if (!encoded) return hash || "";
+
+  const decoded = encoded.replace(/~and~/g, "&");
+  const [path, ...queryParts] = decoded.split("&");
+  const query = queryParts.join("&");
+
+  return `${path}${query ? `?${query}` : ""}${hash || ""}`;
+}

--- a/src/lib/githubPagesRoute.test.js
+++ b/src/lib/githubPagesRoute.test.js
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { decodeGithubPagesRedirect } from "./githubPagesRoute";
+
+describe("decodeGithubPagesRedirect", () => {
+  it("decodes SPA fallback path with token query", () => {
+    const out = decodeGithubPagesRedirect("?/admin/login/callback&token=abc");
+    expect(out).toBe("admin/login/callback?token=abc");
+  });
+
+  it("restores encoded ampersands in query values", () => {
+    const out = decodeGithubPagesRedirect("?/admin/login/callback&token=a~and~b");
+    expect(out).toBe("admin/login/callback?token=a&b");
+  });
+
+  it("preserves hash fragment", () => {
+    const out = decodeGithubPagesRedirect("?/admin/login/callback&token=abc", "#x");
+    expect(out).toBe("admin/login/callback?token=abc#x");
+  });
+
+  it("returns null for regular query strings", () => {
+    const out = decodeGithubPagesRedirect("?token=abc");
+    expect(out).toBeNull();
+  });
+});

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -7,11 +7,12 @@ import './index.css'
 
 import { TournamentProvider } from './context/TournamentContext'
 import { initVitals } from './lib/vitals.js'
+import { decodeGithubPagesRedirect } from './lib/githubPagesRoute.js'
 
 // Handle client-side routing for GitHub Pages
-if (window.location.search.startsWith('?/')) {
-  const path = window.location.search.slice(2);
-  window.history.replaceState(null, '', path);
+const rewrittenPath = decodeGithubPagesRedirect(window.location.search, window.location.hash);
+if (rewrittenPath !== null) {
+  window.history.replaceState(null, '', rewrittenPath);
 }
 
 console.warn("HJ build", import.meta.env.VITE_BUILD_ID);


### PR DESCRIPTION
## Summary\n- fix GitHub Pages SPA fallback decoding so callback query params are preserved\n- add unit tests for redirect decoding behavior\n- bump service worker cache version to force clients onto updated routing code\n\n## Validation\n- npm run test -- src/lib/githubPagesRoute.test.js\n- npm run verify