### PR TITLE
fix: copy .npmrc before npm ci in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM node:20-alpine
 
 WORKDIR /app
 
-COPY package.json package-lock.json ./
+COPY package.json package-lock.json .npmrc ./
 RUN npm ci --omit=dev
 
 COPY . .


### PR DESCRIPTION
## Summary

- All Northflank production builds have been failing since **April 3** due to a peer dependency conflict in the Storybook packages (`@storybook/addon-essentials@8` requires `storybook@^8` but `storybook@10` is installed)
- The repo already has `legacy-peer-deps=true` in `.npmrc` to suppress this, but the Dockerfile only copied `package.json` and `package-lock.json` before running `npm ci` — so `.npmrc` wasn't present and npm strict mode rejected the install
- Fix: add `.npmrc` to the same `COPY` line so it's present when `npm ci` runs

**Verified locally:** `npm ci --omit=dev` exits 0 with `.npmrc` present, exits 1 without it.

## Test plan
- [ ] CI passes
- [ ] Northflank build succeeds after merge (watch build status via API)
- [ ] Production venues load at `/api/venues`

🤖 Generated with [Claude Code](https://claude.com/claude-code)