### PR TITLE
fix: admin console layout — full width, scroll, venue 2-col grid

### DIFF
--- a/src/styles/hj-tokens.css
+++ b/src/styles/hj-tokens.css
@@ -1961,7 +1961,6 @@ select {
 .admin-layout {
   display: flex;
   height: 100dvh;
-  overflow: hidden;
 }
 
 .admin-sidebar {
@@ -2036,6 +2035,8 @@ select {
 }
 
 .admin-content {
+  flex: 1;
+  min-width: 0;
   margin-left: 250px;
   padding: var(--hj-space-6);
   background-color: var(--hj-color-surface-1);
@@ -2043,6 +2044,19 @@ select {
   overflow-y: auto;
   box-sizing: border-box;
   color: var(--hj-color-text-primary);
+}
+
+/* Venue card grid */
+.venue-card-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: var(--hj-space-5);
+}
+
+@media (max-width: 768px) {
+  .venue-card-grid {
+    grid-template-columns: 1fr;
+  }
 }
 
 /* Teams list */

--- a/src/views/admin/VenuesPage.jsx
+++ b/src/views/admin/VenuesPage.jsx
@@ -191,13 +191,7 @@ export default function VenuesPage() {
         )}
 
         {!loading && venues.length > 0 && (
-          <div
-            style={{
-              display: 'grid',
-              gridTemplateColumns: 'repeat(auto-fill, minmax(320px, 1fr))',
-              gap: 'var(--hj-space-5)',
-            }}
-          >
+          <div className="venue-card-grid">
             {venues.map((venue) => {
               const embedSrc = mapEmbedUrl(venue);
               return (


### PR DESCRIPTION
## Summary

- **Dead zone removed** — `.admin-content` now has `flex: 1; min-width: 0`, filling the full viewport width after the sidebar on every admin page
- **Scroll restored** — removed `overflow: hidden` from `.admin-layout`; Venues, Teams, and Fixtures all scroll correctly
- **Venues 2-column grid** — extracted inline grid style to `.venue-card-grid` CSS class; 2 columns on desktop, 1 column below 768px; map thumbnails retained

## Test plan

- [ ] Venues — cards render in 2-column grid, page scrolls, no dead zone on right
- [ ] Teams — page scrolls, full width
- [ ] Fixtures — table fills full width, page scrolls
- [ ] Announcements / Tournaments / Dashboard — no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)