### PR TITLE
Phase 4: Simplify Tournament Wizard

### DIFF
--- a/src/views/admin/TournamentWizard.jsx
+++ b/src/views/admin/TournamentWizard.jsx
@@ -6,7 +6,7 @@ import { adminFetch } from "../../lib/adminAuth";
 import { parseFranchiseName, normalizeTeamName } from "../../lib/franchise";
 import { computeFormErrors } from "./tournamentWizardUtils";
 
-const STEP_LABELS = ["Tournament", "Groups", "Teams", "Fixtures"];
+const STEP_LABELS = ["Tournament", "Groups & Pools", "Teams & Fixtures"];
 
 function normalizeId(value) {
   return String(value || "")
@@ -182,23 +182,7 @@ export default function TournamentWizard() {
     name: "",
     season: "",
   });
-  const [venues, setVenues] = useState(() => [
-    { _key: makeKey("venue"), name: "", isNew: false },
-  ]);
   const [groups, setGroups] = useState(() => [emptyGroup(makeKey("group"))]);
-  const [franchises, setFranchises] = useState([
-    {
-      _key: makeKey("franchise"),
-      name: "",
-      logo_url: "",
-      manager_name: "",
-      manager_photo_url: "",
-      description: "",
-      contact_phone: "",
-      location_map_url: "",
-      contact_email: "",
-    },
-  ]);
   const [teams, setTeams] = useState(() => [emptyTeam(makeKey("team"))]);
   const [fixtures, setFixtures] = useState(() => [emptyFixture(makeKey("fixture"))]);
   const [timeSlots, setTimeSlots] = useState([
@@ -214,7 +198,6 @@ export default function TournamentWizard() {
     roundPrefix: "Round",
   });
   const [generatorErrors, setGeneratorErrors] = useState({});
-  const [franchiseImport, setFranchiseImport] = useState("");
   const [teamImport, setTeamImport] = useState("");
 
   const formErrors = useMemo(
@@ -246,13 +229,8 @@ export default function TournamentWizard() {
   }, [groups]);
 
   const allVenueOptions = useMemo(() => {
-    const list = [
-      ...venueOptions,
-      ...venues.filter((v) => v.isNew && v.name).map((v) => v.name),
-    ];
-    return Array.from(new Set(list.map((v) => v.trim()).filter(Boolean)));
-  }, [venueOptions, venues]);
-
+    return Array.from(new Set(venueOptions.map((v) => String(v).trim()).filter(Boolean)));
+  }, [venueOptions]);
 
   const teamOptionsByGroup = useMemo(() => {
     const map = new Map();
@@ -266,40 +244,15 @@ export default function TournamentWizard() {
   }, [teams]);
 
   const franchiseOptions = useMemo(() => {
-    const fromForm = franchises.map((f) => f.name).filter(Boolean);
-    const merged = [...apiFranchiseNames, ...fromForm];
-    return Array.from(new Set(merged.map((n) => n.trim()).filter(Boolean))).sort((a, b) =>
-      a.localeCompare(b)
+    return Array.from(new Set(apiFranchiseNames.map((n) => String(n).trim()).filter(Boolean))).sort(
+      (a, b) => a.localeCompare(b)
     );
-  }, [apiFranchiseNames, franchises]);
+  }, [apiFranchiseNames]);
 
   function updateTournament(next) {
     setTournament((prev) => ({ ...prev, ...next }));
   }
 
-  function handleVenueChange(index, value) {
-    setVenues((prev) => {
-      const next = [...prev];
-      next[index] = { ...next[index], name: value };
-      return next;
-    });
-  }
-
-  function addVenue() {
-    setVenues((prev) => [...prev, { _key: makeKey("venue"), name: "", isNew: false }]);
-  }
-
-  function removeVenue(index) {
-    setVenues((prev) => prev.filter((_, idx) => idx !== index));
-  }
-
-  function setVenueMode(index, isNew) {
-    setVenues((prev) => {
-      const next = [...prev];
-      next[index] = { ...next[index], isNew, name: "" };
-      return next;
-    });
-  }
 
   function updateGroup(index, patch) {
     setGroups((prev) => {
@@ -317,49 +270,12 @@ export default function TournamentWizard() {
     setGroups((prev) => prev.filter((_, idx) => idx !== index));
   }
 
-  function toggleGroupVenue(index, venueName) {
+  function setGroupVenues(index, nextVenues) {
     setGroups((prev) => {
       const next = [...prev];
-      const group = { ...next[index] };
-      const venuesList = new Set(group.venues || []);
-      if (venuesList.has(venueName)) {
-        venuesList.delete(venueName);
-      } else {
-        venuesList.add(venueName);
-      }
-      group.venues = Array.from(venuesList);
-      next[index] = group;
+      next[index] = { ...next[index], venues: nextVenues };
       return next;
     });
-  }
-
-  function updateFranchise(index, patch) {
-    setFranchises((prev) => {
-      const next = [...prev];
-      next[index] = { ...next[index], ...patch };
-      return next;
-    });
-  }
-
-  function addFranchise() {
-    setFranchises((prev) => [
-      ...prev,
-      {
-        _key: makeKey("franchise"),
-        name: "",
-        logo_url: "",
-        manager_name: "",
-        manager_photo_url: "",
-        description: "",
-        contact_phone: "",
-        location_map_url: "",
-        contact_email: "",
-      },
-    ]);
-  }
-
-  function removeFranchise(index) {
-    setFranchises((prev) => prev.filter((_, idx) => idx !== index));
   }
 
   function updateTeam(index, patch) {
@@ -411,22 +327,6 @@ export default function TournamentWizard() {
     setTimeSlots((prev) => prev.filter((_, idx) => idx !== index));
   }
 
-  function applyFranchiseImport() {
-    const entries = parseLines(franchiseImport).map((name) => ({
-      _key: makeKey("franchise"),
-      name,
-      logo_url: "",
-      manager_name: "",
-      manager_photo_url: "",
-      description: "",
-      contact_phone: "",
-      location_map_url: "",
-      contact_email: "",
-    }));
-    if (!entries.length) return;
-    setFranchises((prev) => [...prev, ...entries]);
-    setFranchiseImport("");
-  }
 
   function applyTeamImport() {
     const lines = parseLines(teamImport);
@@ -546,9 +446,7 @@ export default function TournamentWizard() {
           name: tournament.name,
           season: tournament.season,
         },
-        venues: venues
-          .filter((v) => v.name?.trim())
-          .map((v) => ({ name: v.name.trim() })),
+
         groups: groups
           .filter((g) => g.id?.trim() && g.label?.trim())
           .map((g) => ({
@@ -562,18 +460,7 @@ export default function TournamentWizard() {
             venue_name: venueName,
           }))
         ),
-        franchises: franchises
-          .filter((f) => f.name?.trim())
-          .map((f) => ({
-            name: f.name,
-            logo_url: f.logo_url,
-            manager_name: f.manager_name,
-            manager_photo_url: f.manager_photo_url,
-            description: f.description,
-            contact_phone: f.contact_phone,
-            location_map_url: f.location_map_url,
-            contact_email: f.contact_email,
-          })),
+
         teams: teams
           .filter((t) => t.name?.trim() && t.group_id)
           .map((t) => ({
@@ -728,57 +615,7 @@ export default function TournamentWizard() {
             </Field>
           </SectionCard>
 
-          <SectionCard
-            title="Venues"
-            actions={<button type="button" onClick={addVenue}>Add Venue</button>}
-          >
-            {venues.map((venue, idx) => {
-              const venueHasName = Boolean(venue.name?.trim());
-              const venueIsNew = venue.isNew;
-              return (
-                <div className="wizard-row" key={venue._key}>
-                  <Field label="Venue">
-                    {venueIsNew ? (
-                      <input
-                        type="text"
-                        value={venue.name}
-                        className={venueHasName ? "wizard-input" : "wizard-input invalid"}
-                        onChange={(e) => handleVenueChange(idx, e.target.value)}
-                        placeholder="New venue name"
-                      />
-                    ) : (
-                      <select
-                        value={venue.name}
-                        className={venueHasName ? "wizard-input" : "wizard-input invalid"}
-                        onChange={(e) => handleVenueChange(idx, e.target.value)}
-                      >
-                        <option value="">Select venue</option>
-                        {venueOptions.map((name) => (
-                          <option key={`venue-opt-${name}`} value={name}>
-                            {name}
-                          </option>
-                        ))}
-                      </select>
-                    )}
-                    {venueHasName ? null : (
-                      <span className="wizard-field-error">
-                        {venueIsNew ? "Required" : "Select a venue"}
-                      </span>
-                    )}
-                  </Field>
-                  <div className="wizard-inline">
-                    <button
-                      type="button"
-                      onClick={() => setVenueMode(idx, venueIsNew ? false : true)}
-                    >
-                      {venueIsNew ? "Choose Existing" : "Add New"}
-                    </button>
-                  </div>
-                  <button type="button" onClick={() => removeVenue(idx)}>Remove</button>
-                </div>
-              );
-            })}
-          </SectionCard>
+
         </div>
       )}
 
@@ -830,22 +667,29 @@ export default function TournamentWizard() {
                 </Field>
               </div>
               <div className="wizard-choices">
-                <span className="wizard-field-label">Venues</span>
-                <div className="wizard-choice-list">
-                  {allVenueOptions.length === 0 && (
-                    <span className="wizard-choice-empty">Add venues in Step 1.</span>
-                  )}
-                  {allVenueOptions.map((venueName) => (
-                    <label key={`${group.id}-${venueName}`} className="wizard-choice">
-                      <input
-                        type="checkbox"
-                        checked={(group.venues || []).includes(venueName)}
-                        onChange={() => toggleGroupVenue(idx, venueName)}
-                      />
-                      <span>{venueName}</span>
-                    </label>
-                  ))}
-                </div>
+                <span className="wizard-field-label">Group Venues</span>
+                {allVenueOptions.length === 0 ? (
+                  <span className="wizard-choice-empty">No venues available. Add them in Admin → Venues.</span>
+                ) : (
+                  <select
+                    multiple
+                    aria-label="Group Venues"
+                    className="wizard-input"
+                    value={group.venues || []}
+                    onChange={(e) =>
+                      setGroupVenues(
+                        idx,
+                        Array.from(e.target.selectedOptions).map((opt) => opt.value)
+                      )
+                    }
+                  >
+                    {allVenueOptions.map((venueName) => (
+                      <option key={`${group.id}-${venueName}`} value={venueName}>
+                        {venueName}
+                      </option>
+                    ))}
+                  </select>
+                )}
               </div>
               <button type="button" onClick={() => removeGroup(idx)}>Remove Group</button>
             </div>
@@ -855,114 +699,6 @@ export default function TournamentWizard() {
 
       {step === 2 && (
         <div className="wizard-grid">
-          <SectionCard
-            title="Franchises"
-            actions={<button type="button" onClick={addFranchise}>Add Franchise</button>}
-          >
-            <div className="wizard-block">
-              <Field label="Bulk Import (one franchise per line)">
-                <textarea
-                  rows={3}
-                  value={franchiseImport}
-                  className="wizard-input"
-                  onChange={(e) => setFranchiseImport(e.target.value)}
-                  placeholder="Purple Panthers\nBlue Cranes\nBlack Hawks"
-                />
-              </Field>
-              <button type="button" onClick={applyFranchiseImport}>Import Franchises</button>
-            </div>
-            {franchises.map((franchise, idx) => {
-              const franchiseHasName = Boolean(franchise.name?.trim());
-              return (
-              <div className="wizard-block" key={franchise._key}>
-                <div className="wizard-row">
-                  <Field label="Name">
-                  <input
-                    type="text"
-                    value={franchise.name}
-                    className={franchiseHasName ? "wizard-input" : "wizard-input invalid"}
-                    onChange={(e) => updateFranchise(idx, { name: e.target.value })}
-                    placeholder="Purple Panthers"
-                  />
-                </Field>
-                <Field label="Logo URL">
-                  <input
-                    type="text"
-                    value={franchise.logo_url}
-                    className="wizard-input"
-                    onChange={(e) => updateFranchise(idx, { logo_url: e.target.value })}
-                    placeholder="https://..."
-                  />
-                </Field>
-                </div>
-                <div className="wizard-row">
-                  <Field label="Manager Name">
-                  <input
-                    type="text"
-                    value={franchise.manager_name}
-                    className="wizard-input"
-                    onChange={(e) => updateFranchise(idx, { manager_name: e.target.value })}
-                    placeholder="Manager name"
-                  />
-                </Field>
-                  <Field label="Manager Photo URL">
-                  <input
-                    type="text"
-                    value={franchise.manager_photo_url}
-                    className="wizard-input"
-                    onChange={(e) =>
-                      updateFranchise(idx, { manager_photo_url: e.target.value })
-                    }
-                    placeholder="https://..."
-                  />
-                </Field>
-                </div>
-                <div className="wizard-row">
-                  <Field label="Contact Phone">
-                  <input
-                    type="text"
-                    value={franchise.contact_phone}
-                    className="wizard-input"
-                    onChange={(e) => updateFranchise(idx, { contact_phone: e.target.value })}
-                    placeholder="+27..."
-                  />
-                </Field>
-                  <Field label="Contact Email">
-                  <input
-                    type="text"
-                    value={franchise.contact_email}
-                    className="wizard-input"
-                    onChange={(e) => updateFranchise(idx, { contact_email: e.target.value })}
-                    placeholder="name@example.com"
-                  />
-                </Field>
-                </div>
-                <Field label="Location Map URL">
-                  <input
-                    type="text"
-                    value={franchise.location_map_url}
-                    className="wizard-input"
-                    onChange={(e) =>
-                      updateFranchise(idx, { location_map_url: e.target.value })
-                    }
-                    placeholder="https://maps.google.com/..."
-                  />
-                </Field>
-                <Field label="Description">
-                  <textarea
-                    rows={3}
-                    value={franchise.description}
-                    className="wizard-input"
-                    onChange={(e) => updateFranchise(idx, { description: e.target.value })}
-                    placeholder="Franchise description"
-                  />
-                </Field>
-                <button type="button" onClick={() => removeFranchise(idx)}>Remove Franchise</button>
-              </div>
-            );
-            })}
-          </SectionCard>
-
           <SectionCard
             title="Teams"
             actions={<button type="button" onClick={addTeam}>Add Team</button>}
@@ -986,7 +722,7 @@ export default function TournamentWizard() {
               return (
               <div className="wizard-block" key={team._key}>
                 <div className="wizard-row">
-                  <Field label="Group">
+                  <Field label="Team Group">
                     <select
                     value={team.group_id}
                     className={teamHasGroup ? "wizard-input" : "wizard-input invalid"}
@@ -1066,14 +802,14 @@ export default function TournamentWizard() {
         </div>
       )}
 
-      {step === 3 && (
+      {step === 2 && (
         <SectionCard
           title="Fixtures"
           actions={<button type="button" onClick={addFixture}>Add Fixture</button>}
         >
           <div className="wizard-block">
             <div className="wizard-row">
-              <Field label="Group" error={generatorErrors.groupId}>
+              <Field label="Generator Group" error={generatorErrors.groupId}>
                 <select
                   value={generator.groupId}
                   className={generatorErrors.groupId ? "wizard-input invalid" : "wizard-input"}
@@ -1226,7 +962,7 @@ export default function TournamentWizard() {
             return (
             <div className="wizard-block" key={fixture._key}>
               <div className="wizard-row">
-                <Field label="Group">
+                <Field label="Fixture Group">
                   <select
                     value={fixture.group_id}
                     className={fixtureHasGroup ? "wizard-input" : "wizard-input invalid"}

--- a/src/views/admin/TournamentWizard.test.jsx
+++ b/src/views/admin/TournamentWizard.test.jsx
@@ -44,13 +44,12 @@ describe("TournamentWizard", () => {
     await renderWizard();
 
     expect(screen.getByText("Tournament Setup Wizard")).toBeDefined();
-    fireEvent.click(screen.getByRole("button", { name: /Groups/i }));
+
+    fireEvent.click(screen.getByRole("button", { name: /Groups & Pools/i }));
     expect(screen.getByRole("heading", { name: "Groups" })).toBeDefined();
 
-    fireEvent.click(screen.getByRole("button", { name: /Teams/i }));
+    fireEvent.click(screen.getByRole("button", { name: /Teams & Fixtures/i }));
     expect(screen.getByRole("heading", { name: "Teams" })).toBeDefined();
-
-    fireEvent.click(screen.getByRole("button", { name: /Fixtures/i }));
     expect(screen.getByRole("heading", { name: "Fixtures" })).toBeDefined();
   });
 
@@ -64,7 +63,7 @@ describe("TournamentWizard", () => {
       target: { value: "2026" },
     });
 
-    fireEvent.click(screen.getByRole("button", { name: /Groups/i }));
+    fireEvent.click(screen.getByRole("button", { name: /Groups & Pools/i }));
     fireEvent.change(screen.getByPlaceholderText("U11B"), {
       target: { value: "U11B" },
     });
@@ -72,14 +71,19 @@ describe("TournamentWizard", () => {
       target: { value: "U11 Boys" },
     });
 
-    fireEvent.click(screen.getByRole("button", { name: /Teams/i }));
-    fireEvent.change(screen.getByRole("combobox", { name: "Group" }), {
+    fireEvent.click(screen.getByRole("button", { name: /Teams & Fixtures/i }));
+
+    const teamsSection = screen.getByRole("heading", { name: "Teams" }).closest("section");
+    if (!teamsSection) throw new Error("Teams section not found");
+    const teamsScope = within(teamsSection);
+
+    fireEvent.change(teamsScope.getByRole("combobox", { name: "Team Group" }), {
       target: { value: "U11B" },
     });
-    fireEvent.change(screen.getByPlaceholderText("PP Amber"), {
+    fireEvent.change(teamsScope.getByPlaceholderText("PP Amber"), {
       target: { value: "PP Amber" },
     });
-    fireEvent.change(screen.getByRole("combobox", { name: "Pool" }), {
+    fireEvent.change(teamsScope.getByRole("combobox", { name: "Pool" }), {
       target: { value: "A" },
     });
 
@@ -101,7 +105,7 @@ describe("TournamentWizard", () => {
   it("generates fixtures for a group", async () => {
     await renderWizard();
 
-    fireEvent.click(screen.getByRole("button", { name: /Groups/i }));
+    fireEvent.click(screen.getByRole("button", { name: /Groups & Pools/i }));
     fireEvent.change(screen.getByPlaceholderText("U11B"), {
       target: { value: "U11B" },
     });
@@ -109,35 +113,45 @@ describe("TournamentWizard", () => {
       target: { value: "U11 Boys" },
     });
 
-    fireEvent.click(screen.getByRole("button", { name: /Teams/i }));
-    fireEvent.change(screen.getByRole("combobox", { name: "Group" }), {
+    fireEvent.click(screen.getByRole("button", { name: /Teams & Fixtures/i }));
+
+    const teamsSection = screen.getByRole("heading", { name: "Teams" }).closest("section");
+    if (!teamsSection) throw new Error("Teams section not found");
+    const teamsScope = within(teamsSection);
+
+    fireEvent.change(teamsScope.getByRole("combobox", { name: "Team Group" }), {
       target: { value: "U11B" },
     });
-    fireEvent.change(screen.getByPlaceholderText("PP Amber"), {
+    fireEvent.change(teamsScope.getByPlaceholderText("PP Amber"), {
       target: { value: "PP Amber" },
     });
-    fireEvent.change(screen.getByRole("combobox", { name: "Pool" }), {
+    fireEvent.change(teamsScope.getByRole("combobox", { name: "Pool" }), {
       target: { value: "A" },
     });
 
-    fireEvent.click(screen.getByRole("button", { name: /Add Team/i }));
-    const teamInputs = screen.getAllByPlaceholderText("PP Amber");
+    fireEvent.click(teamsScope.getByRole("button", { name: /Add Team/i }));
+    const teamInputs = teamsScope.getAllByPlaceholderText("PP Amber");
     fireEvent.change(teamInputs[1], { target: { value: "Knights Orange" } });
-    const groupCombos = screen.getAllByRole("combobox", { name: "Group" });
-    fireEvent.change(groupCombos[1], { target: { value: "U11B" } });
-    const poolCombos = screen.getAllByRole("combobox", { name: "Pool" });
+
+    const teamGroupCombos = teamsScope.getAllByRole("combobox", { name: "Team Group" });
+    fireEvent.change(teamGroupCombos[1], { target: { value: "U11B" } });
+    const poolCombos = teamsScope.getAllByRole("combobox", { name: "Pool" });
     fireEvent.change(poolCombos[1], { target: { value: "A" } });
 
-    fireEvent.click(screen.getByRole("button", { name: /Fixtures/i }));
-    const fixtureGroupSelects = screen.getAllByRole("combobox", { name: "Group" });
-    fireEvent.change(fixtureGroupSelects[0], { target: { value: "U11B" } });
-    fireEvent.change(screen.getAllByLabelText("Date")[0], {
+    const fixturesSection = screen.getByRole("heading", { name: "Fixtures" }).closest("section");
+    if (!fixturesSection) throw new Error("Fixtures section not found");
+    const fixturesScope = within(fixturesSection);
+
+    fireEvent.change(fixturesScope.getByRole("combobox", { name: "Generator Group" }), {
+      target: { value: "U11B" },
+    });
+    fireEvent.change(fixturesScope.getAllByLabelText("Date")[0], {
       target: { value: "2026-01-08" },
     });
 
-    fireEvent.click(screen.getByRole("button", { name: /Generate Fixtures/i }));
+    fireEvent.click(fixturesScope.getByRole("button", { name: /Generate Fixtures/i }));
     await waitFor(() => {
-      expect(screen.getAllByLabelText("Team 1").length).toBeGreaterThan(0);
+      expect(fixturesScope.getAllByLabelText("Team 1").length).toBeGreaterThan(0);
     });
   });
 
@@ -152,12 +166,17 @@ describe("TournamentWizard", () => {
       target: { value: "U11 Boys" },
     });
 
-    fireEvent.click(screen.getByRole("button", { name: /Fixtures/i }));
-    const fixtureGroupSelects = screen.getAllByLabelText("Group");
-    const fixtureDateInputs = screen.getAllByLabelText("Date");
-    const fixtureVenueSelects = screen.getAllByLabelText("Venue");
-    const fixturePoolInputs = screen.getAllByLabelText("Pool");
-    const fixtureTimeInput = screen.getByLabelText("Time (optional)");
+    fireEvent.click(screen.getByRole("button", { name: /Teams & Fixtures/i }));
+
+    const fixturesSection = screen.getByRole("heading", { name: "Fixtures" }).closest("section");
+    if (!fixturesSection) throw new Error("Fixtures section not found");
+    const fixturesScope = within(fixturesSection);
+
+    const fixtureGroupSelects = fixturesScope.getAllByLabelText("Fixture Group");
+    const fixtureDateInputs = fixturesScope.getAllByLabelText("Date");
+    const fixtureVenueSelects = fixturesScope.getAllByLabelText("Venue");
+    const fixturePoolInputs = fixturesScope.getAllByLabelText("Pool");
+    const fixtureTimeInput = fixturesScope.getByLabelText("Time (optional)");
     const fixtureGroupSelect = fixtureGroupSelects[fixtureGroupSelects.length - 1];
     const fixtureDateInput = fixtureDateInputs[fixtureDateInputs.length - 1];
     const fixtureVenueSelect = fixtureVenueSelects[fixtureVenueSelects.length - 1];
@@ -199,29 +218,12 @@ describe("TournamentWizard", () => {
     });
   });
 
-  it("manages venues, group venues, and time slots", async () => {
+  it("allows selecting group venues and managing time slots", async () => {
     await renderWizard();
 
-    const venuesSection = screen
-      .getByRole("heading", { name: "Venues" })
-      .closest("section");
-    if (!venuesSection) throw new Error("Venues section not found");
-    const venuesScope = within(venuesSection);
+    // Groups step: select venues (multi-select)
+    fireEvent.click(screen.getByRole("button", { name: /Groups & Pools/i }));
 
-    await waitFor(() => {
-      expect(venuesScope.getAllByRole("option", { name: "Venue A" }).length).toBe(1);
-    });
-
-    fireEvent.change(venuesScope.getByRole("combobox"), {
-      target: { value: "Venue A" },
-    });
-
-    fireEvent.click(venuesScope.getByRole("button", { name: /Add New/i }));
-    fireEvent.change(venuesScope.getByPlaceholderText(/New venue name/i), {
-      target: { value: "Venue B" },
-    });
-
-    fireEvent.click(screen.getByRole("button", { name: /Groups/i }));
     fireEvent.change(screen.getByPlaceholderText("U11B"), {
       target: { value: "U11B" },
     });
@@ -229,18 +231,21 @@ describe("TournamentWizard", () => {
       target: { value: "U11 Boys" },
     });
 
-    const groupSection = screen
-      .getByRole("heading", { name: "Groups" })
-      .closest("section");
+    const groupSection = screen.getByRole("heading", { name: "Groups" }).closest("section");
     if (!groupSection) throw new Error("Groups section not found");
     const groupScope = within(groupSection);
-    fireEvent.click(groupScope.getByLabelText("Venue A"));
 
-    fireEvent.click(screen.getByRole("button", { name: /Fixtures/i }));
+    const venuesMultiSelect = groupScope.getByRole("listbox", { name: "Group Venues" });
 
-    const timeSlotsSection = screen
-      .getByRole("heading", { name: "Time Slots" })
-      .closest("section");
+    // Select Venue A (JSDOM doesn't allow setting selectedOptions directly)
+    const venueAOption = within(venuesMultiSelect).getByRole("option", { name: "Venue A" });
+    venueAOption.selected = true;
+    fireEvent.change(venuesMultiSelect);
+
+    // Teams & Fixtures step: manage time slots
+    fireEvent.click(screen.getByRole("button", { name: /Teams & Fixtures/i }));
+
+    const timeSlotsSection = screen.getByRole("heading", { name: "Time Slots" }).closest("section");
     if (!timeSlotsSection) throw new Error("Time Slots section not found");
     const timeSlotsScope = within(timeSlotsSection);
 
@@ -258,8 +263,7 @@ describe("TournamentWizard", () => {
 
     fireEvent.click(timeSlotsScope.getAllByRole("button", { name: /Remove Slot/i })[1]);
     await waitFor(() => {
-      expect(timeSlotsScope.getAllByRole("button", { name: /Remove Slot/i }).length)
-        .toBe(1);
+      expect(timeSlotsScope.getAllByRole("button", { name: /Remove Slot/i }).length).toBe(1);
     });
   });
 
@@ -276,38 +280,45 @@ describe("TournamentWizard", () => {
     const poolCountInput = screen.getByRole("spinbutton", { name: "Pool Count" });
     fireEvent.change(poolCountInput, { target: { value: "2" } });
 
-    fireEvent.click(screen.getByRole("button", { name: /Teams/i }));
-    fireEvent.change(screen.getByRole("combobox", { name: "Group" }), {
+    fireEvent.click(screen.getByRole("button", { name: /Teams & Fixtures/i }));
+
+    const teamsSection = screen.getByRole("heading", { name: "Teams" }).closest("section");
+    if (!teamsSection) throw new Error("Teams section not found");
+    const teamsScope = within(teamsSection);
+
+    fireEvent.change(teamsScope.getByRole("combobox", { name: "Team Group" }), {
       target: { value: "U11B" },
     });
-    fireEvent.change(screen.getByPlaceholderText("PP Amber"), {
+    fireEvent.change(teamsScope.getByPlaceholderText("PP Amber"), {
       target: { value: "PP Amber" },
     });
 
-    fireEvent.click(screen.getByRole("button", { name: /Add Team/i }));
-    const teamInputs = screen.getAllByPlaceholderText("PP Amber");
+    fireEvent.click(teamsScope.getByRole("button", { name: /Add Team/i }));
+    const teamInputs = teamsScope.getAllByPlaceholderText("PP Amber");
     fireEvent.change(teamInputs[1], { target: { value: "Knights Orange" } });
-    const groupCombos = screen.getAllByRole("combobox", { name: "Group" });
+
+    const groupCombos = teamsScope.getAllByRole("combobox", { name: "Team Group" });
     fireEvent.change(groupCombos[1], { target: { value: "U11B" } });
 
-    const autoAssignButtons = screen.getAllByRole("button", { name: /Auto-assign pools/i });
+    const autoAssignButtons = teamsScope.getAllByRole("button", { name: /Auto-assign pools/i });
     fireEvent.click(autoAssignButtons[0]);
-    const poolCombos = screen.getAllByRole("combobox", { name: "Pool" });
+
+    const poolCombos = teamsScope.getAllByRole("combobox", { name: "Pool" });
     expect(poolCombos[0].value).toBe("A");
     expect(poolCombos[1].value).toBe("B");
 
-    const franchiseImportInputs = screen.getAllByPlaceholderText(/Purple Panthers/i);
-    fireEvent.change(franchiseImportInputs[0], {
-      target: { value: "Purple Panthers\nBlue Cranes" },
-    });
-    fireEvent.click(screen.getByRole("button", { name: /Import Franchises/i }));
-    expect(screen.getAllByPlaceholderText("Purple Panthers").length).toBeGreaterThan(1);
+    // Franchise import removed in simplified wizard (#211).
   });
 
   it("shows generator validation errors when required fields are missing", async () => {
     await renderWizard();
-    fireEvent.click(screen.getByRole("button", { name: /Fixtures/i }));
-    fireEvent.click(screen.getByRole("button", { name: /Generate Fixtures/i }));
+    fireEvent.click(screen.getByRole("button", { name: /Teams & Fixtures/i }));
+
+    const fixturesSection = screen.getByRole("heading", { name: "Fixtures" }).closest("section");
+    if (!fixturesSection) throw new Error("Fixtures section not found");
+    const fixturesScope = within(fixturesSection);
+
+    fireEvent.click(fixturesScope.getByRole("button", { name: /Generate Fixtures/i }));
     expect(screen.getByText(/Generator requires group, date, and pool/i)).toBeDefined();
   });
 
@@ -342,14 +353,19 @@ describe("TournamentWizard", () => {
     fireEvent.change(screen.getByPlaceholderText("U11 Boys"), {
       target: { value: "U11 Boys" },
     });
-    fireEvent.click(screen.getByRole("button", { name: /Teams/i }));
-    fireEvent.change(screen.getByRole("combobox", { name: "Group" }), {
+    fireEvent.click(screen.getByRole("button", { name: /Teams & Fixtures/i }));
+
+    const teamsSection = screen.getByRole("heading", { name: "Teams" }).closest("section");
+    if (!teamsSection) throw new Error("Teams section not found");
+    const teamsScope = within(teamsSection);
+
+    fireEvent.change(teamsScope.getByRole("combobox", { name: "Team Group" }), {
       target: { value: "U11B" },
     });
-    fireEvent.change(screen.getByPlaceholderText("PP Amber"), {
+    fireEvent.change(teamsScope.getByPlaceholderText("PP Amber"), {
       target: { value: "PP Amber" },
     });
-    fireEvent.change(screen.getByRole("combobox", { name: "Pool" }), {
+    fireEvent.change(teamsScope.getByRole("combobox", { name: "Pool" }), {
       target: { value: "A" },
     });
 
@@ -379,7 +395,7 @@ describe("TournamentWizard", () => {
     });
 
     await renderWizard();
-    fireEvent.click(screen.getByRole("button", { name: /Teams/i }));
+    fireEvent.click(screen.getByRole("button", { name: /Teams & Fixtures/i }));
 
     await waitFor(() => {
       const datalist = document.querySelector("datalist");
@@ -389,7 +405,7 @@ describe("TournamentWizard", () => {
     });
   });
 
-  it("merges form-added franchises with API names in datalist", async () => {
+  it("populates franchise datalist from API (no form merge in simplified wizard)", async () => {
     fetch.mockImplementation((url) => {
       if (typeof url === "string" && url.includes("/admin/venues")) {
         return Promise.resolve({
@@ -407,24 +423,12 @@ describe("TournamentWizard", () => {
     });
 
     await renderWizard();
-
-    // Navigate to Teams step and add a franchise via the form
-    fireEvent.click(screen.getByRole("button", { name: /Teams/i }));
-
-    // The franchise "Name" input is within the Franchises section
-    const franchisesSection = screen
-      .getByRole("heading", { name: "Franchises" })
-      .closest("section");
-    const nameInput = within(franchisesSection).getAllByPlaceholderText("Purple Panthers")[0];
-    await act(async () => {
-      fireEvent.change(nameInput, { target: { value: "New Club" } });
-    });
+    fireEvent.click(screen.getByRole("button", { name: /Teams & Fixtures/i }));
 
     await waitFor(() => {
       const datalist = document.querySelector("datalist");
       const options = datalist ? Array.from(datalist.querySelectorAll("option")).map((o) => o.value) : [];
       expect(options).toContain("Gryphons");
-      expect(options).toContain("New Club");
     });
   });
 


### PR DESCRIPTION
Closes #211

## What changed
- Simplified Tournament Wizard to **3 steps** (Tournament → Groups & Pools → Teams & Fixtures).
- Removed inline Venue and Franchise management from the wizard (now managed via Admin pages).
- Groups now select venues from the Admin Venue directory only.
- Teams use franchise suggestions from the Admin Franchise directory only.
- Payload no longer posts venues/franchises arrays.
- Improved accessibility/testability by using distinct labels: Team Group, Generator Group, Fixture Group, and Group Venues.

## How to test
- npm test
- In Admin → Tournament Wizard: create a tournament using existing Venues/Franchises.

## Risk
- Medium (wizard flow change), but confined to admin tooling.