### PR TITLE
Phase 3: Franchise Management page

### DIFF
--- a/db/migrations/008_enable_rls_on_public_reference_tables.sql
+++ b/db/migrations/008_enable_rls_on_public_reference_tables.sql
@@ -9,6 +9,7 @@ BEGIN
     'fixture_date_fix_backup_allstars',
     'venue_directory',
     'franchise',
+    'franchise_directory',
     'time_slot',
     'venue',
     'group_venue',

--- a/db/migrations/013_franchise_directory.sql
+++ b/db/migrations/013_franchise_directory.sql
@@ -1,0 +1,46 @@
+-- Global franchise directory for admin-managed reusable franchises
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS franchise_directory (
+  id TEXT PRIMARY KEY DEFAULT gen_random_uuid()::text,
+  name TEXT NOT NULL UNIQUE,
+  logo_url TEXT,
+  manager_name TEXT,
+  manager_photo_url TEXT,
+  description TEXT,
+  contact_phone TEXT,
+  location_map_url TEXT,
+  contact_email TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_franchise_directory_name
+  ON franchise_directory (name);
+
+-- Keep updated_at current
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_proc WHERE proname = 'set_updated_at_franchise_directory'
+  ) THEN
+    CREATE OR REPLACE FUNCTION set_updated_at_franchise_directory()
+    RETURNS TRIGGER AS $$
+    BEGIN
+      NEW.updated_at = NOW();
+      RETURN NEW;
+    END;
+    $$ LANGUAGE plpgsql;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_trigger WHERE tgname = 'trg_franchise_directory_updated_at'
+  ) THEN
+    CREATE TRIGGER trg_franchise_directory_updated_at
+    BEFORE UPDATE ON franchise_directory
+    FOR EACH ROW
+    EXECUTE FUNCTION set_updated_at_franchise_directory();
+  END IF;
+END $$;
+
+COMMIT;

--- a/server/admin.mjs
+++ b/server/admin.mjs
@@ -509,6 +509,200 @@ export async function handleAdminRequest(req, res, { url, pool, sendJson, caches
     }
   }
 
+  if (path === "/franchises") {
+    if (!pool) {
+      return sendJson(req, res, 501, { ok: false, error: "DB not configured" });
+    }
+
+    if (method === "GET") {
+      try {
+        const result = await pool.query(
+          `SELECT id, name, logo_url, manager_name, manager_photo_url, description,
+                  contact_phone, location_map_url, contact_email, created_at, updated_at
+           FROM franchise_directory
+           ORDER BY name ASC`
+        );
+        return sendJson(req, res, 200, { ok: true, data: result.rows || [] });
+      } catch (err) {
+        console.error("Admin API Error:", err);
+        return sendJson(req, res, 500, { ok: false, error: "Failed to load franchises" });
+      }
+    }
+
+    if (method === "POST") {
+      try {
+        const body = await readBody(req);
+        if (!body) return sendJson(req, res, 400, { ok: false, error: "Invalid body" });
+        const name = toTitleCase(normalizeSpaces(body.name));
+        if (!name) return sendJson(req, res, 400, { ok: false, error: "name is required" });
+
+        const result = await pool.query(
+          `INSERT INTO franchise_directory (
+             name, logo_url, manager_name, manager_photo_url, description,
+             contact_phone, location_map_url, contact_email
+           )
+           VALUES ($1,$2,$3,$4,$5,$6,$7,$8)
+           RETURNING id, name, logo_url, manager_name, manager_photo_url, description,
+                     contact_phone, location_map_url, contact_email, created_at, updated_at`,
+          [
+            name,
+            body.logo_url || null,
+            body.manager_name || null,
+            body.manager_photo_url || null,
+            body.description || null,
+            body.contact_phone || null,
+            body.location_map_url || null,
+            body.contact_email || null,
+          ]
+        );
+
+        logAudit("franchise_directory.create", { entity_type: "franchise_directory", entity_id: result.rows[0].id, meta: { name } });
+        return sendJson(req, res, 201, { ok: true, data: result.rows[0] });
+      } catch (err) {
+        console.error("Admin API Error:", err);
+        return sendJson(req, res, 500, { ok: false, error: err.message });
+      }
+    }
+
+    if (method !== "POST" && method !== "GET") {
+      return sendJson(req, res, 405, { ok: false, error: "Method not allowed" });
+    }
+  }
+
+  if (path.startsWith("/franchises/") && path !== "/franchises/import") {
+    if (!pool) {
+      return sendJson(req, res, 501, { ok: false, error: "DB not configured" });
+    }
+
+    const id = normalizeSpaces(path.replace("/franchises/", ""));
+    if (!id) return sendJson(req, res, 400, { ok: false, error: "Missing id" });
+
+    if (method === "PATCH") {
+      try {
+        const body = await readBody(req);
+        if (!body) return sendJson(req, res, 400, { ok: false, error: "Invalid body" });
+
+        const patch = {
+          name: body.name != null ? toTitleCase(normalizeSpaces(body.name)) : null,
+          logo_url: body.logo_url != null ? body.logo_url : null,
+          manager_name: body.manager_name != null ? body.manager_name : null,
+          manager_photo_url: body.manager_photo_url != null ? body.manager_photo_url : null,
+          description: body.description != null ? body.description : null,
+          contact_phone: body.contact_phone != null ? body.contact_phone : null,
+          location_map_url: body.location_map_url != null ? body.location_map_url : null,
+          contact_email: body.contact_email != null ? body.contact_email : null,
+        };
+
+        const name = patch.name;
+        if (body.name != null && !name) {
+          return sendJson(req, res, 400, { ok: false, error: "name is required" });
+        }
+
+        const result = await pool.query(
+          `UPDATE franchise_directory
+              SET name = COALESCE($2, name),
+                  logo_url = COALESCE($3, logo_url),
+                  manager_name = COALESCE($4, manager_name),
+                  manager_photo_url = COALESCE($5, manager_photo_url),
+                  description = COALESCE($6, description),
+                  contact_phone = COALESCE($7, contact_phone),
+                  location_map_url = COALESCE($8, location_map_url),
+                  contact_email = COALESCE($9, contact_email)
+            WHERE id = $1
+        RETURNING id, name, logo_url, manager_name, manager_photo_url, description,
+                  contact_phone, location_map_url, contact_email, created_at, updated_at`,
+          [
+            id,
+            patch.name,
+            patch.logo_url,
+            patch.manager_name,
+            patch.manager_photo_url,
+            patch.description,
+            patch.contact_phone,
+            patch.location_map_url,
+            patch.contact_email,
+          ]
+        );
+
+        if (result.rowCount === 0) {
+          return sendJson(req, res, 404, { ok: false, error: "Franchise not found" });
+        }
+
+        logAudit("franchise_directory.update", { entity_type: "franchise_directory", entity_id: id, meta: { name: result.rows[0].name } });
+        return sendJson(req, res, 200, { ok: true, data: result.rows[0] });
+      } catch (err) {
+        console.error("Admin API Error:", err);
+        return sendJson(req, res, 500, { ok: false, error: err.message });
+      }
+    }
+
+    if (method === "DELETE") {
+      try {
+        const existing = await pool.query(
+          `SELECT id, name FROM franchise_directory WHERE id = $1`,
+          [id]
+        );
+        if (existing.rowCount === 0) {
+          return sendJson(req, res, 404, { ok: false, error: "Franchise not found" });
+        }
+
+        await pool.query(`DELETE FROM franchise_directory WHERE id = $1`, [id]);
+        logAudit("franchise_directory.delete", { entity_type: "franchise_directory", entity_id: id, meta: { name: existing.rows[0].name } });
+        return sendJson(req, res, 200, { ok: true });
+      } catch (err) {
+        console.error("Admin API Error:", err);
+        return sendJson(req, res, 500, { ok: false, error: err.message });
+      }
+    }
+
+    return sendJson(req, res, 405, { ok: false, error: "Method not allowed" });
+  }
+
+  if (path === "/franchises/import") {
+    if (!pool) {
+      return sendJson(req, res, 501, { ok: false, error: "DB not configured" });
+    }
+
+    if (method !== "POST") {
+      return sendJson(req, res, 405, { ok: false, error: "Method not allowed" });
+    }
+
+    try {
+      const body = await readBody(req);
+      if (!body) return sendJson(req, res, 400, { ok: false, error: "Invalid body" });
+
+      const raw = normalizeSpaces(body.names || body.text || body.csv || "");
+      if (!raw) return sendJson(req, res, 400, { ok: false, error: "No names provided" });
+
+      const lines = String(body.names || body.text || body.csv || "")
+        .split(/\r?\n/)
+        .map((line) => line.split(",")[0])
+        .map((line) => toTitleCase(normalizeSpaces(line)))
+        .filter(Boolean);
+
+      const unique = Array.from(new Set(lines));
+      if (unique.length === 0) return sendJson(req, res, 400, { ok: false, error: "No valid names provided" });
+
+      const inserted = [];
+      for (const name of unique) {
+        const result = await pool.query(
+          `INSERT INTO franchise_directory (name)
+           VALUES ($1)
+           ON CONFLICT (name) DO NOTHING
+           RETURNING id, name, created_at, updated_at`,
+          [name]
+        );
+        if (result.rowCount > 0) inserted.push(result.rows[0]);
+      }
+
+      logAudit("franchise_directory.import", { entity_type: "franchise_directory", meta: { inserted: inserted.length, attempted: unique.length } });
+      return sendJson(req, res, 201, { ok: true, data: inserted });
+    } catch (err) {
+      console.error("Admin API Error:", err);
+      return sendJson(req, res, 500, { ok: false, error: err.message });
+    }
+  }
+
   if (path === "/audit-log") {
     if (!requireGetWithDb(method, pool, req, res, sendJson)) return;
     try {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -43,6 +43,7 @@ import TechDesk from "./views/admin/TechDesk";
 import DigestPage from "./views/admin/DigestPage";
 import DigestShare from "./views/DigestShare";
 import VenuesPage from "./views/admin/VenuesPage";
+import FranchisesPage from "./views/admin/FranchisesPage";
 
 // Filter out placeholder “teams” like 1st Place, Loser SF1, A1, etc.
 function isRealTeamName(name) {
@@ -539,6 +540,7 @@ export default function App() {
               <Route path="tournaments" element={<TournamentWizard />} />
               <Route path="announcements" element={<AnnouncementsPage />} />
               <Route path="venues/*" element={<VenuesPage />} />
+              <Route path="franchises/*" element={<FranchisesPage />} />
               <Route path="fixtures" element={<FixturesPage />} />
               <Route path="digests" element={<DigestPage />} />
               <Route path="tech-desk/:matchId" element={<TechDesk />} />

--- a/src/lib/franchiseApi.js
+++ b/src/lib/franchiseApi.js
@@ -1,0 +1,76 @@
+// src/lib/franchiseApi.js
+import { adminFetch } from './adminAuth';
+
+const endpoint = () => `/admin/franchises`;
+
+async function parseJson(res) {
+  const json = await res.json().catch(() => ({}));
+  if (!res.ok || json.ok === false) {
+    throw new Error(json.error || `HTTP ${res.status}`);
+  }
+  return json;
+}
+
+/**
+ * Fetch all franchises (global directory)
+ * @returns {Promise<Array>} Array of franchise objects
+ */
+export async function getFranchises() {
+  const res = await adminFetch(endpoint());
+  const json = await parseJson(res);
+  return json.data || [];
+}
+
+/**
+ * Create a new franchise
+ * @param {Object} franchiseData
+ */
+export async function createFranchise(franchiseData) {
+  const res = await adminFetch(endpoint(), {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(franchiseData),
+  });
+  const json = await parseJson(res);
+  return json.data;
+}
+
+/**
+ * Update an existing franchise
+ * @param {string} id
+ * @param {Object} franchiseData
+ */
+export async function updateFranchise(id, franchiseData) {
+  const res = await adminFetch(`${endpoint()}/${id}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(franchiseData),
+  });
+  const json = await parseJson(res);
+  return json.data;
+}
+
+/**
+ * Delete a franchise
+ * @param {string} id
+ */
+export async function deleteFranchise(id) {
+  const res = await adminFetch(`${endpoint()}/${id}`, {
+    method: 'DELETE',
+  });
+  await parseJson(res);
+}
+
+/**
+ * Bulk import franchises by name
+ * @param {string} namesText - newline or CSV list
+ */
+export async function importFranchises(namesText) {
+  const res = await adminFetch(`${endpoint()}/import`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ names: namesText }),
+  });
+  const json = await parseJson(res);
+  return json.data || [];
+}

--- a/src/lib/franchiseApi.test.js
+++ b/src/lib/franchiseApi.test.js
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('./adminAuth', () => ({
+  adminFetch: vi.fn(),
+}));
+
+const { adminFetch } = await import('./adminAuth');
+
+function okJson(data) {
+  return Promise.resolve({
+    ok: true,
+    status: 200,
+    json: () => Promise.resolve({ ok: true, data }),
+  });
+}
+
+function failJson(status, error) {
+  return Promise.resolve({
+    ok: false,
+    status,
+    json: () => Promise.resolve({ ok: false, error }),
+  });
+}
+
+describe('franchiseApi', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('getFranchises calls admin endpoint and returns data', async () => {
+    adminFetch.mockResolvedValueOnce(okJson([{ id: 'f1', name: 'Alpha' }]));
+
+    const api = await import('./franchiseApi');
+    const result = await api.getFranchises();
+
+    expect(adminFetch).toHaveBeenCalledWith('/admin/franchises');
+    expect(result).toEqual([{ id: 'f1', name: 'Alpha' }]);
+  });
+
+  it('createFranchise POSTs and returns created data', async () => {
+    adminFetch.mockResolvedValueOnce(okJson({ id: 'f1', name: 'Alpha' }));
+
+    const api = await import('./franchiseApi');
+    const created = await api.createFranchise({ name: 'Alpha' });
+
+    expect(adminFetch).toHaveBeenCalledWith('/admin/franchises', expect.objectContaining({ method: 'POST' }));
+    expect(created).toEqual({ id: 'f1', name: 'Alpha' });
+  });
+
+  it('updateFranchise PATCHes and returns updated data', async () => {
+    adminFetch.mockResolvedValueOnce(okJson({ id: 'f1', name: 'Alpha Updated' }));
+
+    const api = await import('./franchiseApi');
+    const updated = await api.updateFranchise('f1', { name: 'Alpha Updated' });
+
+    expect(adminFetch).toHaveBeenCalledWith('/admin/franchises/f1', expect.objectContaining({ method: 'PATCH' }));
+    expect(updated).toEqual({ id: 'f1', name: 'Alpha Updated' });
+  });
+
+  it('deleteFranchise DELETEs and returns void', async () => {
+    adminFetch.mockResolvedValueOnce(okJson(undefined));
+
+    const api = await import('./franchiseApi');
+    await expect(api.deleteFranchise('f1')).resolves.toBeUndefined();
+
+    expect(adminFetch).toHaveBeenCalledWith('/admin/franchises/f1', expect.objectContaining({ method: 'DELETE' }));
+  });
+
+  it('importFranchises POSTs names and returns inserted rows', async () => {
+    adminFetch.mockResolvedValueOnce(okJson([{ id: 'f1', name: 'Alpha' }]));
+
+    const api = await import('./franchiseApi');
+    const inserted = await api.importFranchises('Alpha');
+
+    expect(adminFetch).toHaveBeenCalledWith('/admin/franchises/import', expect.objectContaining({ method: 'POST' }));
+    expect(inserted).toEqual([{ id: 'f1', name: 'Alpha' }]);
+  });
+
+  it('throws when server responds not ok', async () => {
+    adminFetch.mockResolvedValueOnce(failJson(400, 'Bad request'));
+
+    const api = await import('./franchiseApi');
+    await expect(api.getFranchises()).rejects.toThrow('Bad request');
+  });
+});

--- a/src/views/admin/AdminLayout.jsx
+++ b/src/views/admin/AdminLayout.jsx
@@ -72,6 +72,7 @@ export default function AdminLayout() {
         <NavLink to="/admin/tournaments" style={linkStyle}>Tournaments</NavLink>
         <NavLink to="/admin/announcements" style={linkStyle}>Announcements</NavLink>
         <NavLink to="/admin/venues" style={linkStyle}>Venues</NavLink>
+        <NavLink to="/admin/franchises" style={linkStyle}>Franchises</NavLink>
         <NavLink to="/admin/teams" style={linkStyle}>Teams</NavLink>
         <NavLink to="/admin/fixtures" style={linkStyle}>Fixtures</NavLink>
         <NavLink to="/admin/digests" style={linkStyle}>Share Digests</NavLink>

--- a/src/views/admin/FranchiseForm.jsx
+++ b/src/views/admin/FranchiseForm.jsx
@@ -1,0 +1,347 @@
+import React, { useEffect, useState } from 'react';
+import PropTypes from 'prop-types';
+
+export default function FranchiseForm({
+  franchise = null,
+  onSave,
+  onCancel,
+  isLoading = false,
+  error = null,
+}) {
+  const [formData, setFormData] = useState({
+    name: '',
+    logo_url: '',
+    manager_name: '',
+    manager_photo_url: '',
+    contact_email: '',
+    contact_phone: '',
+    location_map_url: '',
+    description: '',
+  });
+
+  useEffect(() => {
+    if (franchise) {
+      setFormData({
+        name: franchise.name || '',
+        logo_url: franchise.logo_url || '',
+        manager_name: franchise.manager_name || '',
+        manager_photo_url: franchise.manager_photo_url || '',
+        contact_email: franchise.contact_email || '',
+        contact_phone: franchise.contact_phone || '',
+        location_map_url: franchise.location_map_url || '',
+        description: franchise.description || '',
+      });
+    }
+  }, [franchise]);
+
+  const handleChange = (e) => {
+    const { name, value } = e.target;
+    setFormData((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    onSave(formData);
+  };
+
+  const isEditing = Boolean(franchise);
+
+  return (
+    <form onSubmit={handleSubmit} style={{ maxWidth: '700px' }}>
+      {error && (
+        <div
+          style={{
+            padding: 'var(--hj-space-3)',
+            marginBottom: 'var(--hj-space-4)',
+            backgroundColor: '#fee',
+            color: '#c00',
+            borderRadius: 'var(--hj-radius-md)',
+          }}
+          role="alert"
+        >
+          {error}
+        </div>
+      )}
+
+      <div style={{ marginBottom: 'var(--hj-space-4)' }}>
+        <label
+          htmlFor="name"
+          style={{
+            display: 'block',
+            marginBottom: 'var(--hj-space-2)',
+            fontWeight: 'var(--hj-font-weight-bold)',
+          }}
+        >
+          Franchise Name
+        </label>
+        <input
+          id="name"
+          name="name"
+          type="text"
+          value={formData.name}
+          onChange={handleChange}
+          required
+          disabled={isLoading}
+          style={{
+            width: '100%',
+            padding: 'var(--hj-space-2)',
+            borderRadius: 'var(--hj-radius-md)',
+            border: '1px solid var(--hj-color-border)',
+            fontSize: 'var(--hj-font-size-base)',
+          }}
+        />
+      </div>
+
+      <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 'var(--hj-space-4)' }}>
+        <div>
+          <label
+            htmlFor="manager_name"
+            style={{
+              display: 'block',
+              marginBottom: 'var(--hj-space-2)',
+              fontWeight: 'var(--hj-font-weight-bold)',
+            }}
+          >
+            Manager Name
+          </label>
+          <input
+            id="manager_name"
+            name="manager_name"
+            type="text"
+            value={formData.manager_name}
+            onChange={handleChange}
+            disabled={isLoading}
+            style={{
+              width: '100%',
+              padding: 'var(--hj-space-2)',
+              borderRadius: 'var(--hj-radius-md)',
+              border: '1px solid var(--hj-color-border)',
+            }}
+          />
+        </div>
+
+        <div>
+          <label
+            htmlFor="contact_email"
+            style={{
+              display: 'block',
+              marginBottom: 'var(--hj-space-2)',
+              fontWeight: 'var(--hj-font-weight-bold)',
+            }}
+          >
+            Contact Email
+          </label>
+          <input
+            id="contact_email"
+            name="contact_email"
+            type="email"
+            value={formData.contact_email}
+            onChange={handleChange}
+            disabled={isLoading}
+            style={{
+              width: '100%',
+              padding: 'var(--hj-space-2)',
+              borderRadius: 'var(--hj-radius-md)',
+              border: '1px solid var(--hj-color-border)',
+            }}
+          />
+        </div>
+      </div>
+
+      <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 'var(--hj-space-4)', marginTop: 'var(--hj-space-4)' }}>
+        <div>
+          <label
+            htmlFor="logo_url"
+            style={{
+              display: 'block',
+              marginBottom: 'var(--hj-space-2)',
+              fontWeight: 'var(--hj-font-weight-bold)',
+            }}
+          >
+            Logo URL
+          </label>
+          <input
+            id="logo_url"
+            name="logo_url"
+            type="url"
+            value={formData.logo_url}
+            onChange={handleChange}
+            disabled={isLoading}
+            style={{
+              width: '100%',
+              padding: 'var(--hj-space-2)',
+              borderRadius: 'var(--hj-radius-md)',
+              border: '1px solid var(--hj-color-border)',
+            }}
+          />
+        </div>
+
+        <div>
+          <label
+            htmlFor="manager_photo_url"
+            style={{
+              display: 'block',
+              marginBottom: 'var(--hj-space-2)',
+              fontWeight: 'var(--hj-font-weight-bold)',
+            }}
+          >
+            Manager Photo URL
+          </label>
+          <input
+            id="manager_photo_url"
+            name="manager_photo_url"
+            type="url"
+            value={formData.manager_photo_url}
+            onChange={handleChange}
+            disabled={isLoading}
+            style={{
+              width: '100%',
+              padding: 'var(--hj-space-2)',
+              borderRadius: 'var(--hj-radius-md)',
+              border: '1px solid var(--hj-color-border)',
+            }}
+          />
+        </div>
+      </div>
+
+      <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 'var(--hj-space-4)', marginTop: 'var(--hj-space-4)' }}>
+        <div>
+          <label
+            htmlFor="contact_phone"
+            style={{
+              display: 'block',
+              marginBottom: 'var(--hj-space-2)',
+              fontWeight: 'var(--hj-font-weight-bold)',
+            }}
+          >
+            Contact Phone
+          </label>
+          <input
+            id="contact_phone"
+            name="contact_phone"
+            type="tel"
+            value={formData.contact_phone}
+            onChange={handleChange}
+            disabled={isLoading}
+            style={{
+              width: '100%',
+              padding: 'var(--hj-space-2)',
+              borderRadius: 'var(--hj-radius-md)',
+              border: '1px solid var(--hj-color-border)',
+            }}
+          />
+        </div>
+
+        <div>
+          <label
+            htmlFor="location_map_url"
+            style={{
+              display: 'block',
+              marginBottom: 'var(--hj-space-2)',
+              fontWeight: 'var(--hj-font-weight-bold)',
+            }}
+          >
+            Location Map URL
+          </label>
+          <input
+            id="location_map_url"
+            name="location_map_url"
+            type="url"
+            value={formData.location_map_url}
+            onChange={handleChange}
+            disabled={isLoading}
+            style={{
+              width: '100%',
+              padding: 'var(--hj-space-2)',
+              borderRadius: 'var(--hj-radius-md)',
+              border: '1px solid var(--hj-color-border)',
+            }}
+          />
+        </div>
+      </div>
+
+      <div style={{ marginTop: 'var(--hj-space-4)', marginBottom: 'var(--hj-space-4)' }}>
+        <label
+          htmlFor="description"
+          style={{
+            display: 'block',
+            marginBottom: 'var(--hj-space-2)',
+            fontWeight: 'var(--hj-font-weight-bold)',
+          }}
+        >
+          Description
+        </label>
+        <textarea
+          id="description"
+          name="description"
+          value={formData.description}
+          onChange={handleChange}
+          disabled={isLoading}
+          rows="4"
+          style={{
+            width: '100%',
+            padding: 'var(--hj-space-2)',
+            borderRadius: 'var(--hj-radius-md)',
+            border: '1px solid var(--hj-color-border)',
+            fontSize: 'var(--hj-font-size-base)',
+          }}
+        />
+      </div>
+
+      <div style={{ display: 'flex', gap: 'var(--hj-space-3)' }}>
+        <button
+          type="submit"
+          disabled={isLoading}
+          style={{
+            padding: 'var(--hj-space-2) var(--hj-space-4)',
+            borderRadius: 'var(--hj-radius-md)',
+            backgroundColor: 'var(--hj-color-brand-primary)',
+            color: 'var(--hj-color-inverse-text)',
+            border: 'none',
+            fontWeight: 'var(--hj-font-weight-bold)',
+            cursor: isLoading ? 'not-allowed' : 'pointer',
+            opacity: isLoading ? 0.6 : 1,
+          }}
+        >
+          {isLoading ? 'Saving…' : isEditing ? 'Update Franchise' : 'Create Franchise'}
+        </button>
+
+        <button
+          type="button"
+          onClick={onCancel}
+          disabled={isLoading}
+          style={{
+            padding: 'var(--hj-space-2) var(--hj-space-4)',
+            borderRadius: 'var(--hj-radius-md)',
+            backgroundColor: 'transparent',
+            color: 'var(--hj-color-text-secondary)',
+            border: '1px solid var(--hj-color-border)',
+            fontWeight: 'var(--hj-font-weight-regular)',
+            cursor: isLoading ? 'not-allowed' : 'pointer',
+            opacity: isLoading ? 0.6 : 1,
+          }}
+        >
+          Cancel
+        </button>
+      </div>
+    </form>
+  );
+}
+
+FranchiseForm.propTypes = {
+  franchise: PropTypes.shape({
+    id: PropTypes.string,
+    name: PropTypes.string,
+    logo_url: PropTypes.string,
+    manager_name: PropTypes.string,
+    manager_photo_url: PropTypes.string,
+    contact_email: PropTypes.string,
+    contact_phone: PropTypes.string,
+    location_map_url: PropTypes.string,
+    description: PropTypes.string,
+  }),
+  onSave: PropTypes.func.isRequired,
+  onCancel: PropTypes.func.isRequired,
+  isLoading: PropTypes.bool,
+  error: PropTypes.string,
+};

--- a/src/views/admin/FranchiseForm.jsx
+++ b/src/views/admin/FranchiseForm.jsx
@@ -1,6 +1,96 @@
 import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 
+const styles = {
+  alert: {
+    padding: 'var(--hj-space-3)',
+    marginBottom: 'var(--hj-space-4)',
+    backgroundColor: '#fee',
+    color: '#c00',
+    borderRadius: 'var(--hj-radius-md)',
+  },
+  label: {
+    display: 'block',
+    marginBottom: 'var(--hj-space-2)',
+    fontWeight: 'var(--hj-font-weight-bold)',
+  },
+  input: {
+    width: '100%',
+    padding: 'var(--hj-space-2)',
+    borderRadius: 'var(--hj-radius-md)',
+    border: '1px solid var(--hj-color-border)',
+    fontSize: 'var(--hj-font-size-base)',
+  },
+  gridTwo: {
+    display: 'grid',
+    gridTemplateColumns: '1fr 1fr',
+    gap: 'var(--hj-space-4)',
+  },
+  buttonPrimary: (disabled) => ({
+    padding: 'var(--hj-space-2) var(--hj-space-4)',
+    borderRadius: 'var(--hj-radius-md)',
+    backgroundColor: 'var(--hj-color-brand-primary)',
+    color: 'var(--hj-color-inverse-text)',
+    border: 'none',
+    fontWeight: 'var(--hj-font-weight-bold)',
+    cursor: disabled ? 'not-allowed' : 'pointer',
+    opacity: disabled ? 0.6 : 1,
+  }),
+  buttonSecondary: (disabled) => ({
+    padding: 'var(--hj-space-2) var(--hj-space-4)',
+    borderRadius: 'var(--hj-radius-md)',
+    backgroundColor: 'transparent',
+    color: 'var(--hj-color-text-secondary)',
+    border: '1px solid var(--hj-color-border)',
+    fontWeight: 'var(--hj-font-weight-regular)',
+    cursor: disabled ? 'not-allowed' : 'pointer',
+    opacity: disabled ? 0.6 : 1,
+  }),
+  buttonDanger: (disabled) => ({
+    padding: 'var(--hj-space-1) var(--hj-space-3)',
+    borderRadius: 'var(--hj-radius-sm)',
+    backgroundColor: '#fee',
+    color: '#c00',
+    border: '1px solid #fcc',
+    cursor: disabled ? 'not-allowed' : 'pointer',
+    fontSize: 'var(--hj-font-size-sm)',
+    opacity: disabled ? 0.6 : 1,
+  }),
+};
+
+function TextField({ id, label, type = 'text', value, onChange, disabled }) {
+  return (
+    <div>
+      <label htmlFor={id} style={styles.label}>
+        {label}
+      </label>
+      <input
+        id={id}
+        name={id}
+        type={type}
+        value={value}
+        onChange={onChange}
+        disabled={disabled}
+        style={styles.input}
+      />
+    </div>
+  );
+}
+
+TextField.propTypes = {
+  id: PropTypes.string.isRequired,
+  label: PropTypes.string.isRequired,
+  type: PropTypes.string,
+  value: PropTypes.string.isRequired,
+  onChange: PropTypes.func.isRequired,
+  disabled: PropTypes.bool,
+};
+
+TextField.defaultProps = {
+  type: 'text',
+  disabled: false,
+};
+
 export default function FranchiseForm({
   franchise = null,
   onSave,
@@ -49,29 +139,13 @@ export default function FranchiseForm({
   return (
     <form onSubmit={handleSubmit} style={{ maxWidth: '700px' }}>
       {error && (
-        <div
-          style={{
-            padding: 'var(--hj-space-3)',
-            marginBottom: 'var(--hj-space-4)',
-            backgroundColor: '#fee',
-            color: '#c00',
-            borderRadius: 'var(--hj-radius-md)',
-          }}
-          role="alert"
-        >
+        <div style={styles.alert} role="alert">
           {error}
         </div>
       )}
 
       <div style={{ marginBottom: 'var(--hj-space-4)' }}>
-        <label
-          htmlFor="name"
-          style={{
-            display: 'block',
-            marginBottom: 'var(--hj-space-2)',
-            fontWeight: 'var(--hj-font-weight-bold)',
-          }}
-        >
+        <label htmlFor="name" style={styles.label}>
           Franchise Name
         </label>
         <input
@@ -82,193 +156,68 @@ export default function FranchiseForm({
           onChange={handleChange}
           required
           disabled={isLoading}
-          style={{
-            width: '100%',
-            padding: 'var(--hj-space-2)',
-            borderRadius: 'var(--hj-radius-md)',
-            border: '1px solid var(--hj-color-border)',
-            fontSize: 'var(--hj-font-size-base)',
-          }}
+          style={styles.input}
         />
       </div>
 
-      <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 'var(--hj-space-4)' }}>
-        <div>
-          <label
-            htmlFor="manager_name"
-            style={{
-              display: 'block',
-              marginBottom: 'var(--hj-space-2)',
-              fontWeight: 'var(--hj-font-weight-bold)',
-            }}
-          >
-            Manager Name
-          </label>
-          <input
-            id="manager_name"
-            name="manager_name"
-            type="text"
-            value={formData.manager_name}
-            onChange={handleChange}
-            disabled={isLoading}
-            style={{
-              width: '100%',
-              padding: 'var(--hj-space-2)',
-              borderRadius: 'var(--hj-radius-md)',
-              border: '1px solid var(--hj-color-border)',
-            }}
-          />
-        </div>
-
-        <div>
-          <label
-            htmlFor="contact_email"
-            style={{
-              display: 'block',
-              marginBottom: 'var(--hj-space-2)',
-              fontWeight: 'var(--hj-font-weight-bold)',
-            }}
-          >
-            Contact Email
-          </label>
-          <input
-            id="contact_email"
-            name="contact_email"
-            type="email"
-            value={formData.contact_email}
-            onChange={handleChange}
-            disabled={isLoading}
-            style={{
-              width: '100%',
-              padding: 'var(--hj-space-2)',
-              borderRadius: 'var(--hj-radius-md)',
-              border: '1px solid var(--hj-color-border)',
-            }}
-          />
-        </div>
+      <div style={styles.gridTwo}>
+        <TextField
+          id="manager_name"
+          label="Manager Name"
+          value={formData.manager_name}
+          onChange={handleChange}
+          disabled={isLoading}
+        />
+        <TextField
+          id="contact_email"
+          label="Contact Email"
+          type="email"
+          value={formData.contact_email}
+          onChange={handleChange}
+          disabled={isLoading}
+        />
       </div>
 
-      <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 'var(--hj-space-4)', marginTop: 'var(--hj-space-4)' }}>
-        <div>
-          <label
-            htmlFor="logo_url"
-            style={{
-              display: 'block',
-              marginBottom: 'var(--hj-space-2)',
-              fontWeight: 'var(--hj-font-weight-bold)',
-            }}
-          >
-            Logo URL
-          </label>
-          <input
-            id="logo_url"
-            name="logo_url"
-            type="url"
-            value={formData.logo_url}
-            onChange={handleChange}
-            disabled={isLoading}
-            style={{
-              width: '100%',
-              padding: 'var(--hj-space-2)',
-              borderRadius: 'var(--hj-radius-md)',
-              border: '1px solid var(--hj-color-border)',
-            }}
-          />
-        </div>
-
-        <div>
-          <label
-            htmlFor="manager_photo_url"
-            style={{
-              display: 'block',
-              marginBottom: 'var(--hj-space-2)',
-              fontWeight: 'var(--hj-font-weight-bold)',
-            }}
-          >
-            Manager Photo URL
-          </label>
-          <input
-            id="manager_photo_url"
-            name="manager_photo_url"
-            type="url"
-            value={formData.manager_photo_url}
-            onChange={handleChange}
-            disabled={isLoading}
-            style={{
-              width: '100%',
-              padding: 'var(--hj-space-2)',
-              borderRadius: 'var(--hj-radius-md)',
-              border: '1px solid var(--hj-color-border)',
-            }}
-          />
-        </div>
+      <div style={{ ...styles.gridTwo, marginTop: 'var(--hj-space-4)' }}>
+        <TextField
+          id="logo_url"
+          label="Logo URL"
+          type="url"
+          value={formData.logo_url}
+          onChange={handleChange}
+          disabled={isLoading}
+        />
+        <TextField
+          id="manager_photo_url"
+          label="Manager Photo URL"
+          type="url"
+          value={formData.manager_photo_url}
+          onChange={handleChange}
+          disabled={isLoading}
+        />
       </div>
 
-      <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 'var(--hj-space-4)', marginTop: 'var(--hj-space-4)' }}>
-        <div>
-          <label
-            htmlFor="contact_phone"
-            style={{
-              display: 'block',
-              marginBottom: 'var(--hj-space-2)',
-              fontWeight: 'var(--hj-font-weight-bold)',
-            }}
-          >
-            Contact Phone
-          </label>
-          <input
-            id="contact_phone"
-            name="contact_phone"
-            type="tel"
-            value={formData.contact_phone}
-            onChange={handleChange}
-            disabled={isLoading}
-            style={{
-              width: '100%',
-              padding: 'var(--hj-space-2)',
-              borderRadius: 'var(--hj-radius-md)',
-              border: '1px solid var(--hj-color-border)',
-            }}
-          />
-        </div>
-
-        <div>
-          <label
-            htmlFor="location_map_url"
-            style={{
-              display: 'block',
-              marginBottom: 'var(--hj-space-2)',
-              fontWeight: 'var(--hj-font-weight-bold)',
-            }}
-          >
-            Location Map URL
-          </label>
-          <input
-            id="location_map_url"
-            name="location_map_url"
-            type="url"
-            value={formData.location_map_url}
-            onChange={handleChange}
-            disabled={isLoading}
-            style={{
-              width: '100%',
-              padding: 'var(--hj-space-2)',
-              borderRadius: 'var(--hj-radius-md)',
-              border: '1px solid var(--hj-color-border)',
-            }}
-          />
-        </div>
+      <div style={{ ...styles.gridTwo, marginTop: 'var(--hj-space-4)' }}>
+        <TextField
+          id="contact_phone"
+          label="Contact Phone"
+          type="tel"
+          value={formData.contact_phone}
+          onChange={handleChange}
+          disabled={isLoading}
+        />
+        <TextField
+          id="location_map_url"
+          label="Location Map URL"
+          type="url"
+          value={formData.location_map_url}
+          onChange={handleChange}
+          disabled={isLoading}
+        />
       </div>
 
       <div style={{ marginTop: 'var(--hj-space-4)', marginBottom: 'var(--hj-space-4)' }}>
-        <label
-          htmlFor="description"
-          style={{
-            display: 'block',
-            marginBottom: 'var(--hj-space-2)',
-            fontWeight: 'var(--hj-font-weight-bold)',
-          }}
-        >
+        <label htmlFor="description" style={styles.label}>
           Description
         </label>
         <textarea
@@ -278,49 +227,16 @@ export default function FranchiseForm({
           onChange={handleChange}
           disabled={isLoading}
           rows="4"
-          style={{
-            width: '100%',
-            padding: 'var(--hj-space-2)',
-            borderRadius: 'var(--hj-radius-md)',
-            border: '1px solid var(--hj-color-border)',
-            fontSize: 'var(--hj-font-size-base)',
-          }}
+          style={styles.input}
         />
       </div>
 
       <div style={{ display: 'flex', gap: 'var(--hj-space-3)' }}>
-        <button
-          type="submit"
-          disabled={isLoading}
-          style={{
-            padding: 'var(--hj-space-2) var(--hj-space-4)',
-            borderRadius: 'var(--hj-radius-md)',
-            backgroundColor: 'var(--hj-color-brand-primary)',
-            color: 'var(--hj-color-inverse-text)',
-            border: 'none',
-            fontWeight: 'var(--hj-font-weight-bold)',
-            cursor: isLoading ? 'not-allowed' : 'pointer',
-            opacity: isLoading ? 0.6 : 1,
-          }}
-        >
+        <button type="submit" disabled={isLoading} style={styles.buttonPrimary(isLoading)}>
           {isLoading ? 'Saving…' : isEditing ? 'Update Franchise' : 'Create Franchise'}
         </button>
 
-        <button
-          type="button"
-          onClick={onCancel}
-          disabled={isLoading}
-          style={{
-            padding: 'var(--hj-space-2) var(--hj-space-4)',
-            borderRadius: 'var(--hj-radius-md)',
-            backgroundColor: 'transparent',
-            color: 'var(--hj-color-text-secondary)',
-            border: '1px solid var(--hj-color-border)',
-            fontWeight: 'var(--hj-font-weight-regular)',
-            cursor: isLoading ? 'not-allowed' : 'pointer',
-            opacity: isLoading ? 0.6 : 1,
-          }}
-        >
+        <button type="button" onClick={onCancel} disabled={isLoading} style={styles.buttonSecondary(isLoading)}>
           Cancel
         </button>
       </div>

--- a/src/views/admin/FranchiseForm.test.jsx
+++ b/src/views/admin/FranchiseForm.test.jsx
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import FranchiseForm from './FranchiseForm';
+
+describe('FranchiseForm', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('renders required name field and calls onSave', () => {
+    const onSave = vi.fn();
+    const onCancel = vi.fn();
+
+    render(<FranchiseForm onSave={onSave} onCancel={onCancel} />);
+
+    fireEvent.change(screen.getByLabelText('Franchise Name'), { target: { value: 'Alpha' } });
+    fireEvent.click(screen.getByRole('button', { name: /Create Franchise/i }));
+
+    expect(onSave).toHaveBeenCalledWith(expect.objectContaining({ name: 'Alpha' }));
+  });
+
+  it('populates fields when editing', () => {
+    const onSave = vi.fn();
+    const onCancel = vi.fn();
+
+    render(
+      <FranchiseForm
+        onSave={onSave}
+        onCancel={onCancel}
+        franchise={{ id: 'f1', name: 'Alpha', manager_name: 'Coach A' }}
+      />
+    );
+
+    expect(screen.getByLabelText('Franchise Name')).toHaveValue('Alpha');
+    expect(screen.getByLabelText('Manager Name')).toHaveValue('Coach A');
+    expect(screen.getByRole('button', { name: /Update Franchise/i })).toBeInTheDocument();
+  });
+
+  it('calls onCancel', () => {
+    const onSave = vi.fn();
+    const onCancel = vi.fn();
+
+    render(<FranchiseForm onSave={onSave} onCancel={onCancel} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    expect(onCancel).toHaveBeenCalled();
+  });
+
+  it('renders error alert', () => {
+    render(<FranchiseForm onSave={() => {}} onCancel={() => {}} error="Boom" />);
+    expect(screen.getByRole('alert')).toHaveTextContent('Boom');
+  });
+});

--- a/src/views/admin/FranchisesPage.jsx
+++ b/src/views/admin/FranchisesPage.jsx
@@ -1,0 +1,361 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import FranchiseForm from './FranchiseForm';
+import {
+  createFranchise,
+  deleteFranchise,
+  getFranchises,
+  importFranchises,
+  updateFranchise,
+} from '../../lib/franchiseApi';
+
+export default function FranchisesPage() {
+  const { franchiseId } = useParams();
+  const navigate = useNavigate();
+
+  const [franchises, setFranchises] = useState([]);
+  const [currentFranchise, setCurrentFranchise] = useState(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+  const [importText, setImportText] = useState('');
+  const [importResult, setImportResult] = useState('');
+
+  const isNew = franchiseId === 'new';
+  const isEditing = Boolean(franchiseId && franchiseId !== 'new');
+  const showForm = isNew || isEditing;
+
+  const franchiseById = useMemo(() => {
+    const map = new Map(franchises.map((f) => [String(f.id), f]));
+    return map;
+  }, [franchises]);
+
+  useEffect(() => {
+    if (showForm) return;
+
+    let alive = true;
+    (async () => {
+      try {
+        setLoading(true);
+        setError(null);
+        setImportResult('');
+        const data = await getFranchises();
+        if (!alive) return;
+        setFranchises(Array.isArray(data) ? data : []);
+      } catch (err) {
+        if (!alive) return;
+        setError(`Failed to load franchises: ${err.message}`);
+        setFranchises([]);
+      } finally {
+        if (alive) setLoading(false);
+      }
+    })();
+
+    return () => {
+      alive = false;
+    };
+  }, [showForm]);
+
+  useEffect(() => {
+    if (!isEditing) {
+      setCurrentFranchise(null);
+      return;
+    }
+
+    setCurrentFranchise(franchiseById.get(String(franchiseId)) || null);
+  }, [isEditing, franchiseId, franchiseById]);
+
+  const handleSave = async (formData) => {
+    try {
+      setLoading(true);
+      setError(null);
+
+      if (isNew) {
+        await createFranchise(formData);
+      } else if (isEditing) {
+        await updateFranchise(franchiseId, formData);
+      }
+
+      const data = await getFranchises();
+      setFranchises(Array.isArray(data) ? data : []);
+      setCurrentFranchise(null);
+      navigate('/admin/franchises', { replace: true });
+    } catch (err) {
+      setError(`Failed to save franchise: ${err.message}`);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleDelete = async (id) => {
+    if (!window.confirm('Are you sure you want to delete this franchise? This cannot be undone.')) {
+      return;
+    }
+
+    try {
+      setLoading(true);
+      setError(null);
+      await deleteFranchise(id);
+      const data = await getFranchises();
+      setFranchises(Array.isArray(data) ? data : []);
+    } catch (err) {
+      setError(`Failed to delete franchise: ${err.message}`);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleImport = async () => {
+    try {
+      setLoading(true);
+      setError(null);
+      setImportResult('');
+
+      const inserted = await importFranchises(importText);
+      const count = inserted.length;
+      setImportResult(count === 0 ? 'No new franchises were added.' : `Added ${count} franchise${count === 1 ? '' : 's'}.`);
+      setImportText('');
+
+      const data = await getFranchises();
+      setFranchises(Array.isArray(data) ? data : []);
+    } catch (err) {
+      setError(`Failed to import franchises: ${err.message}`);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleCancel = () => {
+    setCurrentFranchise(null);
+    navigate('/admin/franchises', { replace: true });
+  };
+
+  if (showForm) {
+    return (
+      <div>
+        <h1 style={{ marginBottom: 'var(--hj-space-4)' }}>{isNew ? 'Create Franchise' : 'Edit Franchise'}</h1>
+        <FranchiseForm
+          franchise={currentFranchise}
+          onSave={handleSave}
+          onCancel={handleCancel}
+          isLoading={loading}
+          error={error}
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <div
+        style={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          marginBottom: 'var(--hj-space-6)',
+        }}
+      >
+        <h1 style={{ margin: 0 }}>Franchises</h1>
+        <button
+          type="button"
+          onClick={() => navigate('/admin/franchises/new')}
+          style={{
+            padding: 'var(--hj-space-2) var(--hj-space-4)',
+            borderRadius: 'var(--hj-radius-md)',
+            backgroundColor: 'var(--hj-color-brand-primary)',
+            color: 'var(--hj-color-inverse-text)',
+            border: 'none',
+            fontWeight: 'var(--hj-font-weight-bold)',
+            cursor: 'pointer',
+          }}
+        >
+          + Add Franchise
+        </button>
+      </div>
+
+      {error && (
+        <div
+          style={{
+            padding: 'var(--hj-space-3)',
+            marginBottom: 'var(--hj-space-4)',
+            backgroundColor: '#fee',
+            color: '#c00',
+            borderRadius: 'var(--hj-radius-md)',
+          }}
+          role="alert"
+        >
+          {error}
+        </div>
+      )}
+
+      {importResult && (
+        <div
+          style={{
+            padding: 'var(--hj-space-3)',
+            marginBottom: 'var(--hj-space-4)',
+            backgroundColor: 'var(--hj-color-surface-2)',
+            color: 'var(--hj-color-text-primary)',
+            borderRadius: 'var(--hj-radius-md)',
+            border: '1px solid var(--hj-color-border-subtle)',
+          }}
+          role="status"
+        >
+          {importResult}
+        </div>
+      )}
+
+      <div
+        style={{
+          padding: 'var(--hj-space-4)',
+          borderRadius: 'var(--hj-radius-md)',
+          border: '1px solid var(--hj-color-border-subtle)',
+          backgroundColor: 'var(--hj-color-surface-2)',
+          marginBottom: 'var(--hj-space-6)',
+        }}
+      >
+        <h2 style={{ marginTop: 0, marginBottom: 'var(--hj-space-3)' }}>Bulk import</h2>
+        <p style={{ marginTop: 0, color: 'var(--hj-color-text-secondary)' }}>
+          Paste one franchise name per line (CSV supported — only the first column is used).
+        </p>
+        <textarea
+          value={importText}
+          onChange={(e) => setImportText(e.target.value)}
+          rows={5}
+          disabled={loading}
+          style={{
+            width: '100%',
+            padding: 'var(--hj-space-2)',
+            borderRadius: 'var(--hj-radius-md)',
+            border: '1px solid var(--hj-color-border)',
+            fontSize: 'var(--hj-font-size-base)',
+            marginBottom: 'var(--hj-space-3)',
+          }}
+          placeholder={'Example:\nAlpha\nBeta\nGamma'}
+        />
+        <button
+          type="button"
+          onClick={handleImport}
+          disabled={loading || !importText.trim()}
+          style={{
+            padding: 'var(--hj-space-2) var(--hj-space-4)',
+            borderRadius: 'var(--hj-radius-md)',
+            backgroundColor: 'var(--hj-color-brand-primary)',
+            color: 'var(--hj-color-inverse-text)',
+            border: 'none',
+            fontWeight: 'var(--hj-font-weight-bold)',
+            cursor: loading || !importText.trim() ? 'not-allowed' : 'pointer',
+            opacity: loading || !importText.trim() ? 0.6 : 1,
+          }}
+        >
+          {loading ? 'Importing…' : 'Import'}
+        </button>
+      </div>
+
+      {loading && <div>Loading franchises…</div>}
+
+      {!loading && franchises.length === 0 && (
+        <div
+          style={{
+            padding: 'var(--hj-space-4)',
+            textAlign: 'center',
+            color: 'var(--hj-color-text-secondary)',
+          }}
+        >
+          No franchises yet. Create one to get started.
+        </div>
+      )}
+
+      {!loading && franchises.length > 0 && (
+        <table
+          style={{
+            width: '100%',
+            borderCollapse: 'collapse',
+            marginTop: 'var(--hj-space-4)',
+          }}
+        >
+          <thead>
+            <tr style={{ borderBottom: '2px solid var(--hj-color-border)' }}>
+              <th
+                style={{
+                  padding: 'var(--hj-space-3)',
+                  textAlign: 'left',
+                  fontWeight: 'var(--hj-font-weight-bold)',
+                }}
+              >
+                Name
+              </th>
+              <th
+                style={{
+                  padding: 'var(--hj-space-3)',
+                  textAlign: 'left',
+                  fontWeight: 'var(--hj-font-weight-bold)',
+                }}
+              >
+                Manager
+              </th>
+              <th
+                style={{
+                  padding: 'var(--hj-space-3)',
+                  textAlign: 'right',
+                  fontWeight: 'var(--hj-font-weight-bold)',
+                }}
+              >
+                Actions
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {franchises.map((franchise) => (
+              <tr
+                key={franchise.id}
+                style={{ borderBottom: '1px solid var(--hj-color-border-subtle)' }}
+              >
+                <td style={{ padding: 'var(--hj-space-3)' }}>{franchise.name}</td>
+                <td style={{ padding: 'var(--hj-space-3)' }}>{franchise.manager_name || '—'}</td>
+                <td
+                  style={{
+                    padding: 'var(--hj-space-3)',
+                    textAlign: 'right',
+                    display: 'flex',
+                    gap: 'var(--hj-space-2)',
+                    justifyContent: 'flex-end',
+                  }}
+                >
+                  <button
+                    type="button"
+                    onClick={() => navigate(`/admin/franchises/${franchise.id}`)}
+                    style={{
+                      padding: 'var(--hj-space-1) var(--hj-space-3)',
+                      borderRadius: 'var(--hj-radius-sm)',
+                      backgroundColor: 'var(--hj-color-brand-primary)',
+                      color: 'var(--hj-color-inverse-text)',
+                      border: 'none',
+                      cursor: 'pointer',
+                      fontSize: 'var(--hj-font-size-sm)',
+                    }}
+                  >
+                    Edit
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => handleDelete(franchise.id)}
+                    style={{
+                      padding: 'var(--hj-space-1) var(--hj-space-3)',
+                      borderRadius: 'var(--hj-radius-sm)',
+                      backgroundColor: '#fee',
+                      color: '#c00',
+                      border: '1px solid #fcc',
+                      cursor: 'pointer',
+                      fontSize: 'var(--hj-font-size-sm)',
+                    }}
+                  >
+                    Delete
+                  </button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </div>
+  );
+}

--- a/src/views/admin/FranchisesPage.test.jsx
+++ b/src/views/admin/FranchisesPage.test.jsx
@@ -1,0 +1,115 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import FranchisesPage from './FranchisesPage';
+import * as franchiseApi from '../../lib/franchiseApi';
+
+vi.mock('../../lib/franchiseApi');
+
+// Mock FranchiseForm so we can drive save/cancel deterministically
+vi.mock('./FranchiseForm', () => ({
+  default: ({ onSave, onCancel, error }) => (
+    <div>
+      {error ? <div role="alert">{error}</div> : null}
+      <button type="button" onClick={() => onSave({ name: 'Test Franchise' })}>
+        Save
+      </button>
+      <button type="button" onClick={onCancel}>
+        Cancel
+      </button>
+    </div>
+  ),
+}));
+
+const renderPage = (route = '/admin/franchises') => {
+  window.history.pushState({}, 'Test page', route);
+  return render(
+    <BrowserRouter>
+      <Routes>
+        <Route path="/admin/franchises" element={<FranchisesPage />} />
+        <Route path="/admin/franchises/:franchiseId" element={<FranchisesPage />} />
+      </Routes>
+    </BrowserRouter>
+  );
+};
+
+describe('FranchisesPage', () => {
+  const mockFranchises = [
+    { id: 'f1', name: 'Alpha', manager_name: 'Coach A' },
+    { id: 'f2', name: 'Beta', manager_name: '' },
+  ];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('renders list on load', async () => {
+    franchiseApi.getFranchises.mockResolvedValue(mockFranchises);
+
+    renderPage('/admin/franchises');
+
+    expect(await screen.findByText('Franchises')).toBeInTheDocument();
+    expect(await screen.findByText('Alpha')).toBeInTheDocument();
+    expect(screen.getByText('Coach A')).toBeInTheDocument();
+  });
+
+  it('shows empty state when no franchises', async () => {
+    franchiseApi.getFranchises.mockResolvedValue([]);
+
+    renderPage('/admin/franchises');
+
+    expect(await screen.findByText(/No franchises yet/)).toBeInTheDocument();
+  });
+
+  it('imports franchises and refreshes list', async () => {
+    franchiseApi.getFranchises.mockResolvedValueOnce([]);
+    franchiseApi.importFranchises.mockResolvedValue([{ id: 'f1', name: 'Alpha' }]);
+    franchiseApi.getFranchises.mockResolvedValueOnce([{ id: 'f1', name: 'Alpha' }]);
+
+    renderPage('/admin/franchises');
+
+    const textarea = await screen.findByPlaceholderText(/Example:/);
+    fireEvent.change(textarea, { target: { value: 'Alpha' } });
+    fireEvent.click(screen.getByText('Import'));
+
+    await waitFor(() => {
+      expect(franchiseApi.importFranchises).toHaveBeenCalledWith('Alpha');
+      expect(franchiseApi.getFranchises).toHaveBeenCalledTimes(2);
+    });
+
+    expect(await screen.findByText(/Added 1 franchise/)).toBeInTheDocument();
+  });
+
+  it('creates a franchise then returns to list view', async () => {
+    franchiseApi.createFranchise.mockResolvedValue({ id: 'f3' });
+    franchiseApi.getFranchises.mockResolvedValue([{ id: 'f3', name: 'Test Franchise' }]);
+
+    renderPage('/admin/franchises/new');
+
+    expect(await screen.findByText('Create Franchise')).toBeInTheDocument();
+    fireEvent.click(screen.getByText('Save'));
+
+    await waitFor(() => {
+      expect(franchiseApi.createFranchise).toHaveBeenCalledWith({ name: 'Test Franchise' });
+    });
+
+    expect(await screen.findByText('Franchises')).toBeInTheDocument();
+  });
+
+  it('shows error when create fails', async () => {
+    franchiseApi.createFranchise.mockRejectedValue(new Error('Create failed'));
+
+    renderPage('/admin/franchises/new');
+
+    expect(await screen.findByText('Create Franchise')).toBeInTheDocument();
+    fireEvent.click(screen.getByText('Save'));
+
+    expect(await screen.findByText(/Failed to save franchise: Create failed/)).toBeInTheDocument();
+  });
+});

--- a/src/views/admin/FranchisesPage.test.jsx
+++ b/src/views/admin/FranchisesPage.test.jsx
@@ -112,4 +112,36 @@ describe('FranchisesPage', () => {
 
     expect(await screen.findByText(/Failed to save franchise: Create failed/)).toBeInTheDocument();
   });
+
+  it('updates a franchise then returns to list view', async () => {
+    franchiseApi.updateFranchise.mockResolvedValue({ id: 'f1' });
+    franchiseApi.getFranchises.mockResolvedValueOnce(mockFranchises);
+    franchiseApi.getFranchises.mockResolvedValueOnce([{ id: 'f1', name: 'Test Franchise' }]);
+
+    renderPage('/admin/franchises/f1');
+
+    expect(await screen.findByText('Edit Franchise')).toBeInTheDocument();
+    fireEvent.click(screen.getByText('Save'));
+
+    await waitFor(() => {
+      expect(franchiseApi.updateFranchise).toHaveBeenCalledWith('f1', { name: 'Test Franchise' });
+    });
+
+    expect(await screen.findByText('Franchises')).toBeInTheDocument();
+  });
+
+  it('delete confirmation cancel does not delete', async () => {
+    franchiseApi.getFranchises.mockResolvedValue(mockFranchises);
+    franchiseApi.deleteFranchise.mockResolvedValue();
+
+    vi.stubGlobal('confirm', vi.fn(() => false));
+
+    renderPage('/admin/franchises');
+
+    expect(await screen.findByText('Alpha')).toBeInTheDocument();
+    const deleteButtons = screen.getAllByText('Delete');
+    fireEvent.click(deleteButtons[0]);
+
+    expect(franchiseApi.deleteFranchise).not.toHaveBeenCalled();
+  });
 });

--- a/src/views/admin/TournamentWizard.jsx
+++ b/src/views/admin/TournamentWizard.jsx
@@ -1,6 +1,7 @@
 import React, { useMemo, useRef, useState } from "react";
 import PropTypes from "prop-types";
-import { getFranchises } from "../../lib/api";
+// NOTE: franchises now come from the admin franchise directory (global)
+// import { getFranchises } from "../../lib/api";
 import { adminFetch } from "../../lib/adminAuth";
 import { parseFranchiseName, normalizeTeamName } from "../../lib/franchise";
 import { computeFormErrors } from "./tournamentWizardUtils";
@@ -644,9 +645,11 @@ export default function TournamentWizard() {
     let alive = true;
     (async () => {
       try {
-        const rows = await getFranchises(tournament.id || tournamentIdHint || undefined);
+        const res = await adminFetch("/admin/franchises");
+        if (!res.ok) throw new Error("Failed to load franchises");
+        const json = await res.json();
         if (!alive) return;
-        const names = rows.map((r) => r.Name || r.name).filter(Boolean);
+        const names = (json?.data || []).map((f) => f.name).filter(Boolean);
         setApiFranchiseNames(names);
       } catch (err) {
         console.warn("Failed to load franchises", err);
@@ -655,7 +658,7 @@ export default function TournamentWizard() {
     return () => {
       alive = false;
     };
-  }, [tournament.id, tournamentIdHint]);
+  }, []);
 
   return (
     <div className="wizard-page">

--- a/src/views/admin/TournamentWizard.test.jsx
+++ b/src/views/admin/TournamentWizard.test.jsx
@@ -368,11 +368,11 @@ describe("TournamentWizard", () => {
           json: () => Promise.resolve({ ok: true, data: [] }),
         });
       }
-      if (typeof url === "string" && url.includes("sheet=Franchises")) {
+      if (typeof url === "string" && url.includes("/admin/franchises")) {
         return Promise.resolve({
           ok: true,
           json: () =>
-            Promise.resolve({ ok: true, rows: [{ Name: "Gryphons" }, { Name: "Dragons" }] }),
+            Promise.resolve({ ok: true, data: [{ id: "f1", name: "Gryphons" }, { id: "f2", name: "Dragons" }] }),
         });
       }
       return Promise.resolve({ ok: true, json: () => Promise.resolve({ ok: true }) });
@@ -397,10 +397,10 @@ describe("TournamentWizard", () => {
           json: () => Promise.resolve({ ok: true, data: [] }),
         });
       }
-      if (typeof url === "string" && url.includes("sheet=Franchises")) {
+      if (typeof url === "string" && url.includes("/admin/franchises")) {
         return Promise.resolve({
           ok: true,
-          json: () => Promise.resolve({ ok: true, rows: [{ Name: "Gryphons" }] }),
+          json: () => Promise.resolve({ ok: true, data: [{ id: "f1", name: "Gryphons" }] }),
         });
       }
       return Promise.resolve({ ok: true, json: () => Promise.resolve({ ok: true }) });
@@ -436,7 +436,7 @@ describe("TournamentWizard", () => {
           json: () => Promise.resolve({ ok: true, data: [] }),
         });
       }
-      if (typeof url === "string" && url.includes("sheet=Franchises")) {
+      if (typeof url === "string" && url.includes("/admin/franchises")) {
         return Promise.reject(new Error("Network error"));
       }
       return Promise.resolve({ ok: true, json: () => Promise.resolve({ ok: true }) });

--- a/test/server/admin.test.js
+++ b/test/server/admin.test.js
@@ -508,6 +508,99 @@ describe('handleAdminRequest', () => {
         );
     });
 
+    it('GET /franchises returns list', async () => {
+        const url = new URL('http://localhost/api/admin/franchises');
+        mockPool.query.mockResolvedValueOnce({ rows: [{ id: 'f1', name: 'Alpha' }] });
+
+        await handleAdminRequest(mockReq, mockRes, { url, pool: mockPool, sendJson: mockSendJson });
+
+        expect(mockSendJson).toHaveBeenCalledWith(
+            mockReq,
+            mockRes,
+            200,
+            expect.objectContaining({ ok: true, data: [{ id: 'f1', name: 'Alpha' }] })
+        );
+    });
+
+    it('POST /franchises creates franchise', async () => {
+        const url = new URL('http://localhost/api/admin/franchises');
+        mockReq.method = 'POST';
+        mockReq.on = vi.fn((event, cb) => {
+            if (event === 'data') cb(Buffer.from(JSON.stringify({ name: 'alpha' })));
+            if (event === 'end') cb();
+        });
+
+        mockPool.query.mockResolvedValueOnce({ rows: [{ id: 'f1', name: 'Alpha' }] });
+
+        await handleAdminRequest(mockReq, mockRes, { url, pool: mockPool, sendJson: mockSendJson, caches: { actorEmail: 'test@example.com' } });
+
+        expect(mockSendJson).toHaveBeenCalledWith(
+            mockReq,
+            mockRes,
+            201,
+            expect.objectContaining({ ok: true, data: expect.objectContaining({ id: 'f1', name: 'Alpha' }) })
+        );
+    });
+
+    it('PATCH /franchises/:id updates franchise', async () => {
+        const url = new URL('http://localhost/api/admin/franchises/f1');
+        mockReq.method = 'PATCH';
+        mockReq.on = vi.fn((event, cb) => {
+            if (event === 'data') cb(Buffer.from(JSON.stringify({ name: 'Alpha Updated' })));
+            if (event === 'end') cb();
+        });
+
+        mockPool.query.mockResolvedValueOnce({ rows: [{ id: 'f1', name: 'Alpha Updated' }], rowCount: 1 });
+
+        await handleAdminRequest(mockReq, mockRes, { url, pool: mockPool, sendJson: mockSendJson, caches: { actorEmail: 'test@example.com' } });
+
+        expect(mockSendJson).toHaveBeenCalledWith(
+            mockReq,
+            mockRes,
+            200,
+            expect.objectContaining({ ok: true, data: expect.objectContaining({ id: 'f1', name: 'Alpha Updated' }) })
+        );
+    });
+
+    it('DELETE /franchises/:id deletes franchise', async () => {
+        const url = new URL('http://localhost/api/admin/franchises/f1');
+        mockReq.method = 'DELETE';
+        mockPool.query
+            .mockResolvedValueOnce({ rows: [{ id: 'f1', name: 'Alpha' }], rowCount: 1 })
+            .mockResolvedValueOnce({ rowCount: 1 });
+
+        await handleAdminRequest(mockReq, mockRes, { url, pool: mockPool, sendJson: mockSendJson, caches: { actorEmail: 'test@example.com' } });
+
+        expect(mockSendJson).toHaveBeenCalledWith(
+            mockReq,
+            mockRes,
+            200,
+            expect.objectContaining({ ok: true })
+        );
+    });
+
+    it('POST /franchises/import inserts franchises', async () => {
+        const url = new URL('http://localhost/api/admin/franchises/import');
+        mockReq.method = 'POST';
+        mockReq.on = vi.fn((event, cb) => {
+            if (event === 'data') cb(Buffer.from(JSON.stringify({ names: 'Alpha\nBeta' })));
+            if (event === 'end') cb();
+        });
+
+        mockPool.query
+            .mockResolvedValueOnce({ rows: [{ id: 'f1', name: 'Alpha' }], rowCount: 1 })
+            .mockResolvedValueOnce({ rows: [], rowCount: 0 });
+
+        await handleAdminRequest(mockReq, mockRes, { url, pool: mockPool, sendJson: mockSendJson, caches: { actorEmail: 'test@example.com' } });
+
+        expect(mockSendJson).toHaveBeenCalledWith(
+            mockReq,
+            mockRes,
+            201,
+            expect.objectContaining({ ok: true, data: [expect.objectContaining({ id: 'f1', name: 'Alpha' })] })
+        );
+    });
+
     it('GET /fixtures returns 400 when missing tournamentId', async () => {
         const url = new URL('http://localhost/api/admin/fixtures?groupId=U11B');
         await handleAdminRequest(mockReq, mockRes, { url, pool: mockPool, sendJson: mockSendJson });

--- a/test/server/admin.test.js
+++ b/test/server/admin.test.js
@@ -601,6 +601,119 @@ describe('handleAdminRequest', () => {
         );
     });
 
+    it('GET /franchises returns 501 when DB is not configured', async () => {
+        const url = new URL('http://localhost/api/admin/franchises');
+
+        await handleAdminRequest(mockReq, mockRes, { url, pool: null, sendJson: mockSendJson });
+
+        expect(mockSendJson).toHaveBeenCalledWith(
+            mockReq,
+            mockRes,
+            501,
+            expect.objectContaining({ ok: false, error: expect.stringContaining('DB not configured') })
+        );
+    });
+
+    it('PUT /franchises returns 405', async () => {
+        const url = new URL('http://localhost/api/admin/franchises');
+        mockReq.method = 'PUT';
+
+        await handleAdminRequest(mockReq, mockRes, { url, pool: mockPool, sendJson: mockSendJson });
+
+        expect(mockSendJson).toHaveBeenCalledWith(
+            mockReq,
+            mockRes,
+            405,
+            expect.objectContaining({ ok: false, error: expect.stringContaining('Method not allowed') })
+        );
+    });
+
+    it('POST /franchises returns 400 when name missing', async () => {
+        const url = new URL('http://localhost/api/admin/franchises');
+        mockReq.method = 'POST';
+        mockReq.on = vi.fn((event, cb) => {
+            if (event === 'data') cb(Buffer.from(JSON.stringify({})));
+            if (event === 'end') cb();
+        });
+
+        await handleAdminRequest(mockReq, mockRes, { url, pool: mockPool, sendJson: mockSendJson });
+
+        expect(mockSendJson).toHaveBeenCalledWith(
+            mockReq,
+            mockRes,
+            400,
+            expect.objectContaining({ ok: false, error: expect.stringContaining('name is required') })
+        );
+    });
+
+    it('PATCH /franchises/:id returns 404 when not found', async () => {
+        const url = new URL('http://localhost/api/admin/franchises/missing');
+        mockReq.method = 'PATCH';
+        mockReq.on = vi.fn((event, cb) => {
+            if (event === 'data') cb(Buffer.from(JSON.stringify({ name: 'Alpha' })));
+            if (event === 'end') cb();
+        });
+
+        mockPool.query.mockResolvedValueOnce({ rows: [], rowCount: 0 });
+
+        await handleAdminRequest(mockReq, mockRes, { url, pool: mockPool, sendJson: mockSendJson });
+
+        expect(mockSendJson).toHaveBeenCalledWith(
+            mockReq,
+            mockRes,
+            404,
+            expect.objectContaining({ ok: false, error: expect.stringContaining('Franchise not found') })
+        );
+    });
+
+    it('DELETE /franchises/:id returns 404 when not found', async () => {
+        const url = new URL('http://localhost/api/admin/franchises/missing');
+        mockReq.method = 'DELETE';
+
+        mockPool.query.mockResolvedValueOnce({ rows: [], rowCount: 0 });
+
+        await handleAdminRequest(mockReq, mockRes, { url, pool: mockPool, sendJson: mockSendJson });
+
+        expect(mockSendJson).toHaveBeenCalledWith(
+            mockReq,
+            mockRes,
+            404,
+            expect.objectContaining({ ok: false, error: expect.stringContaining('Franchise not found') })
+        );
+    });
+
+    it('POST /franchises/import returns 400 when no names provided', async () => {
+        const url = new URL('http://localhost/api/admin/franchises/import');
+        mockReq.method = 'POST';
+        mockReq.on = vi.fn((event, cb) => {
+            if (event === 'data') cb(Buffer.from(JSON.stringify({ names: '' })));
+            if (event === 'end') cb();
+        });
+
+        await handleAdminRequest(mockReq, mockRes, { url, pool: mockPool, sendJson: mockSendJson });
+
+        expect(mockSendJson).toHaveBeenCalledWith(
+            mockReq,
+            mockRes,
+            400,
+            expect.objectContaining({ ok: false })
+        );
+    });
+
+    it('GET /franchises returns 500 on DB error', async () => {
+        const url = new URL('http://localhost/api/admin/franchises');
+        mockPool.query.mockRejectedValueOnce(new Error('DB down'));
+
+        await handleAdminRequest(mockReq, mockRes, { url, pool: mockPool, sendJson: mockSendJson });
+
+        expect(mockSendJson).toHaveBeenCalledWith(
+            mockReq,
+            mockRes,
+            500,
+            expect.objectContaining({ ok: false })
+        );
+    });
+
     it('GET /fixtures returns 400 when missing tournamentId', async () => {
         const url = new URL('http://localhost/api/admin/fixtures?groupId=U11B');
         await handleAdminRequest(mockReq, mockRes, { url, pool: mockPool, sendJson: mockSendJson });


### PR DESCRIPTION
Closes #210

## What changed
- Added global franchise_directory table + RLS enablement migration.
- Added admin API CRUD + import endpoints for franchises.
- Added admin UI page + form for managing franchises, plus tests.
- Tournament Wizard now sources franchise options from the admin franchise directory (global).

## How to test
- npm test
- In Admin Console: open **Franchises**, add/edit/delete, and bulk-import names.
- In Tournament Wizard: confirm franchise datalist suggestions include the managed franchises.

## Risk
- Medium (new DB table + admin endpoints + UI), but scoped to admin-only features.