### PR TITLE
Admin Venues: CRUD-backed venue_directory

### DIFF
--- a/db/migrations/014_venue_directory.sql
+++ b/db/migrations/014_venue_directory.sql
@@ -1,0 +1,41 @@
+-- Global venue directory for admin-managed reusable venues
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS venue_directory (
+  id TEXT PRIMARY KEY DEFAULT gen_random_uuid()::text,
+  name TEXT NOT NULL UNIQUE,
+  location TEXT,
+  notes TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_venue_directory_name
+  ON venue_directory (name);
+
+-- Keep updated_at current
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_proc WHERE proname = 'set_updated_at_venue_directory'
+  ) THEN
+    CREATE OR REPLACE FUNCTION set_updated_at_venue_directory()
+    RETURNS TRIGGER AS $$
+    BEGIN
+      NEW.updated_at = NOW();
+      RETURN NEW;
+    END;
+    $$ LANGUAGE plpgsql;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_trigger WHERE tgname = 'trg_venue_directory_updated_at'
+  ) THEN
+    CREATE TRIGGER trg_venue_directory_updated_at
+    BEFORE UPDATE ON venue_directory
+    FOR EACH ROW
+    EXECUTE FUNCTION set_updated_at_venue_directory();
+  END IF;
+END $$;
+
+COMMIT;

--- a/server/admin.mjs
+++ b/server/admin.mjs
@@ -494,19 +494,173 @@ export async function handleAdminRequest(req, res, { url, pool, sendJson, caches
     // We need to handle /announcements/:id logic.
   }
 
-  if (path === "/venues") {
-    if (!requireGetWithDb(method, pool, req, res, sendJson)) return;
-    try {
-      const result = await pool.query(
-        `SELECT DISTINCT name
-         FROM venue_directory
-         ORDER BY name ASC`
-      );
-      return sendJson(req, res, 200, { ok: true, data: result.rows });
-    } catch (err) {
-      console.error("Admin API Error:", err);
-      return sendJson(req, res, 500, { ok: false, error: err.message });
+  // Venues (global directory)
+  // - GET    /api/admin/venues
+  // - POST   /api/admin/venues
+  // - GET    /api/admin/venues/:id
+  // - PATCH  /api/admin/venues/:id
+  // - DELETE /api/admin/venues/:id
+  if (path === "/venues" || path.startsWith("/venues/")) {
+    if (!pool) {
+      return sendJson(req, res, 501, { ok: false, error: "DB not configured" });
     }
+
+    const venueId = path.startsWith("/venues/") ? decodeURIComponent(path.split("/")[2] || "") : "";
+
+    if (method === "GET" && !venueId) {
+      try {
+        const result = await pool.query(
+          `SELECT id, name, location, notes, created_at, updated_at
+           FROM venue_directory
+           ORDER BY name ASC`
+        );
+        return sendJson(req, res, 200, { ok: true, data: result.rows || [] });
+      } catch (err) {
+        console.error("Admin API Error:", err);
+        return sendJson(req, res, 500, { ok: false, error: "Failed to load venues" });
+      }
+    }
+
+    if (method === "GET" && venueId) {
+      try {
+        const result = await pool.query(
+          `SELECT id, name, location, notes, created_at, updated_at
+           FROM venue_directory
+           WHERE id = $1`,
+          [venueId]
+        );
+        if (!result.rows?.length) {
+          return sendJson(req, res, 404, { ok: false, error: "Venue not found" });
+        }
+        return sendJson(req, res, 200, { ok: true, data: result.rows[0] });
+      } catch (err) {
+        console.error("Admin API Error:", err);
+        return sendJson(req, res, 500, { ok: false, error: "Failed to load venue" });
+      }
+    }
+
+    if (method === "POST" && !venueId) {
+      try {
+        const body = await readBody(req);
+        if (!body) return sendJson(req, res, 400, { ok: false, error: "Invalid body" });
+
+        const name = toTitleCase(normalizeSpaces(body.name));
+        if (!name) return sendJson(req, res, 400, { ok: false, error: "name is required" });
+
+        const result = await pool.query(
+          `INSERT INTO venue_directory (name, location, notes)
+           VALUES ($1, $2, $3)
+           RETURNING id, name, location, notes, created_at, updated_at`,
+          [
+            name,
+            body.location ? normalizeSpaces(body.location) : null,
+            body.notes ? normalizeSpaces(body.notes) : null,
+          ]
+        );
+
+        await logAudit("venue.create", {
+          entity_type: "venue_directory",
+          entity_id: String(result.rows[0]?.id ?? ""),
+          meta: { name },
+        });
+
+        return sendJson(req, res, 201, { ok: true, data: result.rows[0] });
+      } catch (err) {
+        console.error("Admin API Error:", err);
+        return sendJson(req, res, 500, { ok: false, error: err.message });
+      }
+    }
+
+    if (method === "PATCH" && venueId) {
+      try {
+        const body = await readBody(req);
+        if (!body) return sendJson(req, res, 400, { ok: false, error: "Invalid body" });
+
+        const updates = {
+          name: body.name ? toTitleCase(normalizeSpaces(body.name)) : null,
+          location: Object.prototype.hasOwnProperty.call(body, "location")
+            ? (body.location ? normalizeSpaces(body.location) : null)
+            : undefined,
+          notes: Object.prototype.hasOwnProperty.call(body, "notes")
+            ? (body.notes ? normalizeSpaces(body.notes) : null)
+            : undefined,
+        };
+
+        // Build dynamic update set
+        const set = [];
+        const values = [];
+        let idx = 1;
+
+        if (updates.name !== null) {
+          set.push(`name = $${idx++}`);
+          values.push(updates.name);
+        }
+        if (updates.location !== undefined) {
+          set.push(`location = $${idx++}`);
+          values.push(updates.location);
+        }
+        if (updates.notes !== undefined) {
+          set.push(`notes = $${idx++}`);
+          values.push(updates.notes);
+        }
+
+        if (set.length === 0) {
+          return sendJson(req, res, 400, { ok: false, error: "No fields to update" });
+        }
+
+        values.push(venueId);
+        const result = await pool.query(
+          `UPDATE venue_directory
+           SET ${set.join(", ")}
+           WHERE id = $${idx}
+           RETURNING id, name, location, notes, created_at, updated_at`,
+          values
+        );
+
+        if (!result.rowCount) {
+          return sendJson(req, res, 404, { ok: false, error: "Venue not found" });
+        }
+
+        await logAudit("venue.update", {
+          entity_type: "venue_directory",
+          entity_id: String(venueId),
+          meta: { fields: Object.keys(body || {}) },
+        });
+
+        return sendJson(req, res, 200, { ok: true, data: result.rows[0] });
+      } catch (err) {
+        console.error("Admin API Error:", err);
+        return sendJson(req, res, 500, { ok: false, error: err.message });
+      }
+    }
+
+    if (method === "DELETE" && venueId) {
+      try {
+        const result = await pool.query(
+          `DELETE FROM venue_directory
+           WHERE id = $1
+           RETURNING id, name`,
+          [venueId]
+        );
+
+        if (!result.rowCount) {
+          return sendJson(req, res, 404, { ok: false, error: "Venue not found" });
+        }
+
+        await logAudit("venue.delete", {
+          entity_type: "venue_directory",
+          entity_id: String(venueId),
+          meta: { name: result.rows[0]?.name || "" },
+        });
+
+        return sendJson(req, res, 200, { ok: true, data: result.rows[0] });
+      } catch (err) {
+        console.error("Admin API Error:", err);
+        return sendJson(req, res, 500, { ok: false, error: err.message });
+      }
+    }
+
+    return sendJson(req, res, 405, { ok: false, error: "Method not allowed" });
   }
 
   if (path === "/franchises") {

--- a/src/lib/venueApi.js
+++ b/src/lib/venueApi.js
@@ -4,13 +4,14 @@ import { adminFetch } from './adminAuth';
 
 const basePath = '/admin/venues';
 
-async function okJson(res, errPrefix) {
-  if (!res.ok) {
-    const err = new Error(`${errPrefix}: ${res.status}`);
+async function parseJson(res) {
+  const json = await res.json().catch(() => ({}));
+  if (!res.ok || json.ok === false) {
+    const err = new Error(json.error || `HTTP ${res.status}`);
     err.status = res.status;
     throw err;
   }
-  return res.json();
+  return json;
 }
 
 /**
@@ -20,7 +21,8 @@ async function okJson(res, errPrefix) {
 export async function getVenues() {
   if (!API_BASE) throw new Error('Missing API_BASE');
   const res = await adminFetch(basePath);
-  return okJson(res, 'Failed to fetch venues');
+  const json = await parseJson(res);
+  return json.data || [];
 }
 
 /**
@@ -31,7 +33,8 @@ export async function getVenues() {
 export async function getVenue(id) {
   if (!API_BASE) throw new Error('Missing API_BASE');
   const res = await adminFetch(`${basePath}/${id}`);
-  return okJson(res, 'Failed to fetch venue');
+  const json = await parseJson(res);
+  return json.data;
 }
 
 /**
@@ -46,7 +49,8 @@ export async function createVenue(venueData) {
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(venueData),
   });
-  return okJson(res, 'Failed to create venue');
+  const json = await parseJson(res);
+  return json.data;
 }
 
 /**
@@ -62,7 +66,8 @@ export async function updateVenue(id, venueData) {
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(venueData),
   });
-  return okJson(res, 'Failed to update venue');
+  const json = await parseJson(res);
+  return json.data;
 }
 
 /**
@@ -75,9 +80,5 @@ export async function deleteVenue(id) {
   const res = await adminFetch(`${basePath}/${id}`, {
     method: 'DELETE',
   });
-  if (!res.ok) {
-    const err = new Error(`Failed to delete venue: ${res.status}`);
-    err.status = res.status;
-    throw err;
-  }
+  await parseJson(res);
 }

--- a/src/lib/venueApi.test.js
+++ b/src/lib/venueApi.test.js
@@ -1,11 +1,11 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 function okJson(data) {
-  return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve(data) });
+  return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve({ ok: true, data }) });
 }
 
 function fail(status = 500) {
-  return Promise.resolve({ ok: false, status, json: () => Promise.resolve({ ok: false }) });
+  return Promise.resolve({ ok: false, status, json: () => Promise.resolve({ ok: false, error: 'nope' }) });
 }
 
 describe('venueApi', () => {
@@ -92,7 +92,7 @@ describe('venueApi', () => {
 
   it('deleteVenue issues DELETE via adminFetch and returns void', async () => {
     vi.doMock('./api', () => ({ API_BASE: 'http://example.test/api' }));
-    const adminFetch = vi.fn().mockReturnValue(Promise.resolve({ ok: true, status: 204 }));
+    const adminFetch = vi.fn().mockReturnValue(okJson({}));
     vi.doMock('./adminAuth', () => ({ adminFetch }));
 
     const { deleteVenue } = await import('./venueApi');
@@ -109,7 +109,7 @@ describe('venueApi', () => {
     const { getVenues } = await import('./venueApi');
 
     await expect(getVenues()).rejects.toMatchObject({ status: 403 });
-    await expect(getVenues()).rejects.toThrow('Failed to fetch venues: 403');
+    await expect(getVenues()).rejects.toThrow('nope');
   });
 
   it('getVenue throws a status error when request fails', async () => {
@@ -120,7 +120,7 @@ describe('venueApi', () => {
     const { getVenue } = await import('./venueApi');
 
     await expect(getVenue('v404')).rejects.toMatchObject({ status: 404 });
-    await expect(getVenue('v404')).rejects.toThrow('Failed to fetch venue: 404');
+    await expect(getVenue('v404')).rejects.toThrow('nope');
   });
 
   it('createVenue throws a status error when request fails', async () => {
@@ -131,7 +131,7 @@ describe('venueApi', () => {
     const { createVenue } = await import('./venueApi');
 
     await expect(createVenue({ name: 'Bad payload' })).rejects.toMatchObject({ status: 400 });
-    await expect(createVenue({ name: 'Bad payload' })).rejects.toThrow('Failed to create venue: 400');
+    await expect(createVenue({ name: 'Bad payload' })).rejects.toThrow('nope');
   });
 
   it('updateVenue throws a status error when request fails', async () => {
@@ -142,7 +142,7 @@ describe('venueApi', () => {
     const { updateVenue } = await import('./venueApi');
 
     await expect(updateVenue('v1', { name: 'Conflict' })).rejects.toMatchObject({ status: 409 });
-    await expect(updateVenue('v1', { name: 'Conflict' })).rejects.toThrow('Failed to update venue: 409');
+    await expect(updateVenue('v1', { name: 'Conflict' })).rejects.toThrow('nope');
   });
 
   it('deleteVenue throws a status error when request fails', async () => {
@@ -153,6 +153,6 @@ describe('venueApi', () => {
     const { deleteVenue } = await import('./venueApi');
 
     await expect(deleteVenue('v1')).rejects.toMatchObject({ status: 500 });
-    await expect(deleteVenue('v1')).rejects.toThrow('Failed to delete venue: 500');
+    await expect(deleteVenue('v1')).rejects.toThrow('nope');
   });
 });

--- a/test/server/admin.test.js
+++ b/test/server/admin.test.js
@@ -482,7 +482,7 @@ describe('handleAdminRequest', () => {
 
     it('GET /venues returns venue list', async () => {
         const url = new URL('http://localhost/api/admin/venues');
-        mockPool.query.mockResolvedValueOnce({ rows: [{ name: 'Beaulieu College' }] });
+        mockPool.query.mockResolvedValueOnce({ rows: [{ id: 'v1', name: 'Beaulieu College', location: null, notes: null }] });
 
         await handleAdminRequest(mockReq, mockRes, { url, pool: mockPool, sendJson: mockSendJson });
 
@@ -494,17 +494,23 @@ describe('handleAdminRequest', () => {
         );
     });
 
-    it('POST /venues returns method not allowed', async () => {
+    it('POST /venues creates venue', async () => {
         const url = new URL('http://localhost/api/admin/venues');
         mockReq.method = 'POST';
+        mockReq.on = vi.fn((event, cb) => {
+            if (event === 'data') cb(Buffer.from(JSON.stringify({ name: 'beaulieu college', location: 'Johannesburg', notes: 'Indoor' })));
+            if (event === 'end') cb();
+        });
 
-        await handleAdminRequest(mockReq, mockRes, { url, pool: mockPool, sendJson: mockSendJson });
+        mockPool.query.mockResolvedValueOnce({ rows: [{ id: 'v1', name: 'Beaulieu College', location: 'Johannesburg', notes: 'Indoor' }] });
+
+        await handleAdminRequest(mockReq, mockRes, { url, pool: mockPool, sendJson: mockSendJson, caches: { actorEmail: 'test@example.com' } });
 
         expect(mockSendJson).toHaveBeenCalledWith(
             mockReq,
             mockRes,
-            405,
-            expect.objectContaining({ error: expect.stringContaining('Method not allowed') })
+            201,
+            expect.objectContaining({ ok: true, data: expect.objectContaining({ id: 'v1', name: 'Beaulieu College' }) })
         );
     });
 

--- a/test/server/admin.test.js
+++ b/test/server/admin.test.js
@@ -514,6 +514,59 @@ describe('handleAdminRequest', () => {
         );
     });
 
+    it('GET /venues/:id returns a single venue', async () => {
+        const url = new URL('http://localhost/api/admin/venues/v1');
+        mockPool.query.mockResolvedValueOnce({ rows: [{ id: 'v1', name: 'Beaulieu College', location: null, notes: null }] });
+
+        await handleAdminRequest(mockReq, mockRes, { url, pool: mockPool, sendJson: mockSendJson });
+
+        expect(mockSendJson).toHaveBeenCalledWith(
+            mockReq,
+            mockRes,
+            200,
+            expect.objectContaining({ ok: true, data: expect.objectContaining({ id: 'v1', name: 'Beaulieu College' }) })
+        );
+    });
+
+    it('PATCH /venues/:id updates a venue', async () => {
+        const url = new URL('http://localhost/api/admin/venues/v1');
+        mockReq.method = 'PATCH';
+        mockReq.on = vi.fn((event, cb) => {
+            if (event === 'data') cb(Buffer.from(JSON.stringify({ location: 'Pretoria', notes: 'Updated' })));
+            if (event === 'end') cb();
+        });
+
+        mockPool.query.mockResolvedValueOnce({
+            rows: [{ id: 'v1', name: 'Beaulieu College', location: 'Pretoria', notes: 'Updated' }],
+            rowCount: 1,
+        });
+
+        await handleAdminRequest(mockReq, mockRes, { url, pool: mockPool, sendJson: mockSendJson, caches: { actorEmail: 'test@example.com' } });
+
+        expect(mockSendJson).toHaveBeenCalledWith(
+            mockReq,
+            mockRes,
+            200,
+            expect.objectContaining({ ok: true, data: expect.objectContaining({ id: 'v1', location: 'Pretoria' }) })
+        );
+    });
+
+    it('DELETE /venues/:id deletes a venue', async () => {
+        const url = new URL('http://localhost/api/admin/venues/v1');
+        mockReq.method = 'DELETE';
+
+        mockPool.query.mockResolvedValueOnce({ rows: [{ id: 'v1', name: 'Beaulieu College' }], rowCount: 1 });
+
+        await handleAdminRequest(mockReq, mockRes, { url, pool: mockPool, sendJson: mockSendJson, caches: { actorEmail: 'test@example.com' } });
+
+        expect(mockSendJson).toHaveBeenCalledWith(
+            mockReq,
+            mockRes,
+            200,
+            expect.objectContaining({ ok: true, data: expect.objectContaining({ id: 'v1' }) })
+        );
+    });
+
     it('GET /franchises returns list', async () => {
         const url = new URL('http://localhost/api/admin/franchises');
         mockPool.query.mockResolvedValueOnce({ rows: [{ id: 'f1', name: 'Alpha' }] });

--- a/test/server/admin.test.js
+++ b/test/server/admin.test.js
@@ -567,6 +567,105 @@ describe('handleAdminRequest', () => {
         );
     });
 
+    it('GET /venues/:id returns 404 when venue not found', async () => {
+        const url = new URL('http://localhost/api/admin/venues/missing');
+        mockPool.query.mockResolvedValueOnce({ rows: [] });
+
+        await handleAdminRequest(mockReq, mockRes, { url, pool: mockPool, sendJson: mockSendJson });
+
+        expect(mockSendJson).toHaveBeenCalledWith(
+            mockReq,
+            mockRes,
+            404,
+            expect.objectContaining({ ok: false, error: expect.stringContaining('Venue not found') })
+        );
+    });
+
+    it('POST /venues returns 400 when name is missing', async () => {
+        const url = new URL('http://localhost/api/admin/venues');
+        mockReq.method = 'POST';
+        mockReq.on = vi.fn((event, cb) => {
+            if (event === 'data') cb(Buffer.from(JSON.stringify({ location: 'X' })));
+            if (event === 'end') cb();
+        });
+
+        await handleAdminRequest(mockReq, mockRes, { url, pool: mockPool, sendJson: mockSendJson });
+
+        expect(mockSendJson).toHaveBeenCalledWith(
+            mockReq,
+            mockRes,
+            400,
+            expect.objectContaining({ ok: false, error: expect.stringContaining('name is required') })
+        );
+    });
+
+    it('PATCH /venues/:id returns 400 when no fields are provided', async () => {
+        const url = new URL('http://localhost/api/admin/venues/v1');
+        mockReq.method = 'PATCH';
+        mockReq.on = vi.fn((event, cb) => {
+            if (event === 'data') cb(Buffer.from(JSON.stringify({})));
+            if (event === 'end') cb();
+        });
+
+        await handleAdminRequest(mockReq, mockRes, { url, pool: mockPool, sendJson: mockSendJson });
+
+        expect(mockSendJson).toHaveBeenCalledWith(
+            mockReq,
+            mockRes,
+            400,
+            expect.objectContaining({ ok: false, error: expect.stringContaining('No fields to update') })
+        );
+    });
+
+    it('PATCH /venues/:id returns 404 when venue not found', async () => {
+        const url = new URL('http://localhost/api/admin/venues/missing');
+        mockReq.method = 'PATCH';
+        mockReq.on = vi.fn((event, cb) => {
+            if (event === 'data') cb(Buffer.from(JSON.stringify({ notes: 'X' })));
+            if (event === 'end') cb();
+        });
+
+        mockPool.query.mockResolvedValueOnce({ rows: [], rowCount: 0 });
+
+        await handleAdminRequest(mockReq, mockRes, { url, pool: mockPool, sendJson: mockSendJson, caches: { actorEmail: 'test@example.com' } });
+
+        expect(mockSendJson).toHaveBeenCalledWith(
+            mockReq,
+            mockRes,
+            404,
+            expect.objectContaining({ ok: false, error: expect.stringContaining('Venue not found') })
+        );
+    });
+
+    it('DELETE /venues/:id returns 404 when venue not found', async () => {
+        const url = new URL('http://localhost/api/admin/venues/missing');
+        mockReq.method = 'DELETE';
+        mockPool.query.mockResolvedValueOnce({ rows: [], rowCount: 0 });
+
+        await handleAdminRequest(mockReq, mockRes, { url, pool: mockPool, sendJson: mockSendJson, caches: { actorEmail: 'test@example.com' } });
+
+        expect(mockSendJson).toHaveBeenCalledWith(
+            mockReq,
+            mockRes,
+            404,
+            expect.objectContaining({ ok: false, error: expect.stringContaining('Venue not found') })
+        );
+    });
+
+    it('PUT /venues returns 405 (method not allowed)', async () => {
+        const url = new URL('http://localhost/api/admin/venues');
+        mockReq.method = 'PUT';
+
+        await handleAdminRequest(mockReq, mockRes, { url, pool: mockPool, sendJson: mockSendJson });
+
+        expect(mockSendJson).toHaveBeenCalledWith(
+            mockReq,
+            mockRes,
+            405,
+            expect.objectContaining({ ok: false, error: expect.stringContaining('Method not allowed') })
+        );
+    });
+
     it('GET /franchises returns list', async () => {
         const url = new URL('http://localhost/api/admin/franchises');
         mockPool.query.mockResolvedValueOnce({ rows: [{ id: 'f1', name: 'Alpha' }] });


### PR DESCRIPTION
### What changed
- Added DB migration to create `venue_directory` with id/name/location/notes + updated_at trigger
- Implemented full CRUD admin API for venues:
  - GET/POST `/api/admin/venues`
  - GET/PATCH/DELETE `/api/admin/venues/:id`
- Fixed admin client parsing to use `{ ok, data }` envelope (prevents blank Venues page)

### How to test
1. Run migrations (apply `014_venue_directory.sql`)
2. Start server + UI
3. In Admin Console → Venues: create/edit/delete a venue; refresh and confirm persistence

### Evidence
- `npm test` → 689 passed

### Risk
Low–Medium (new table + endpoints; existing UI now receives richer objects; old name-only use cases remain compatible).
