### PR TITLE
fix: persist admin session and restore franchise endpoint

### DIFF
--- a/server/index.mjs
+++ b/server/index.mjs
@@ -390,6 +390,26 @@ async function getStandingsAllPayload(tournamentId) {
   return { rows: (result && result.rows) ? result.rows.map(mapStandingsRow) : [] };
 }
 
+async function getFranchisesPayload(tournamentId) {
+  if (!pool) {
+    throw new Error("DB provider disabled");
+  }
+  const result = await pool.query(
+    `SELECT DISTINCT franchise_name AS name
+     FROM team
+     WHERE tournament_id = $1
+       AND franchise_name IS NOT NULL
+       AND btrim(franchise_name) <> ''
+     ORDER BY franchise_name ASC`,
+    [tournamentId]
+  );
+  return {
+    rows: (result && result.rows)
+      ? result.rows.map((row) => ({ Name: row.name }))
+      : [],
+  };
+}
+
 async function getAwardsPayload(tournamentId, ageId) {
   if (!pool) throw new Error("DB provider disabled");
   const [scorersResult, csResult] = await Promise.all([
@@ -1004,6 +1024,23 @@ export const requestHandler = async (req, res) => {
         if (status === 200 && !(body && body.ok === false)) {
           setCachedStandings(cacheKey, body);
         }
+        sendJson(req, res, status, body, {
+          head: isHead,
+          cache: { maxAge: 30, swr: 300 },
+        });
+      }
+      return;
+    }
+    if (sheet === "Franchises") {
+      if (PROVIDER_MODE === "db") {
+        const payload = await getFranchisesPayload(reqTournamentId);
+        sendJson(req, res, 200, payload, {
+          head: isHead,
+          cache: { maxAge: 30, swr: 300 },
+        });
+      } else {
+        const targetUrl = `${APPS_SCRIPT_BASE_URL}?sheet=Franchises`;
+        const { status, body } = await fetchAppsJson(targetUrl);
         sendJson(req, res, status, body, {
           head: isHead,
           cache: { maxAge: 30, swr: 300 },

--- a/src/lib/adminAuth.js
+++ b/src/lib/adminAuth.js
@@ -4,33 +4,72 @@ import { API_BASE } from "./api";
 const TOKEN_KEY = "hj_admin_session_token";
 const EMAIL_KEY = "hj_admin_email";
 const EXP_KEY = "hj_admin_session_expires_at";
+const AUTH_EXPIRED_MESSAGE = "Admin session expired. Please sign in again.";
+
+function readStorage(key) {
+  const localValue = localStorage.getItem(key);
+  if (localValue) return localValue;
+  const sessionValue = sessionStorage.getItem(key);
+  if (!sessionValue) return "";
+  // Migrate legacy tab-only sessions into persistent storage.
+  localStorage.setItem(key, sessionValue);
+  sessionStorage.removeItem(key);
+  return sessionValue;
+}
+
+function isExpired(expiresAt) {
+  if (!expiresAt) return false;
+  const ts = Date.parse(expiresAt);
+  return Number.isFinite(ts) && ts <= Date.now();
+}
+
+function ensureActiveSession() {
+  const expiresAt = readStorage(EXP_KEY);
+  if (isExpired(expiresAt)) {
+    clearAdminSession();
+    return false;
+  }
+  return true;
+}
+
+function authExpiredError() {
+  const err = new Error(AUTH_EXPIRED_MESSAGE);
+  err.code = "ADMIN_AUTH_EXPIRED";
+  return err;
+}
 
 export function getAdminToken() {
-  return sessionStorage.getItem(TOKEN_KEY) || "";
+  if (!ensureActiveSession()) return "";
+  return readStorage(TOKEN_KEY);
 }
 
 export function getAdminEmail() {
-  return sessionStorage.getItem(EMAIL_KEY) || "";
+  if (!ensureActiveSession()) return "";
+  return readStorage(EMAIL_KEY);
 }
 
 export function getAdminExpiresAt() {
-  return sessionStorage.getItem(EXP_KEY) || "";
+  if (!ensureActiveSession()) return "";
+  return readStorage(EXP_KEY);
 }
 
 export function setAdminSession({ token, email, expiresAt }) {
-  if (token) sessionStorage.setItem(TOKEN_KEY, token);
-  if (email) sessionStorage.setItem(EMAIL_KEY, email);
-  if (expiresAt) sessionStorage.setItem(EXP_KEY, expiresAt);
+  if (token) localStorage.setItem(TOKEN_KEY, token);
+  if (email) localStorage.setItem(EMAIL_KEY, email);
+  if (expiresAt) localStorage.setItem(EXP_KEY, expiresAt);
 }
 
 export function clearAdminSession() {
+  localStorage.removeItem(TOKEN_KEY);
+  localStorage.removeItem(EMAIL_KEY);
+  localStorage.removeItem(EXP_KEY);
   sessionStorage.removeItem(TOKEN_KEY);
   sessionStorage.removeItem(EMAIL_KEY);
   sessionStorage.removeItem(EXP_KEY);
 }
 
 export function isAdminAuthed() {
-  return Boolean(getAdminToken());
+  return ensureActiveSession() && Boolean(readStorage(TOKEN_KEY));
 }
 
 function apiUrl(path) {
@@ -67,7 +106,15 @@ export async function verifyMagicToken(token) {
 
 export async function adminFetch(path, opts = {}) {
   const token = getAdminToken();
+  if (!token) {
+    throw authExpiredError();
+  }
   const headers = new Headers(opts.headers || {});
   headers.set("Authorization", `Bearer ${token}`);
-  return fetch(apiUrl(path), { ...opts, headers });
+  const res = await fetch(apiUrl(path), { ...opts, headers });
+  if (res.status === 401) {
+    clearAdminSession();
+    throw authExpiredError();
+  }
+  return res;
 }

--- a/src/lib/adminAuth.test.js
+++ b/src/lib/adminAuth.test.js
@@ -5,6 +5,7 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 describe("adminAuth", () => {
   beforeEach(() => {
     sessionStorage.clear();
+    localStorage.clear();
     vi.restoreAllMocks();
   });
 
@@ -93,5 +94,35 @@ describe("adminAuth", () => {
     const [, opts] = globalThis.fetch.mock.calls[0];
     expect(opts.headers.get("Authorization")).toBe("Bearer sess");
     expect(opts.headers.get("X-Test")).toBe("1");
+  });
+
+  it("migrates legacy sessionStorage session into localStorage", async () => {
+    sessionStorage.setItem("hj_admin_session_token", "legacy-token");
+    const mod = await import("./adminAuth.js");
+    expect(mod.getAdminToken()).toBe("legacy-token");
+    expect(localStorage.getItem("hj_admin_session_token")).toBe("legacy-token");
+    expect(sessionStorage.getItem("hj_admin_session_token")).toBeNull();
+  });
+
+  it("treats expired session as unauthenticated", async () => {
+    const mod = await import("./adminAuth.js");
+    mod.setAdminSession({
+      token: "expired-token",
+      email: "e",
+      expiresAt: "2000-01-01T00:00:00.000Z",
+    });
+    expect(mod.getAdminToken()).toBe("");
+    expect(mod.isAdminAuthed()).toBe(false);
+  });
+
+  it("adminFetch clears session and throws auth error on 401", async () => {
+    const mod = await import("./adminAuth.js");
+    mod.setAdminSession({ token: "sess", email: "e", expiresAt: "2099-01-01T00:00:00.000Z" });
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce({ status: 401 });
+
+    await expect(mod.adminFetch("/admin/announcements")).rejects.toThrow(
+      "Admin session expired. Please sign in again."
+    );
+    expect(mod.isAdminAuthed()).toBe(false);
   });
 });

--- a/src/views/admin/AdminLoginCallback.test.jsx
+++ b/src/views/admin/AdminLoginCallback.test.jsx
@@ -18,6 +18,7 @@ import { setAdminSession } from "../../lib/adminAuth";
 describe("AdminLoginCallback", () => {
   beforeEach(() => {
     sessionStorage.clear();
+    localStorage.clear();
     vi.clearAllMocks();
   });
 

--- a/src/views/admin/AdminRoute.test.jsx
+++ b/src/views/admin/AdminRoute.test.jsx
@@ -19,6 +19,7 @@ function renderAt(path) {
 describe("AdminRoute", () => {
   beforeEach(() => {
     sessionStorage.clear();
+    localStorage.clear();
   });
 
   it("redirects to /admin/login when not authed", () => {
@@ -27,8 +28,16 @@ describe("AdminRoute", () => {
   });
 
   it("allows access when token exists", () => {
-    sessionStorage.setItem("hj_admin_session_token", "token");
+    localStorage.setItem("hj_admin_session_token", "token");
+    localStorage.setItem("hj_admin_session_expires_at", "2099-01-01T00:00:00.000Z");
     renderAt("/admin");
     expect(screen.getByText("ADMIN OK")).toBeTruthy();
+  });
+
+  it("redirects to /admin/login when session is expired", () => {
+    localStorage.setItem("hj_admin_session_token", "token");
+    localStorage.setItem("hj_admin_session_expires_at", "2000-01-01T00:00:00.000Z");
+    renderAt("/admin");
+    expect(screen.getByText("LOGIN")).toBeTruthy();
   });
 });

--- a/src/views/admin/AnnouncementsPage.test.jsx
+++ b/src/views/admin/AnnouncementsPage.test.jsx
@@ -24,6 +24,9 @@ describe('AnnouncementsPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     sessionStorage.clear();
+    localStorage.clear();
+    localStorage.setItem('hj_admin_session_token', 'sess');
+    localStorage.setItem('hj_admin_session_expires_at', '2099-01-01T00:00:00.000Z');
     vi.stubEnv('VITE_API_BASE', 'http://localhost:8787/api');
     vi.resetModules();
     fetch.mockImplementation((url) => {
@@ -67,7 +70,7 @@ describe('AnnouncementsPage', () => {
 
     await renderPage();
     await waitFor(() => {
-      expect(screen.getByText('Unauthorized')).toBeDefined();
+      expect(screen.getByText('Admin session expired. Please sign in again.')).toBeDefined();
     });
     expect(screen.queryByText('No announcements found.')).toBeNull();
   });
@@ -163,7 +166,6 @@ describe('AnnouncementsPage', () => {
     await renderPage();
     await waitFor(() => screen.getByPlaceholderText(/headline/i));
 
-    sessionStorage.setItem('hj_admin_session_token', 'sess');
     fireEvent.change(screen.getByPlaceholderText(/headline/i), { target: { value: 'New Ann' } });
     fireEvent.change(screen.getByPlaceholderText(/update/i), { target: { value: 'New Body' } });
     

--- a/src/views/admin/DigestPage.jsx
+++ b/src/views/admin/DigestPage.jsx
@@ -1,29 +1,24 @@
 import { useEffect, useState } from 'react';
-import { API_BASE } from '../../lib/api';
-import { getAdminToken } from '../../lib/adminAuth';
-
-const DIGEST_ENDPOINT = `${API_BASE}/admin/digests`;
+import { adminFetch } from '../../lib/adminAuth';
 
 async function apiFetch(method, params = {}) {
-  const token = getAdminToken();
-  const headers = {
-    'Content-Type': 'application/json',
-    ...(token ? { Authorization: `Bearer ${token}` } : {}),
-  };
-
   if (method === 'GET') {
     const qs = params.tournamentId ? `?tournamentId=${encodeURIComponent(params.tournamentId)}` : '';
-    const res = await fetch(`${DIGEST_ENDPOINT}${qs}`, { headers });
+    const res = await adminFetch(`/admin/digests${qs}`);
     return res.json();
   }
 
   if (method === 'POST') {
-    const res = await fetch(DIGEST_ENDPOINT, { method: 'POST', headers, body: JSON.stringify(params) });
+    const res = await adminFetch('/admin/digests', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(params),
+    });
     return res.json();
   }
 
   if (method === 'DELETE') {
-    const res = await fetch(`${DIGEST_ENDPOINT}?id=${encodeURIComponent(params.id)}`, { method: 'DELETE', headers });
+    const res = await adminFetch(`/admin/digests?id=${encodeURIComponent(params.id)}`, { method: 'DELETE' });
     return res.json();
   }
 }

--- a/src/views/admin/DigestPage.test.jsx
+++ b/src/views/admin/DigestPage.test.jsx
@@ -1,11 +1,17 @@
 import React from "react";
-import { describe, it, expect, vi, afterEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, waitFor, fireEvent } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import DigestPage from "./DigestPage";
 
 vi.mock("../../lib/api", () => ({ API_BASE: "http://localhost:8787/api" }));
-vi.mock("../../lib/adminAuth", () => ({ getAdminToken: vi.fn(() => "test-token") }));
+
+beforeEach(() => {
+  localStorage.clear();
+  sessionStorage.clear();
+  localStorage.setItem("hj_admin_session_token", "test-token");
+  localStorage.setItem("hj_admin_session_expires_at", "2099-01-01T00:00:00.000Z");
+});
 
 function renderPage() {
   return render(
@@ -345,12 +351,10 @@ describe("DigestPage – create form", () => {
   });
 
   it("uses empty Authorization header when no admin token", async () => {
-    const { getAdminToken } = await import("../../lib/adminAuth");
-    getAdminToken.mockReturnValueOnce(null); // no token for the first apiFetch call
-    mockFetch([EMPTY_LIST]);
+    localStorage.removeItem("hj_admin_session_token");
+    localStorage.removeItem("hj_admin_session_expires_at");
     renderPage();
-    await screen.findByText(/No share links yet/i);
-    // No crash — headers fallback to Content-Type only (no Authorization)
+    expect(await screen.findByText(/Admin session expired. Please sign in again./i)).toBeTruthy();
   });
 
   it("formatExpiry returns raw iso string when toLocaleDateString throws", async () => {

--- a/src/views/admin/TournamentWizard.jsx
+++ b/src/views/admin/TournamentWizard.jsx
@@ -1,6 +1,7 @@
 import React, { useMemo, useRef, useState } from "react";
 import PropTypes from "prop-types";
-import { API_BASE, getFranchises } from "../../lib/api";
+import { getFranchises } from "../../lib/api";
+import { adminFetch } from "../../lib/adminAuth";
 import { parseFranchiseName, normalizeTeamName } from "../../lib/franchise";
 import { computeFormErrors } from "./tournamentWizardUtils";
 
@@ -603,7 +604,7 @@ export default function TournamentWizard() {
           })),
       };
 
-      const res = await fetch(`${API_BASE}/admin/tournament-wizard`, {
+      const res = await adminFetch("/admin/tournament-wizard", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(payload),
@@ -624,7 +625,7 @@ export default function TournamentWizard() {
     let alive = true;
     (async () => {
       try {
-        const res = await fetch(`${API_BASE}/admin/venues`);
+        const res = await adminFetch("/admin/venues");
         if (!res.ok) throw new Error("Failed to load venues");
         const json = await res.json();
         if (!alive) return;
@@ -643,7 +644,7 @@ export default function TournamentWizard() {
     let alive = true;
     (async () => {
       try {
-        const rows = await getFranchises();
+        const rows = await getFranchises(tournament.id || tournamentIdHint || undefined);
         if (!alive) return;
         const names = rows.map((r) => r.Name || r.name).filter(Boolean);
         setApiFranchiseNames(names);
@@ -654,7 +655,7 @@ export default function TournamentWizard() {
     return () => {
       alive = false;
     };
-  }, []);
+  }, [tournament.id, tournamentIdHint]);
 
   return (
     <div className="wizard-page">

--- a/src/views/admin/TournamentWizard.test.jsx
+++ b/src/views/admin/TournamentWizard.test.jsx
@@ -11,6 +11,9 @@ describe("TournamentWizard", () => {
     vi.stubEnv("VITE_API_BASE", "http://localhost:8787/api");
     vi.resetModules();
     sessionStorage.clear();
+    localStorage.clear();
+    localStorage.setItem("hj_admin_session_token", "sess");
+    localStorage.setItem("hj_admin_session_expires_at", "2099-01-01T00:00:00.000Z");
     fetch.mockImplementation((url) => {
       if (typeof url === "string" && url.includes("/admin/venues")) {
         return Promise.resolve({
@@ -83,13 +86,15 @@ describe("TournamentWizard", () => {
     fireEvent.click(screen.getByRole("button", { name: /Create Tournament/i }));
 
     await waitFor(() => {
-      expect(fetch).toHaveBeenCalledWith(
-        "http://localhost:8787/api/admin/tournament-wizard",
-        expect.objectContaining({
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-        })
+      const call = fetch.mock.calls.find(
+        ([url, options]) =>
+          url === "http://localhost:8787/api/admin/tournament-wizard" &&
+          options?.method === "POST"
       );
+      expect(call).toBeDefined();
+      const [, options] = call;
+      expect(options.headers.get("Content-Type")).toBe("application/json");
+      expect(options.headers.get("Authorization")).toBe("Bearer sess");
     });
   });
 

--- a/test/server/endpoints.test.js
+++ b/test/server/endpoints.test.js
@@ -224,6 +224,33 @@ describe('API Endpoints (Mocked DB)', () => {
         expect(responseBody.groups).toHaveLength(2);
     });
 
+    it('GET /api?sheet=Franchises returns distinct franchise names', async () => {
+        mocks.query.mockResolvedValueOnce({
+            rows: [
+                { name: 'Dragons' },
+                { name: 'Gryphons' }
+            ]
+        });
+
+        const req = {
+            method: 'GET',
+            url: '/api?sheet=Franchises',
+            headers: { host: 'localhost' },
+            on: vi.fn()
+        };
+        const res = { setHeader: vi.fn(), writeHead: vi.fn(), end: vi.fn() };
+
+        await requestHandler(req, res);
+
+        expect(mocks.query).toHaveBeenCalledWith(
+            expect.stringContaining('SELECT DISTINCT franchise_name AS name'),
+            ['hj-indoor-allstars-2025']
+        );
+        expect(res.writeHead).toHaveBeenCalledWith(200);
+        const responseBody = JSON.parse(res.end.mock.calls[0][0]);
+        expect(responseBody.rows).toEqual([{ Name: 'Dragons' }, { Name: 'Gryphons' }]);
+    });
+
     it('GET /api/fixtures returns data with params', async () => {
         mocks.query.mockResolvedValueOnce({
             rows: [


### PR DESCRIPTION
## Summary
- persist admin auth across tabs with expiry enforcement
- clear stale sessions on 401 and surface auth-expired state
- switch remaining admin views to adminFetch
- restore db-backed Franchises sheet endpoint for tournament wizard

## Verification
- npm run verify
