### PR TITLE
feat: wizard UX improvements — step nav, time inputs, smart defaults

### DIFF
--- a/e2e/admin-create-tournament.spec.ts
+++ b/e2e/admin-create-tournament.spec.ts
@@ -101,14 +101,14 @@ test('admin can create a tournament via the Tournament Wizard (smoke)', async ({
   await page.getByLabel('Tournament ID').fill(tournamentId);
 
   // Step 2: Groups & Pools
-  await page.getByRole('button', { name: 'Groups & Pools' }).click();
+  await page.getByRole('button', { name: /^2\s*Groups & Pools/i }).click();
   await expect(page.getByRole('heading', { name: 'Groups' })).toBeVisible();
   await page.getByLabel('Group ID').first().fill('U11B');
   await page.getByLabel('Label').first().fill('U11 Boys');
   // Venues are optional; leave empty.
 
   // Step 3: Teams & Fixtures
-  await page.getByRole('button', { name: 'Teams & Fixtures' }).click();
+  await page.getByRole('button', { name: /^3\s*Teams & Fixtures/i }).click();
   await expect(page.getByRole('heading', { name: 'Teams' })).toBeVisible();
 
   const teamsSection = page.locator('section', { has: page.getByRole('heading', { name: 'Teams' }) });

--- a/src/styles/hj-tokens.css
+++ b/src/styles/hj-tokens.css
@@ -1870,6 +1870,31 @@ select {
   cursor: not-allowed;
 }
 
+.wizard-secondary {
+  padding: var(--hj-space-1) var(--hj-space-3);
+  border-radius: var(--hj-radius-pill);
+  border: 1px solid var(--hj-color-brand-strong);
+  background: transparent;
+  color: var(--hj-color-brand-strong);
+  font-weight: var(--hj-font-weight-semibold);
+  font-size: var(--hj-font-size-sm);
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.wizard-secondary:hover {
+  background: var(--hj-color-brand-subtle, #e8f0fe);
+}
+
+.wizard-step-nav {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-top: var(--hj-space-6);
+  padding-top: var(--hj-space-4);
+  border-top: 1px solid var(--hj-color-border-subtle);
+}
+
 .wizard-alert {
   padding: var(--hj-space-2) var(--hj-space-3);
   border-radius: var(--hj-radius-md);

--- a/src/views/admin/TournamentWizard.jsx
+++ b/src/views/admin/TournamentWizard.jsx
@@ -1,5 +1,6 @@
 import React, { useMemo, useRef, useState } from "react";
 import PropTypes from "prop-types";
+import { Link, useNavigate } from "react-router-dom";
 // NOTE: franchises now come from the admin franchise directory (global)
 // import { getFranchises } from "../../lib/api";
 import { adminFetch } from "../../lib/adminAuth";
@@ -170,6 +171,7 @@ export default function TournamentWizard() {
     keyCounter.current += 1;
     return `${prefix}-${keyCounter.current}`;
   }, []);
+  const navigate = useNavigate();
   const [step, setStep] = useState(0);
   const [saving, setSaving] = useState(false);
   const [saveError, setSaveError] = useState("");
@@ -430,6 +432,27 @@ export default function TournamentWizard() {
     setSaveSuccess(`Generated ${nextFixtures.length} fixtures.`);
   }
 
+  function handleNext() {
+    if (step === 0) {
+      if (!tournament.name.trim() || !tournament.season.trim() || !(tournament.id || tournamentIdHint)) {
+        setSaveError("Please fill in all required fields before continuing.");
+        return;
+      }
+      // Auto-apply suggested ID if left blank
+      if (!tournament.id && tournamentIdHint) {
+        updateTournament({ id: tournamentIdHint });
+      }
+    }
+    if (step === 1) {
+      if (!groups.some((g) => g.id?.trim() && g.label?.trim())) {
+        setSaveError("Add at least one complete group before continuing.");
+        return;
+      }
+    }
+    setSaveError("");
+    setStep((s) => Math.min(s + 1, STEP_LABELS.length - 1));
+  }
+
   async function handleSubmit() {
     setSaving(true);
     setSaveError("");
@@ -502,6 +525,7 @@ export default function TournamentWizard() {
         throw new Error(json.error || "Failed to save tournament");
       }
       setSaveSuccess(`Tournament created: ${json.tournament_id}`);
+      setTimeout(() => navigate("/admin/fixtures"), 1500);
     } catch (err) {
       setSaveError(err.message || "Failed to save tournament");
     } finally {
@@ -557,14 +581,6 @@ export default function TournamentWizard() {
             Build the tournament structure, teams, pools, and fixtures in one flow.
           </p>
         </div>
-        <button
-          type="button"
-          className="wizard-primary"
-          onClick={handleSubmit}
-          disabled={saving}
-        >
-          {saving ? "Saving..." : "Create Tournament"}
-        </button>
       </header>
 
       {saveError ? <div className="wizard-alert error">{saveError}</div> : null}
@@ -602,24 +618,42 @@ export default function TournamentWizard() {
             </Field>
             <Field
               label="Tournament ID"
-              hint={`Suggested: ${tournamentIdHint || "hj-..."}`}
+              hint={tournamentIdHint && !tournament.id ? undefined : `Suggested: ${tournamentIdHint || "hj-..."}`}
               error={invalidTournamentId ? "Required" : ""}
             >
-              <input
-                type="text"
-                value={tournament.id}
-                className={invalidTournamentId ? "wizard-input invalid" : "wizard-input"}
-                onChange={(e) => updateTournament({ id: e.target.value })}
-                placeholder={tournamentIdHint || "hj-indoor-2026"}
-              />
+              <div style={{ display: "flex", gap: "var(--hj-space-2)", alignItems: "center" }}>
+                <input
+                  type="text"
+                  value={tournament.id}
+                  className={invalidTournamentId ? "wizard-input invalid" : "wizard-input"}
+                  style={{ flex: 1 }}
+                  onChange={(e) => updateTournament({ id: e.target.value })}
+                  placeholder={tournamentIdHint || "hj-indoor-2026"}
+                />
+                {tournamentIdHint && tournament.id !== tournamentIdHint && (
+                  <button
+                    type="button"
+                    className="wizard-secondary"
+                    onClick={() => updateTournament({ id: tournamentIdHint })}
+                  >
+                    Use suggested
+                  </button>
+                )}
+              </div>
             </Field>
           </SectionCard>
 
-
+          <div className="wizard-step-nav">
+            <span />
+            <button type="button" className="wizard-primary" onClick={handleNext}>
+              Next: Groups &amp; Pools →
+            </button>
+          </div>
         </div>
       )}
 
       {step === 1 && (
+        <>
         <SectionCard
           title="Groups"
           actions={<button type="button" onClick={addGroup}>Add Group</button>}
@@ -669,7 +703,7 @@ export default function TournamentWizard() {
               <div className="wizard-choices">
                 <span className="wizard-field-label">Group Venues</span>
                 {allVenueOptions.length === 0 ? (
-                  <span className="wizard-choice-empty">No venues available. Add them in Admin → Venues.</span>
+                  <span className="wizard-choice-empty">No venues available. <Link to="/admin/venues">Add them in Admin → Venues.</Link></span>
                 ) : (
                   <select
                     multiple
@@ -695,6 +729,15 @@ export default function TournamentWizard() {
             </div>
           ))}
         </SectionCard>
+        <div className="wizard-step-nav">
+          <button type="button" className="wizard-secondary" onClick={() => { setSaveError(""); setStep(0); }}>
+            ← Back: Tournament
+          </button>
+          <button type="button" className="wizard-primary" onClick={handleNext}>
+            Next: Teams &amp; Fixtures →
+          </button>
+        </div>
+        </>
       )}
 
       {step === 2 && (
@@ -803,6 +846,7 @@ export default function TournamentWizard() {
       )}
 
       {step === 2 && (
+        <>
         <SectionCard
           title="Fixtures"
           actions={<button type="button" onClick={addFixture}>Add Fixture</button>}
@@ -850,10 +894,9 @@ export default function TournamentWizard() {
             <div className="wizard-row">
               <Field label="Default Time">
                 <input
-                  type="text"
+                  type="time"
                   value={generator.time}
                   onChange={(e) => setGenerator((prev) => ({ ...prev, time: e.target.value }))}
-                  placeholder="09:00"
                 />
               </Field>
               <Field label="Default Venue">
@@ -917,11 +960,10 @@ export default function TournamentWizard() {
                   </Field>
                   <Field label="Time">
                     <input
-                      type="text"
+                      type="time"
                       value={slot.time}
                       className={slotHasTime ? "wizard-input" : "wizard-input invalid"}
                       onChange={(e) => updateTimeSlot(idx, { time: e.target.value })}
-                      placeholder="09:00"
                     />
                   </Field>
                   <Field label="Venue">
@@ -986,11 +1028,10 @@ export default function TournamentWizard() {
                 </Field>
                 <Field label="Time (optional)">
                   <input
-                    type="text"
+                    type="time"
                     value={fixture.time}
                     className="wizard-input"
                     onChange={(e) => updateFixture(idx, { time: e.target.value })}
-                    placeholder="09:00"
                   />
                 </Field>
               </div>
@@ -1063,6 +1104,20 @@ export default function TournamentWizard() {
           );
           })}
         </SectionCard>
+        <div className="wizard-step-nav">
+          <button type="button" className="wizard-secondary" onClick={() => { setSaveError(""); setStep(1); }}>
+            ← Back: Groups &amp; Pools
+          </button>
+          <button
+            type="button"
+            className="wizard-primary"
+            onClick={handleSubmit}
+            disabled={saving}
+          >
+            {saving ? "Saving..." : "Create Tournament"}
+          </button>
+        </div>
+        </>
       )}
     </div>
   );

--- a/src/views/admin/TournamentWizard.test.jsx
+++ b/src/views/admin/TournamentWizard.test.jsx
@@ -496,4 +496,52 @@ describe("TournamentWizard", () => {
       "Duplicate fixtures found (same teams/date/time/pool).",
     ]));
   });
+
+  it("handleNext blocks step 0 → 1 when required fields are missing, then advances when filled", async () => {
+    await renderWizard();
+
+    // Click Next without any fields filled — expect validation error
+    fireEvent.click(screen.getByRole("button", { name: /Next: Groups/i }));
+    expect(screen.getByText("Please fill in all required fields before continuing.")).toBeDefined();
+
+    // Fill required fields
+    fireEvent.change(screen.getByPlaceholderText("HJ Indoor 2026"), { target: { value: "HJ Test" } });
+    fireEvent.change(screen.getByPlaceholderText("2026"), { target: { value: "2026" } });
+    fireEvent.change(screen.getByLabelText("Tournament ID"), { target: { value: "hj-test-2026" } });
+
+    // Now Next should advance to step 1
+    fireEvent.click(screen.getByRole("button", { name: /Next: Groups/i }));
+    expect(screen.getByRole("heading", { name: "Groups" })).toBeDefined();
+  });
+
+  it("handleNext auto-applies suggested tournament ID when ID field is left empty", async () => {
+    await renderWizard();
+
+    // Fill name + season to generate a hint; leave ID blank
+    fireEvent.change(screen.getByPlaceholderText("HJ Indoor 2026"), { target: { value: "HJ Test" } });
+    fireEvent.change(screen.getByPlaceholderText("2026"), { target: { value: "2026" } });
+
+    // Click Next — hint should be auto-applied and wizard advances to step 1
+    fireEvent.click(screen.getByRole("button", { name: /Next: Groups/i }));
+    expect(screen.getByRole("heading", { name: "Groups" })).toBeDefined();
+  });
+
+  it("handleNext blocks step 1 → 2 when no valid group exists, then advances when group is filled", async () => {
+    await renderWizard();
+
+    // Jump to step 1 via header tab
+    fireEvent.click(screen.getByRole("button", { name: /^2\s*Groups & Pools/i }));
+
+    // Click Next with the default empty group — expect validation error
+    fireEvent.click(screen.getByRole("button", { name: /Next: Teams/i }));
+    expect(screen.getByText("Add at least one complete group before continuing.")).toBeDefined();
+
+    // Fill in the default group's ID and label
+    fireEvent.change(screen.getByPlaceholderText("U11B"), { target: { value: "U11B" } });
+    fireEvent.change(screen.getByPlaceholderText("U11 Boys"), { target: { value: "U11 Boys" } });
+
+    // Now Next should advance to step 2
+    fireEvent.click(screen.getByRole("button", { name: /Next: Teams/i }));
+    expect(screen.getByRole("heading", { name: "Teams" })).toBeDefined();
+  });
 });

--- a/src/views/admin/TournamentWizard.test.jsx
+++ b/src/views/admin/TournamentWizard.test.jsx
@@ -1,5 +1,6 @@
 import { render, screen, fireEvent, waitFor, within, act } from "@testing-library/react";
 import React from "react";
+import { MemoryRouter } from "react-router-dom";
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { computeFormErrors } from "./tournamentWizardUtils";
 
@@ -35,7 +36,7 @@ describe("TournamentWizard", () => {
     const { default: TournamentWizard } = await import("./TournamentWizard");
     let result;
     await act(async () => {
-      result = render(<TournamentWizard />);
+      result = render(<MemoryRouter><TournamentWizard /></MemoryRouter>);
     });
     return result;
   }
@@ -45,10 +46,10 @@ describe("TournamentWizard", () => {
 
     expect(screen.getByText("Tournament Setup Wizard")).toBeDefined();
 
-    fireEvent.click(screen.getByRole("button", { name: /Groups & Pools/i }));
+    fireEvent.click(screen.getByRole("button", { name: /^2\s*Groups & Pools/i }));
     expect(screen.getByRole("heading", { name: "Groups" })).toBeDefined();
 
-    fireEvent.click(screen.getByRole("button", { name: /Teams & Fixtures/i }));
+    fireEvent.click(screen.getByRole("button", { name: /^3\s*Teams & Fixtures/i }));
     expect(screen.getByRole("heading", { name: "Teams" })).toBeDefined();
     expect(screen.getByRole("heading", { name: "Fixtures" })).toBeDefined();
   });
@@ -63,7 +64,7 @@ describe("TournamentWizard", () => {
       target: { value: "2026" },
     });
 
-    fireEvent.click(screen.getByRole("button", { name: /Groups & Pools/i }));
+    fireEvent.click(screen.getByRole("button", { name: /^2\s*Groups & Pools/i }));
     fireEvent.change(screen.getByPlaceholderText("U11B"), {
       target: { value: "U11B" },
     });
@@ -71,7 +72,7 @@ describe("TournamentWizard", () => {
       target: { value: "U11 Boys" },
     });
 
-    fireEvent.click(screen.getByRole("button", { name: /Teams & Fixtures/i }));
+    fireEvent.click(screen.getByRole("button", { name: /^3\s*Teams & Fixtures/i }));
 
     const teamsSection = screen.getByRole("heading", { name: "Teams" }).closest("section");
     if (!teamsSection) throw new Error("Teams section not found");
@@ -105,7 +106,7 @@ describe("TournamentWizard", () => {
   it("generates fixtures for a group", async () => {
     await renderWizard();
 
-    fireEvent.click(screen.getByRole("button", { name: /Groups & Pools/i }));
+    fireEvent.click(screen.getByRole("button", { name: /^2\s*Groups & Pools/i }));
     fireEvent.change(screen.getByPlaceholderText("U11B"), {
       target: { value: "U11B" },
     });
@@ -113,7 +114,7 @@ describe("TournamentWizard", () => {
       target: { value: "U11 Boys" },
     });
 
-    fireEvent.click(screen.getByRole("button", { name: /Teams & Fixtures/i }));
+    fireEvent.click(screen.getByRole("button", { name: /^3\s*Teams & Fixtures/i }));
 
     const teamsSection = screen.getByRole("heading", { name: "Teams" }).closest("section");
     if (!teamsSection) throw new Error("Teams section not found");
@@ -158,7 +159,7 @@ describe("TournamentWizard", () => {
   it("updates and removes fixtures", async () => {
     await renderWizard();
 
-    fireEvent.click(screen.getByRole("button", { name: /Groups/i }));
+    fireEvent.click(screen.getByRole("button", { name: /^2\s*Groups/i }));
     fireEvent.change(screen.getByPlaceholderText("U11B"), {
       target: { value: "U11B" },
     });
@@ -166,7 +167,7 @@ describe("TournamentWizard", () => {
       target: { value: "U11 Boys" },
     });
 
-    fireEvent.click(screen.getByRole("button", { name: /Teams & Fixtures/i }));
+    fireEvent.click(screen.getByRole("button", { name: /^3\s*Teams & Fixtures/i }));
 
     const fixturesSection = screen.getByRole("heading", { name: "Fixtures" }).closest("section");
     if (!fixturesSection) throw new Error("Fixtures section not found");
@@ -222,7 +223,7 @@ describe("TournamentWizard", () => {
     await renderWizard();
 
     // Groups step: select venues (multi-select)
-    fireEvent.click(screen.getByRole("button", { name: /Groups & Pools/i }));
+    fireEvent.click(screen.getByRole("button", { name: /^2\s*Groups & Pools/i }));
 
     fireEvent.change(screen.getByPlaceholderText("U11B"), {
       target: { value: "U11B" },
@@ -243,7 +244,7 @@ describe("TournamentWizard", () => {
     fireEvent.change(venuesMultiSelect);
 
     // Teams & Fixtures step: manage time slots
-    fireEvent.click(screen.getByRole("button", { name: /Teams & Fixtures/i }));
+    fireEvent.click(screen.getByRole("button", { name: /^3\s*Teams & Fixtures/i }));
 
     const timeSlotsSection = screen.getByRole("heading", { name: "Time Slots" }).closest("section");
     if (!timeSlotsSection) throw new Error("Time Slots section not found");
@@ -270,7 +271,7 @@ describe("TournamentWizard", () => {
   it("supports imports and auto-assigning pools", async () => {
     await renderWizard();
 
-    fireEvent.click(screen.getByRole("button", { name: /Groups/i }));
+    fireEvent.click(screen.getByRole("button", { name: /^2\s*Groups/i }));
     fireEvent.change(screen.getByPlaceholderText("U11B"), {
       target: { value: "U11B" },
     });
@@ -280,7 +281,7 @@ describe("TournamentWizard", () => {
     const poolCountInput = screen.getByRole("spinbutton", { name: "Pool Count" });
     fireEvent.change(poolCountInput, { target: { value: "2" } });
 
-    fireEvent.click(screen.getByRole("button", { name: /Teams & Fixtures/i }));
+    fireEvent.click(screen.getByRole("button", { name: /^3\s*Teams & Fixtures/i }));
 
     const teamsSection = screen.getByRole("heading", { name: "Teams" }).closest("section");
     if (!teamsSection) throw new Error("Teams section not found");
@@ -312,7 +313,7 @@ describe("TournamentWizard", () => {
 
   it("shows generator validation errors when required fields are missing", async () => {
     await renderWizard();
-    fireEvent.click(screen.getByRole("button", { name: /Teams & Fixtures/i }));
+    fireEvent.click(screen.getByRole("button", { name: /^3\s*Teams & Fixtures/i }));
 
     const fixturesSection = screen.getByRole("heading", { name: "Fixtures" }).closest("section");
     if (!fixturesSection) throw new Error("Fixtures section not found");
@@ -346,14 +347,14 @@ describe("TournamentWizard", () => {
     fireEvent.change(screen.getByPlaceholderText("2026"), {
       target: { value: "2026" },
     });
-    fireEvent.click(screen.getByRole("button", { name: /Groups/i }));
+    fireEvent.click(screen.getByRole("button", { name: /^2\s*Groups/i }));
     fireEvent.change(screen.getByPlaceholderText("U11B"), {
       target: { value: "U11B" },
     });
     fireEvent.change(screen.getByPlaceholderText("U11 Boys"), {
       target: { value: "U11 Boys" },
     });
-    fireEvent.click(screen.getByRole("button", { name: /Teams & Fixtures/i }));
+    fireEvent.click(screen.getByRole("button", { name: /^3\s*Teams & Fixtures/i }));
 
     const teamsSection = screen.getByRole("heading", { name: "Teams" }).closest("section");
     if (!teamsSection) throw new Error("Teams section not found");
@@ -395,7 +396,7 @@ describe("TournamentWizard", () => {
     });
 
     await renderWizard();
-    fireEvent.click(screen.getByRole("button", { name: /Teams & Fixtures/i }));
+    fireEvent.click(screen.getByRole("button", { name: /^3\s*Teams & Fixtures/i }));
 
     await waitFor(() => {
       const datalist = document.querySelector("datalist");
@@ -423,7 +424,7 @@ describe("TournamentWizard", () => {
     });
 
     await renderWizard();
-    fireEvent.click(screen.getByRole("button", { name: /Teams & Fixtures/i }));
+    fireEvent.click(screen.getByRole("button", { name: /^3\s*Teams & Fixtures/i }));
 
     await waitFor(() => {
       const datalist = document.querySelector("datalist");


### PR DESCRIPTION
## Summary

- **#242** Back/Next buttons at the bottom of each step with validation guards (required fields on step 0, at least one complete group on step 1); removed duplicate "Create Tournament" from the wizard header
- **#245** Redirect to `/admin/fixtures` 1.5 s after successful tournament creation
- **#246** Venue empty-state now links to `/admin/venues` instead of plain text
- **#249** Tournament ID field shows a one-click "Use suggested" button when the auto-generated slug differs from what's typed
- **#250** Fixture time inputs changed from `type="text"` to `type="time"` for native time-picker UX

## Test plan

- [ ] All unit tests pass (`npm test -- --run`) — 2755/2756 pass; 1 failure is a pre-existing failure in an old `.claude/worktrees/` leftover, unrelated to this PR
- [ ] `MemoryRouter` added to `TournamentWizard.test.jsx` `renderWizard()` to satisfy `useNavigate` context requirement
- [ ] Step-header button selectors tightened (`/^2\s*Groups/i` etc.) to avoid ambiguity with new "Next: …" nav buttons

🤖 Generated with [Claude Code](https://claude.com/claude-code)