### PR TITLE
feat: franchise detail page — profile editor + teams registry

### DIFF
--- a/db/migrations/016_franchise_directory_profile.sql
+++ b/db/migrations/016_franchise_directory_profile.sql
@@ -1,0 +1,13 @@
+BEGIN;
+
+ALTER TABLE franchise_directory
+  ADD COLUMN IF NOT EXISTS manager_bio TEXT;
+
+ALTER TABLE franchise_directory
+  ADD COLUMN IF NOT EXISTS home_venue_id TEXT
+    REFERENCES venue_directory(id) ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS idx_franchise_directory_home_venue
+  ON franchise_directory (home_venue_id);
+
+COMMIT;

--- a/server/admin.mjs
+++ b/server/admin.mjs
@@ -809,8 +809,8 @@ export async function handleAdminRequest(req, res, { url, pool, sendJson, caches
     if (method === "GET") {
       try {
         const result = await pool.query(
-          `SELECT id, name, logo_url, manager_name, manager_photo_url, description,
-                  contact_phone, location_map_url, contact_email, created_at, updated_at
+          `SELECT id, name, logo_url, manager_name, manager_photo_url, manager_bio, description,
+                  contact_phone, location_map_url, contact_email, home_venue_id, created_at, updated_at
            FROM franchise_directory
            ORDER BY name ASC`
         );
@@ -830,21 +830,23 @@ export async function handleAdminRequest(req, res, { url, pool, sendJson, caches
 
         const result = await pool.query(
           `INSERT INTO franchise_directory (
-             name, logo_url, manager_name, manager_photo_url, description,
-             contact_phone, location_map_url, contact_email
+             name, logo_url, manager_name, manager_photo_url, manager_bio, description,
+             contact_phone, location_map_url, contact_email, home_venue_id
            )
-           VALUES ($1,$2,$3,$4,$5,$6,$7,$8)
-           RETURNING id, name, logo_url, manager_name, manager_photo_url, description,
-                     contact_phone, location_map_url, contact_email, created_at, updated_at`,
+           VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)
+           RETURNING id, name, logo_url, manager_name, manager_photo_url, manager_bio, description,
+                     contact_phone, location_map_url, contact_email, home_venue_id, created_at, updated_at`,
           [
             name,
             body.logo_url || null,
             body.manager_name || null,
             body.manager_photo_url || null,
+            body.manager_bio || null,
             body.description || null,
             body.contact_phone || null,
             body.location_map_url || null,
             body.contact_email || null,
+            body.home_venue_id || null,
           ]
         );
 
@@ -866,8 +868,55 @@ export async function handleAdminRequest(req, res, { url, pool, sendJson, caches
       return sendJson(req, res, 501, { ok: false, error: "DB not configured" });
     }
 
-    const id = normalizeSpaces(path.replace("/franchises/", ""));
+    const afterPrefix = path.replace("/franchises/", "");
+    const slashIdx = afterPrefix.indexOf("/");
+    const id = normalizeSpaces(slashIdx === -1 ? afterPrefix : afterPrefix.slice(0, slashIdx));
+    const subPath = slashIdx === -1 ? "" : afterPrefix.slice(slashIdx + 1);
+
     if (!id) return sendJson(req, res, 400, { ok: false, error: "Missing id" });
+
+    // GET /admin/franchises/:id/teams
+    if (subPath === "teams" && method === "GET") {
+      try {
+        const result = await pool.query(
+          `SELECT t.id AS team_id, t.name AS team_name, t.group_id,
+                  tr.id AS tournament_id, tr.name AS tournament_name, tr.season
+           FROM team t
+           JOIN tournament tr ON t.tournament_id = tr.id
+           JOIN franchise f ON f.tournament_id = t.tournament_id AND f.id = t.franchise_id
+           JOIN franchise_directory fd ON LOWER(fd.name) = LOWER(f.name)
+           WHERE fd.id = $1
+             AND t.is_placeholder = false
+           ORDER BY tr.season DESC NULLS LAST, t.group_id ASC, t.name ASC`,
+          [id]
+        );
+        return sendJson(req, res, 200, { ok: true, data: result.rows || [] });
+      } catch (err) {
+        console.error("Admin API Error:", err);
+        return sendJson(req, res, 500, { ok: false, error: err.message });
+      }
+    }
+
+    if (subPath) return sendJson(req, res, 404, { ok: false, error: "Not found" });
+
+    // GET /admin/franchises/:id
+    if (method === "GET") {
+      try {
+        const result = await pool.query(
+          `SELECT id, name, logo_url, manager_name, manager_photo_url, manager_bio, description,
+                  contact_phone, location_map_url, contact_email, home_venue_id, created_at, updated_at
+           FROM franchise_directory WHERE id = $1`,
+          [id]
+        );
+        if (result.rowCount === 0) {
+          return sendJson(req, res, 404, { ok: false, error: "Franchise not found" });
+        }
+        return sendJson(req, res, 200, { ok: true, data: result.rows[0] });
+      } catch (err) {
+        console.error("Admin API Error:", err);
+        return sendJson(req, res, 500, { ok: false, error: err.message });
+      }
+    }
 
     if (method === "PATCH") {
       try {
@@ -879,10 +928,12 @@ export async function handleAdminRequest(req, res, { url, pool, sendJson, caches
           logo_url: body.logo_url != null ? body.logo_url : null,
           manager_name: body.manager_name != null ? body.manager_name : null,
           manager_photo_url: body.manager_photo_url != null ? body.manager_photo_url : null,
+          manager_bio: body.manager_bio != null ? body.manager_bio : null,
           description: body.description != null ? body.description : null,
           contact_phone: body.contact_phone != null ? body.contact_phone : null,
           location_map_url: body.location_map_url != null ? body.location_map_url : null,
           contact_email: body.contact_email != null ? body.contact_email : null,
+          home_venue_id: body.home_venue_id != null ? body.home_venue_id : null,
         };
 
         const name = patch.name;
@@ -896,23 +947,27 @@ export async function handleAdminRequest(req, res, { url, pool, sendJson, caches
                   logo_url = COALESCE($3, logo_url),
                   manager_name = COALESCE($4, manager_name),
                   manager_photo_url = COALESCE($5, manager_photo_url),
-                  description = COALESCE($6, description),
-                  contact_phone = COALESCE($7, contact_phone),
-                  location_map_url = COALESCE($8, location_map_url),
-                  contact_email = COALESCE($9, contact_email)
+                  manager_bio = COALESCE($6, manager_bio),
+                  description = COALESCE($7, description),
+                  contact_phone = COALESCE($8, contact_phone),
+                  location_map_url = COALESCE($9, location_map_url),
+                  contact_email = COALESCE($10, contact_email),
+                  home_venue_id = COALESCE($11, home_venue_id)
             WHERE id = $1
-        RETURNING id, name, logo_url, manager_name, manager_photo_url, description,
-                  contact_phone, location_map_url, contact_email, created_at, updated_at`,
+        RETURNING id, name, logo_url, manager_name, manager_photo_url, manager_bio, description,
+                  contact_phone, location_map_url, contact_email, home_venue_id, created_at, updated_at`,
           [
             id,
             patch.name,
             patch.logo_url,
             patch.manager_name,
             patch.manager_photo_url,
+            patch.manager_bio,
             patch.description,
             patch.contact_phone,
             patch.location_map_url,
             patch.contact_email,
+            patch.home_venue_id,
           ]
         );
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -42,6 +42,7 @@ import FixturesPage from "./views/admin/FixturesPage";
 import TechDesk from "./views/admin/TechDesk";
 import VenuesPage from "./views/admin/VenuesPage";
 import FranchisesPage from "./views/admin/FranchisesPage";
+import FranchiseDetailPage from "./views/admin/FranchiseDetailPage";
 import AdminTeamsPage from "./views/admin/AdminTeamsPage";
 
 // Filter out placeholder “teams” like 1st Place, Loser SF1, A1, etc.
@@ -539,7 +540,9 @@ export default function App() {
               <Route path="tournaments" element={<TournamentWizard />} />
               <Route path="announcements" element={<AnnouncementsPage />} />
               <Route path="venues/*" element={<VenuesPage />} />
-              <Route path="franchises/*" element={<FranchisesPage />} />
+              <Route path="franchises" element={<FranchisesPage />} />
+              <Route path="franchises/new" element={<FranchisesPage />} />
+              <Route path="franchises/:franchiseId" element={<FranchiseDetailPage />} />
               <Route path="teams" element={<AdminTeamsPage />} />
               <Route path="fixtures" element={<FixturesPage />} />
               <Route path="tech-desk/:matchId" element={<TechDesk />} />

--- a/src/lib/franchiseApi.js
+++ b/src/lib/franchiseApi.js
@@ -22,6 +22,27 @@ export async function getFranchises() {
 }
 
 /**
+ * Fetch a single franchise by ID
+ * @param {string} id
+ */
+export async function getFranchise(id) {
+  const res = await adminFetch(`${endpoint()}/${id}`);
+  const json = await parseJson(res);
+  return json.data;
+}
+
+/**
+ * Fetch teams linked to a franchise, with tournament/season context
+ * @param {string} id
+ * @returns {Promise<Array>}
+ */
+export async function getFranchiseTeams(id) {
+  const res = await adminFetch(`${endpoint()}/${id}/teams`);
+  const json = await parseJson(res);
+  return json.data || [];
+}
+
+/**
  * Create a new franchise
  * @param {Object} franchiseData
  */

--- a/src/lib/franchiseApi.test.js
+++ b/src/lib/franchiseApi.test.js
@@ -33,6 +33,39 @@ describe('franchiseApi', () => {
     vi.unstubAllGlobals();
   });
 
+  it('getFranchise fetches single franchise by id', async () => {
+    adminFetch.mockResolvedValueOnce(okJson({ id: 'f1', name: 'Alpha' }));
+
+    const api = await import('./franchiseApi');
+    const result = await api.getFranchise('f1');
+
+    expect(adminFetch).toHaveBeenCalledWith('/admin/franchises/f1');
+    expect(result).toEqual({ id: 'f1', name: 'Alpha' });
+  });
+
+  it('getFranchiseTeams fetches teams for a franchise', async () => {
+    const teams = [{ team_id: 't1', team_name: 'Alpha U9', season: '2024-25' }];
+    adminFetch.mockResolvedValueOnce(okJson(teams));
+
+    const api = await import('./franchiseApi');
+    const result = await api.getFranchiseTeams('f1');
+
+    expect(adminFetch).toHaveBeenCalledWith('/admin/franchises/f1/teams');
+    expect(result).toEqual(teams);
+  });
+
+  it('getFranchiseTeams returns empty array when data is absent', async () => {
+    adminFetch.mockResolvedValueOnce(Promise.resolve({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ ok: true }),
+    }));
+
+    const api = await import('./franchiseApi');
+    const result = await api.getFranchiseTeams('f1');
+    expect(result).toEqual([]);
+  });
+
   it('getFranchises calls admin endpoint and returns data', async () => {
     adminFetch.mockResolvedValueOnce(okJson([{ id: 'f1', name: 'Alpha' }]));
 

--- a/src/views/admin/FranchiseDetailPage.jsx
+++ b/src/views/admin/FranchiseDetailPage.jsx
@@ -1,0 +1,387 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { getFranchise, getFranchiseTeams, updateFranchise } from '../../lib/franchiseApi';
+import { getVenues } from '../../lib/venueApi';
+
+const fieldStyle = {
+  width: '100%',
+  padding: '0.5rem 0.75rem',
+  borderRadius: 'var(--hj-radius-md)',
+  border: '1px solid var(--hj-color-border-subtle)',
+  background: 'var(--hj-color-surface-1)',
+  color: 'var(--hj-color-text-primary)',
+  fontSize: 'inherit',
+  boxSizing: 'border-box',
+};
+
+const labelStyle = {
+  display: 'block',
+  marginBottom: 'var(--hj-space-1)',
+  fontWeight: 'var(--hj-font-weight-semibold)',
+  fontSize: 'var(--hj-font-size-sm)',
+  color: 'var(--hj-color-text-primary)',
+};
+
+const fieldGroupStyle = {
+  marginBottom: 'var(--hj-space-4)',
+};
+
+export default function FranchiseDetailPage() {
+  const { franchiseId } = useParams();
+  const navigate = useNavigate();
+
+  const [franchise, setFranchise] = useState(null);
+  const [venues, setVenues] = useState([]);
+  const [teams, setTeams] = useState([]);
+  const [loadError, setLoadError] = useState(null);
+  const [teamsLoading, setTeamsLoading] = useState(true);
+
+  const [form, setForm] = useState({
+    name: '',
+    logo_url: '',
+    manager_name: '',
+    manager_photo_url: '',
+    manager_bio: '',
+    contact_phone: '',
+    contact_email: '',
+    home_venue_id: '',
+  });
+  const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState(null);
+  const [saved, setSaved] = useState(false);
+
+  const [openSeason, setOpenSeason] = useState(null);
+
+  useEffect(() => {
+    let alive = true;
+    Promise.all([getFranchise(franchiseId), getVenues()])
+      .then(([f, v]) => {
+        if (!alive) return;
+        setFranchise(f);
+        setForm({
+          name: f.name || '',
+          logo_url: f.logo_url || '',
+          manager_name: f.manager_name || '',
+          manager_photo_url: f.manager_photo_url || '',
+          manager_bio: f.manager_bio || '',
+          contact_phone: f.contact_phone || '',
+          contact_email: f.contact_email || '',
+          home_venue_id: f.home_venue_id || '',
+        });
+        setVenues(v);
+      })
+      .catch((err) => {
+        if (!alive) return;
+        setLoadError(err.message);
+      });
+    return () => { alive = false; };
+  }, [franchiseId]);
+
+  useEffect(() => {
+    let alive = true;
+    getFranchiseTeams(franchiseId)
+      .then((data) => {
+        if (!alive) return;
+        setTeams(data);
+        setTeamsLoading(false);
+      })
+      .catch(() => {
+        if (!alive) return;
+        setTeamsLoading(false);
+      });
+    return () => { alive = false; };
+  }, [franchiseId]);
+
+  const teamsBySeason = useMemo(() => {
+    const map = new Map();
+    for (const t of teams) {
+      const s = t.season || 'No season';
+      if (!map.has(s)) map.set(s, []);
+      map.get(s).push(t);
+    }
+    return map;
+  }, [teams]);
+
+  const setField = (field) => (e) => {
+    setForm((prev) => ({ ...prev, [field]: e.target.value }));
+    setSaved(false);
+  };
+
+  const handleSave = async (e) => {
+    e.preventDefault();
+    setSaving(true);
+    setSaveError(null);
+    setSaved(false);
+    try {
+      const updated = await updateFranchise(franchiseId, {
+        name: form.name,
+        logo_url: form.logo_url || null,
+        manager_name: form.manager_name || null,
+        manager_photo_url: form.manager_photo_url || null,
+        manager_bio: form.manager_bio || null,
+        contact_phone: form.contact_phone || null,
+        contact_email: form.contact_email || null,
+        home_venue_id: form.home_venue_id || null,
+      });
+      setFranchise(updated);
+      setSaved(true);
+    } catch (err) {
+      setSaveError(err.message);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (loadError) {
+    return (
+      <div role="alert" style={{ color: '#c00', padding: 'var(--hj-space-4)' }}>
+        {loadError}
+      </div>
+    );
+  }
+
+  if (!franchise) {
+    return <div style={{ padding: 'var(--hj-space-4)' }}>Loading…</div>;
+  }
+
+  return (
+    <div style={{ maxWidth: 720 }}>
+      <button
+        type="button"
+        onClick={() => navigate('/admin/franchises')}
+        style={{
+          background: 'none',
+          border: 'none',
+          cursor: 'pointer',
+          color: 'var(--hj-color-brand-primary)',
+          padding: 0,
+          fontSize: 'var(--hj-font-size-sm)',
+        }}
+      >
+        ← Back to Franchises
+      </button>
+
+      <h1 style={{ marginTop: 'var(--hj-space-3)', marginBottom: 'var(--hj-space-6)' }}>
+        {franchise.name}
+      </h1>
+
+      {/* ── Profile ── */}
+      <section style={{ marginBottom: 'var(--hj-space-8)' }}>
+        <h2 style={{ marginBottom: 'var(--hj-space-4)', fontSize: 'var(--hj-font-size-lg)' }}>
+          Profile
+        </h2>
+
+        <form onSubmit={handleSave} noValidate>
+          <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 'var(--hj-space-4)' }}>
+
+            <div style={{ ...fieldGroupStyle, gridColumn: '1 / -1' }}>
+              <label htmlFor="fd-name" style={labelStyle}>Franchise name *</label>
+              <input
+                id="fd-name"
+                type="text"
+                value={form.name}
+                onChange={setField('name')}
+                required
+                style={fieldStyle}
+              />
+            </div>
+
+            <div style={fieldGroupStyle}>
+              <label htmlFor="fd-logo-url" style={labelStyle}>Logo URL</label>
+              <input
+                id="fd-logo-url"
+                type="url"
+                value={form.logo_url}
+                onChange={setField('logo_url')}
+                placeholder="https://…"
+                style={fieldStyle}
+              />
+              {form.logo_url && (
+                <img
+                  src={form.logo_url}
+                  alt="Logo preview"
+                  style={{ marginTop: 'var(--hj-space-2)', height: 48, objectFit: 'contain' }}
+                />
+              )}
+            </div>
+
+            <div style={fieldGroupStyle}>
+              <label htmlFor="fd-home-venue" style={labelStyle}>Home venue</label>
+              <select
+                id="fd-home-venue"
+                value={form.home_venue_id}
+                onChange={setField('home_venue_id')}
+                style={fieldStyle}
+              >
+                <option value="">— None —</option>
+                {venues.map((v) => (
+                  <option key={v.id} value={v.id}>{v.name}</option>
+                ))}
+              </select>
+            </div>
+
+            <div style={fieldGroupStyle}>
+              <label htmlFor="fd-manager-name" style={labelStyle}>Manager name</label>
+              <input
+                id="fd-manager-name"
+                type="text"
+                value={form.manager_name}
+                onChange={setField('manager_name')}
+                style={fieldStyle}
+              />
+            </div>
+
+            <div style={fieldGroupStyle}>
+              <label htmlFor="fd-manager-photo" style={labelStyle}>Manager photo URL</label>
+              <input
+                id="fd-manager-photo"
+                type="url"
+                value={form.manager_photo_url}
+                onChange={setField('manager_photo_url')}
+                placeholder="https://…"
+                style={fieldStyle}
+              />
+              {form.manager_photo_url && (
+                <img
+                  src={form.manager_photo_url}
+                  alt="Manager photo preview"
+                  style={{ marginTop: 'var(--hj-space-2)', height: 48, width: 48, objectFit: 'cover', borderRadius: '50%' }}
+                />
+              )}
+            </div>
+
+            <div style={{ ...fieldGroupStyle, gridColumn: '1 / -1' }}>
+              <label htmlFor="fd-manager-bio" style={labelStyle}>Manager bio</label>
+              <textarea
+                id="fd-manager-bio"
+                value={form.manager_bio}
+                onChange={setField('manager_bio')}
+                rows={3}
+                style={{ ...fieldStyle, resize: 'vertical' }}
+              />
+            </div>
+
+            <div style={fieldGroupStyle}>
+              <label htmlFor="fd-phone" style={labelStyle}>Phone</label>
+              <input
+                id="fd-phone"
+                type="tel"
+                value={form.contact_phone}
+                onChange={setField('contact_phone')}
+                style={fieldStyle}
+              />
+            </div>
+
+            <div style={fieldGroupStyle}>
+              <label htmlFor="fd-email" style={labelStyle}>Email</label>
+              <input
+                id="fd-email"
+                type="email"
+                value={form.contact_email}
+                onChange={setField('contact_email')}
+                style={fieldStyle}
+              />
+            </div>
+
+          </div>
+
+          <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--hj-space-3)', marginTop: 'var(--hj-space-2)' }}>
+            <button
+              type="submit"
+              disabled={saving}
+              className="admin-btn-primary"
+            >
+              {saving ? 'Saving…' : 'Save changes'}
+            </button>
+            {saved && (
+              <span style={{ color: 'var(--hj-color-success, #16a34a)', fontSize: 'var(--hj-font-size-sm)' }}>
+                Saved.
+              </span>
+            )}
+            {saveError && (
+              <span style={{ color: '#c00', fontSize: 'var(--hj-font-size-sm)' }}>
+                {saveError}
+              </span>
+            )}
+          </div>
+        </form>
+      </section>
+
+      <hr style={{ border: 'none', borderTop: '1px solid var(--hj-color-border-subtle)', marginBottom: 'var(--hj-space-8)' }} />
+
+      {/* ── Teams registry ── */}
+      <section>
+        <h2 style={{ marginBottom: 'var(--hj-space-4)', fontSize: 'var(--hj-font-size-lg)' }}>
+          Teams
+        </h2>
+
+        {teamsLoading && <div>Loading teams…</div>}
+
+        {!teamsLoading && teams.length === 0 && (
+          <div style={{ color: 'var(--hj-color-text-secondary)', fontSize: 'var(--hj-font-size-sm)' }}>
+            No teams linked to this franchise yet.
+          </div>
+        )}
+
+        {!teamsLoading && teams.length > 0 && (
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--hj-space-2)' }}>
+            {[...teamsBySeason.entries()].map(([season, seasonTeams]) => (
+              <div
+                key={season}
+                style={{
+                  border: '1px solid var(--hj-color-border-subtle)',
+                  borderRadius: 'var(--hj-radius-md)',
+                  overflow: 'hidden',
+                }}
+              >
+                <button
+                  type="button"
+                  onClick={() => setOpenSeason(openSeason === season ? null : season)}
+                  style={{
+                    width: '100%',
+                    display: 'flex',
+                    justifyContent: 'space-between',
+                    alignItems: 'center',
+                    padding: 'var(--hj-space-3) var(--hj-space-4)',
+                    background: openSeason === season ? 'var(--hj-color-surface-2)' : 'var(--hj-color-surface-1)',
+                    border: 'none',
+                    cursor: 'pointer',
+                    textAlign: 'left',
+                    fontWeight: 'var(--hj-font-weight-semibold)',
+                    color: 'var(--hj-color-text-primary)',
+                  }}
+                >
+                  <span>{season}</span>
+                  <span style={{ color: 'var(--hj-color-text-secondary)', fontSize: 'var(--hj-font-size-sm)' }}>
+                    {seasonTeams.length} team{seasonTeams.length !== 1 ? 's' : ''} {openSeason === season ? '▲' : '▼'}
+                  </span>
+                </button>
+
+                {openSeason === season && (
+                  <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+                    <thead>
+                      <tr style={{ borderBottom: '1px solid var(--hj-color-border-subtle)', background: 'var(--hj-color-surface-muted)' }}>
+                        <th style={{ padding: 'var(--hj-space-2) var(--hj-space-4)', textAlign: 'left', fontSize: 'var(--hj-font-size-sm)', fontWeight: 'var(--hj-font-weight-semibold)' }}>Team</th>
+                        <th style={{ padding: 'var(--hj-space-2) var(--hj-space-4)', textAlign: 'left', fontSize: 'var(--hj-font-size-sm)', fontWeight: 'var(--hj-font-weight-semibold)' }}>Division</th>
+                        <th style={{ padding: 'var(--hj-space-2) var(--hj-space-4)', textAlign: 'left', fontSize: 'var(--hj-font-size-sm)', fontWeight: 'var(--hj-font-weight-semibold)' }}>Tournament</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {seasonTeams.map((t) => (
+                        <tr key={`${t.tournament_id}-${t.team_id}`} style={{ borderBottom: '1px solid var(--hj-color-border-subtle)' }}>
+                          <td style={{ padding: 'var(--hj-space-2) var(--hj-space-4)', fontSize: 'var(--hj-font-size-sm)' }}>{t.team_name}</td>
+                          <td style={{ padding: 'var(--hj-space-2) var(--hj-space-4)', fontSize: 'var(--hj-font-size-sm)', color: 'var(--hj-color-text-secondary)' }}>{t.group_id}</td>
+                          <td style={{ padding: 'var(--hj-space-2) var(--hj-space-4)', fontSize: 'var(--hj-font-size-sm)', color: 'var(--hj-color-text-secondary)' }}>{t.tournament_name}</td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/src/views/admin/FranchiseDetailPage.test.jsx
+++ b/src/views/admin/FranchiseDetailPage.test.jsx
@@ -73,6 +73,32 @@ describe('FranchiseDetailPage', () => {
     expect(screen.getByRole('option', { name: 'North Rink' })).toBeInTheDocument();
   });
 
+  it('sends null for empty optional fields on save', async () => {
+    franchiseApi.getFranchise.mockResolvedValue({
+      ...mockFranchise,
+      manager_name: '',
+      manager_bio: '',
+      contact_phone: '',
+      contact_email: '',
+      home_venue_id: '',
+    });
+    franchiseApi.updateFranchise.mockResolvedValue({ ...mockFranchise });
+    renderDetail();
+    await screen.findByRole('heading', { name: 'Alpha FC' });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save changes' }));
+
+    await waitFor(() => {
+      expect(franchiseApi.updateFranchise).toHaveBeenCalledWith('f1', expect.objectContaining({
+        manager_name: null,
+        manager_bio: null,
+        contact_phone: null,
+        contact_email: null,
+        home_venue_id: null,
+      }));
+    });
+  });
+
   it('saves changes and shows saved confirmation', async () => {
     franchiseApi.updateFranchise.mockResolvedValue({ ...mockFranchise, manager_name: 'New Coach' });
     renderDetail();
@@ -121,6 +147,21 @@ describe('FranchiseDetailPage', () => {
     expect(screen.getAllByText('Spring Cup').length).toBeGreaterThan(0);
   });
 
+  it('shows loading state while teams are fetching', async () => {
+    franchiseApi.getFranchiseTeams.mockReturnValue(new Promise(() => {}));
+    renderDetail();
+    await screen.findByRole('heading', { name: 'Alpha FC' });
+    expect(screen.getByText('Loading teams…')).toBeInTheDocument();
+  });
+
+  it('groups teams with no season under "No season"', async () => {
+    franchiseApi.getFranchiseTeams.mockResolvedValue([
+      { team_id: 't1', team_name: 'Alpha U9', group_id: 'U9', tournament_id: 'tr1', tournament_name: 'Spring Cup', season: null },
+    ]);
+    renderDetail();
+    await screen.findByText('No season');
+  });
+
   it('shows empty teams message when no teams', async () => {
     franchiseApi.getFranchiseTeams.mockResolvedValue([]);
     renderDetail();
@@ -132,6 +173,50 @@ describe('FranchiseDetailPage', () => {
     franchiseApi.getFranchise.mockRejectedValue(new Error('Not found'));
     renderDetail();
     expect(await screen.findByText('Not found')).toBeInTheDocument();
+  });
+
+  it('editing a field clears saved state', async () => {
+    franchiseApi.updateFranchise.mockResolvedValue({ ...mockFranchise });
+    renderDetail();
+    await screen.findByRole('heading', { name: 'Alpha FC' });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save changes' }));
+    await screen.findByText('Saved.');
+
+    fireEvent.change(screen.getByDisplayValue('Coach A'), { target: { value: 'New Coach' } });
+    expect(screen.queryByText('Saved.')).not.toBeInTheDocument();
+  });
+
+  it('still renders when teams fetch fails', async () => {
+    franchiseApi.getFranchiseTeams.mockRejectedValue(new Error('Teams unavailable'));
+    renderDetail();
+    expect(await screen.findByRole('heading', { name: 'Alpha FC' })).toBeInTheDocument();
+    expect(await screen.findByText(/No teams linked/)).toBeInTheDocument();
+  });
+
+  it('shows logo preview when logo_url is set', async () => {
+    franchiseApi.getFranchise.mockResolvedValue({ ...mockFranchise, logo_url: 'https://example.com/logo.png' });
+    renderDetail();
+    await screen.findByRole('heading', { name: 'Alpha FC' });
+    expect(screen.getByAltText('Logo preview')).toBeInTheDocument();
+  });
+
+  it('shows manager photo preview when manager_photo_url is set', async () => {
+    franchiseApi.getFranchise.mockResolvedValue({ ...mockFranchise, manager_photo_url: 'https://example.com/photo.png' });
+    renderDetail();
+    await screen.findByRole('heading', { name: 'Alpha FC' });
+    expect(screen.getByAltText('Manager photo preview')).toBeInTheDocument();
+  });
+
+  it('collapses expanded season accordion on second click', async () => {
+    renderDetail();
+    await screen.findByText('2024-25');
+
+    fireEvent.click(screen.getByText('2024-25'));
+    expect(await screen.findByText('Alpha U9')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('2024-25'));
+    expect(screen.queryByText('Alpha U9')).not.toBeInTheDocument();
   });
 
   it('back button navigates to franchise list', async () => {

--- a/src/views/admin/FranchiseDetailPage.test.jsx
+++ b/src/views/admin/FranchiseDetailPage.test.jsx
@@ -1,0 +1,145 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import FranchiseDetailPage from './FranchiseDetailPage';
+import * as franchiseApi from '../../lib/franchiseApi';
+import * as venueApi from '../../lib/venueApi';
+
+vi.mock('../../lib/franchiseApi');
+vi.mock('../../lib/venueApi');
+
+const mockFranchise = {
+  id: 'f1',
+  name: 'Alpha FC',
+  logo_url: '',
+  manager_name: 'Coach A',
+  manager_photo_url: '',
+  manager_bio: 'Great coach',
+  contact_phone: '555-1234',
+  contact_email: 'alpha@example.com',
+  home_venue_id: 'v1',
+};
+
+const mockVenues = [
+  { id: 'v1', name: 'Main Rink' },
+  { id: 'v2', name: 'North Rink' },
+];
+
+const mockTeams = [
+  { team_id: 't1', team_name: 'Alpha U9', group_id: 'U9', tournament_id: 'tr1', tournament_name: 'Spring Cup', season: '2024-25' },
+  { team_id: 't2', team_name: 'Alpha U12', group_id: 'U12', tournament_id: 'tr1', tournament_name: 'Spring Cup', season: '2024-25' },
+  { team_id: 't3', team_name: 'Alpha U9', group_id: 'U9', tournament_id: 'tr2', tournament_name: 'Fall Classic', season: '2023-24' },
+];
+
+function renderDetail(id = 'f1') {
+  return render(
+    <MemoryRouter initialEntries={[`/admin/franchises/${id}`]}>
+      <Routes>
+        <Route path="/admin/franchises/:franchiseId" element={<FranchiseDetailPage />} />
+        <Route path="/admin/franchises" element={<div>Franchises list</div>} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+describe('FranchiseDetailPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    franchiseApi.getFranchise.mockResolvedValue(mockFranchise);
+    franchiseApi.getFranchiseTeams.mockResolvedValue(mockTeams);
+    venueApi.getVenues.mockResolvedValue(mockVenues);
+  });
+
+  it('renders franchise name as heading', async () => {
+    renderDetail();
+    expect(await screen.findByRole('heading', { name: 'Alpha FC' })).toBeInTheDocument();
+  });
+
+  it('pre-fills form fields from franchise data', async () => {
+    renderDetail();
+    expect(await screen.findByDisplayValue('Coach A')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('alpha@example.com')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('555-1234')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('Great coach')).toBeInTheDocument();
+  });
+
+  it('populates home venue dropdown', async () => {
+    renderDetail();
+    await screen.findByRole('heading', { name: 'Alpha FC' });
+    const select = screen.getByLabelText('Home venue');
+    expect(select).toHaveValue('v1');
+    expect(screen.getByRole('option', { name: 'Main Rink' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'North Rink' })).toBeInTheDocument();
+  });
+
+  it('saves changes and shows saved confirmation', async () => {
+    franchiseApi.updateFranchise.mockResolvedValue({ ...mockFranchise, manager_name: 'New Coach' });
+    renderDetail();
+    await screen.findByRole('heading', { name: 'Alpha FC' });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save changes' }));
+
+    await waitFor(() => {
+      expect(franchiseApi.updateFranchise).toHaveBeenCalledWith('f1', expect.objectContaining({
+        name: 'Alpha FC',
+        manager_name: 'Coach A',
+      }));
+    });
+    expect(await screen.findByText('Saved.')).toBeInTheDocument();
+  });
+
+  it('shows error when save fails', async () => {
+    franchiseApi.updateFranchise.mockRejectedValue(new Error('Save failed'));
+    renderDetail();
+    await screen.findByRole('heading', { name: 'Alpha FC' });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save changes' }));
+
+    expect(await screen.findByText('Save failed')).toBeInTheDocument();
+  });
+
+  it('shows teams grouped by season as collapsed accordions', async () => {
+    renderDetail();
+    await screen.findByRole('heading', { name: 'Alpha FC' });
+    await screen.findByText('2024-25');
+
+    expect(screen.getByText('2024-25')).toBeInTheDocument();
+    expect(screen.getByText('2023-24')).toBeInTheDocument();
+    // Rows are collapsed — team names not visible yet
+    expect(screen.queryByText('Alpha U9')).not.toBeInTheDocument();
+  });
+
+  it('expands a season row on click to show teams', async () => {
+    renderDetail();
+    await screen.findByText('2024-25');
+
+    fireEvent.click(screen.getByText('2024-25'));
+
+    expect(await screen.findByText('Alpha U9')).toBeInTheDocument();
+    expect(screen.getByText('Alpha U12')).toBeInTheDocument();
+    expect(screen.getAllByText('Spring Cup').length).toBeGreaterThan(0);
+  });
+
+  it('shows empty teams message when no teams', async () => {
+    franchiseApi.getFranchiseTeams.mockResolvedValue([]);
+    renderDetail();
+    await screen.findByRole('heading', { name: 'Alpha FC' });
+    expect(await screen.findByText(/No teams linked/)).toBeInTheDocument();
+  });
+
+  it('shows load error when franchise fetch fails', async () => {
+    franchiseApi.getFranchise.mockRejectedValue(new Error('Not found'));
+    renderDetail();
+    expect(await screen.findByText('Not found')).toBeInTheDocument();
+  });
+
+  it('back button navigates to franchise list', async () => {
+    renderDetail();
+    await screen.findByRole('heading', { name: 'Alpha FC' });
+
+    fireEvent.click(screen.getByRole('button', { name: /back to franchises/i }));
+
+    expect(await screen.findByText('Franchises list')).toBeInTheDocument();
+  });
+});

--- a/src/views/admin/FranchisesPage.jsx
+++ b/src/views/admin/FranchisesPage.jsx
@@ -1,35 +1,23 @@
-import React, { useEffect, useMemo, useState } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import React, { useEffect, useState } from 'react';
+import { Link, useLocation, useNavigate } from 'react-router-dom';
 import FranchiseForm from './FranchiseForm';
 import {
   createFranchise,
   deleteFranchise,
   getFranchises,
-  updateFranchise,
 } from '../../lib/franchiseApi';
 
 export default function FranchisesPage() {
-  const params = useParams();
-  // FranchisesPage is mounted under `/admin/franchises/*` in App.jsx, so React Router
-  // stores the trailing segment in the `*` param, not `franchiseId`.
-  const franchiseId = params.franchiseId || (params['*'] ? params['*'].split('/')[0] : undefined);
+  const location = useLocation();
   const navigate = useNavigate();
+  const isNew = location.pathname.endsWith('/new');
 
   const [franchises, setFranchises] = useState([]);
-  const [currentFranchise, setCurrentFranchise] = useState(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
-  const isNew = franchiseId === 'new';
-  const isEditing = Boolean(franchiseId && franchiseId !== 'new');
-  const showForm = isNew || isEditing;
-
-  const franchiseById = useMemo(() => {
-    const map = new Map(franchises.map((f) => [String(f.id), f]));
-    return map;
-  }, [franchises]);
 
   useEffect(() => {
-    if (showForm) return;
+    if (isNew) return;
 
     let alive = true;
     (async () => {
@@ -48,34 +36,16 @@ export default function FranchisesPage() {
       }
     })();
 
-    return () => {
-      alive = false;
-    };
-  }, [showForm]);
-
-  useEffect(() => {
-    if (!isEditing) {
-      setCurrentFranchise(null);
-      return;
-    }
-
-    setCurrentFranchise(franchiseById.get(String(franchiseId)) || null);
-  }, [isEditing, franchiseId, franchiseById]);
+    return () => { alive = false; };
+  }, [isNew]);
 
   const handleSave = async (formData) => {
     try {
       setLoading(true);
       setError(null);
-
-      if (isNew) {
-        await createFranchise(formData);
-      } else if (isEditing) {
-        await updateFranchise(franchiseId, formData);
-      }
-
+      await createFranchise(formData);
       const data = await getFranchises();
       setFranchises(Array.isArray(data) ? data : []);
-      setCurrentFranchise(null);
       navigate('/admin/franchises', { replace: true });
     } catch (err) {
       setError(`Failed to save franchise: ${err.message}`);
@@ -103,16 +73,15 @@ export default function FranchisesPage() {
   };
 
   const handleCancel = () => {
-    setCurrentFranchise(null);
     navigate('/admin/franchises', { replace: true });
   };
 
-  if (showForm) {
+  if (isNew) {
     return (
       <div>
-        <h1 style={{ marginBottom: 'var(--hj-space-4)' }}>{isNew ? 'Create Franchise' : 'Edit Franchise'}</h1>
+        <h1 style={{ marginBottom: 'var(--hj-space-4)' }}>Create Franchise</h1>
         <FranchiseForm
-          franchise={currentFranchise}
+          franchise={null}
           onSave={handleSave}
           onCancel={handleCancel}
           isLoading={loading}
@@ -224,7 +193,18 @@ export default function FranchisesPage() {
                 key={franchise.id}
                 style={{ borderBottom: '1px solid var(--hj-color-border-subtle)' }}
               >
-                <td style={{ padding: 'var(--hj-space-3)' }}>{franchise.name}</td>
+                <td style={{ padding: 'var(--hj-space-3)' }}>
+                  <Link
+                    to={`/admin/franchises/${franchise.id}`}
+                    style={{
+                      color: 'var(--hj-color-brand-primary)',
+                      textDecoration: 'none',
+                      fontWeight: 'var(--hj-font-weight-semibold)',
+                    }}
+                  >
+                    {franchise.name}
+                  </Link>
+                </td>
                 <td style={{ padding: 'var(--hj-space-3)' }}>{franchise.manager_name || '—'}</td>
                 <td
                   style={{

--- a/src/views/admin/FranchisesPage.test.jsx
+++ b/src/views/admin/FranchisesPage.test.jsx
@@ -28,22 +28,7 @@ const renderPage = (route = '/admin/franchises') => {
     <BrowserRouter>
       <Routes>
         <Route path="/admin/franchises" element={<FranchisesPage />} />
-        <Route path="/admin/franchises/:franchiseId" element={<FranchisesPage />} />
-      </Routes>
-    </BrowserRouter>
-  );
-};
-
-// Uses the wildcard route pattern that App.jsx actually registers:
-//   <Route path="franchises/*" element={<FranchisesPage />} />
-// With this pattern useParams() returns { '*': 'new' } not { franchiseId: 'new' },
-// which is exactly the bug this test is guarding against.
-const renderPageWildcard = (route = '/admin/franchises') => {
-  window.history.pushState({}, 'Test page', route);
-  return render(
-    <BrowserRouter>
-      <Routes>
-        <Route path="/admin/franchises/*" element={<FranchisesPage />} />
+        <Route path="/admin/franchises/new" element={<FranchisesPage />} />
       </Routes>
     </BrowserRouter>
   );
@@ -72,6 +57,15 @@ describe('FranchisesPage', () => {
     expect(await screen.findByText('Franchises')).toBeInTheDocument();
     expect(await screen.findByText('Alpha')).toBeInTheDocument();
     expect(screen.getByText('Coach A')).toBeInTheDocument();
+  });
+
+  it('franchise names render as links to the detail page', async () => {
+    franchiseApi.getFranchises.mockResolvedValue(mockFranchises);
+
+    renderPage('/admin/franchises');
+
+    const link = await screen.findByRole('link', { name: 'Alpha' });
+    expect(link).toHaveAttribute('href', '/admin/franchises/f1');
   });
 
   it('shows empty state when no franchises', async () => {
@@ -107,40 +101,6 @@ describe('FranchisesPage', () => {
     fireEvent.click(screen.getByText('Save'));
 
     expect(await screen.findByText(/Failed to save franchise: Create failed/)).toBeInTheDocument();
-  });
-
-  it('updates a franchise then returns to list view', async () => {
-    franchiseApi.updateFranchise.mockResolvedValue({ id: 'f1' });
-    franchiseApi.getFranchises.mockResolvedValueOnce(mockFranchises);
-    franchiseApi.getFranchises.mockResolvedValueOnce([{ id: 'f1', name: 'Test Franchise' }]);
-
-    renderPage('/admin/franchises/f1');
-
-    expect(await screen.findByText('Edit Franchise')).toBeInTheDocument();
-    fireEvent.click(screen.getByText('Save'));
-
-    await waitFor(() => {
-      expect(franchiseApi.updateFranchise).toHaveBeenCalledWith('f1', { name: 'Test Franchise' });
-    });
-
-    expect(await screen.findByText('Franchises')).toBeInTheDocument();
-  });
-
-  it('renders create form at /new via wildcard route (App.jsx pattern)', async () => {
-    // Regression test for the useParams() routing bug:
-    // App.jsx registers <Route path="franchises/*">, so useParams() returns { '*': 'new' }
-    // not { franchiseId: 'new' }. The fix reads params['*'] as fallback.
-    renderPageWildcard('/admin/franchises/new');
-
-    expect(await screen.findByText('Create Franchise')).toBeInTheDocument();
-  });
-
-  it('renders edit form at /:id via wildcard route (App.jsx pattern)', async () => {
-    franchiseApi.getFranchises.mockResolvedValue(mockFranchises);
-
-    renderPageWildcard('/admin/franchises/f1');
-
-    expect(await screen.findByText('Edit Franchise')).toBeInTheDocument();
   });
 
   it('delete confirmation cancel does not delete', async () => {

--- a/src/views/admin/FranchisesPage.test.jsx
+++ b/src/views/admin/FranchisesPage.test.jsx
@@ -29,6 +29,7 @@ const renderPage = (route = '/admin/franchises') => {
       <Routes>
         <Route path="/admin/franchises" element={<FranchisesPage />} />
         <Route path="/admin/franchises/new" element={<FranchisesPage />} />
+        <Route path="/admin/franchises/:id" element={<div>Franchise detail</div>} />
       </Routes>
     </BrowserRouter>
   );
@@ -47,6 +48,14 @@ describe('FranchisesPage', () => {
   afterEach(() => {
     vi.clearAllMocks();
     vi.unstubAllGlobals();
+  });
+
+  it('shows error when initial load fails', async () => {
+    franchiseApi.getFranchises.mockRejectedValue(new Error('Network down'));
+
+    renderPage('/admin/franchises');
+
+    expect(await screen.findByText(/Failed to load franchises: Network down/)).toBeInTheDocument();
   });
 
   it('renders list on load', async () => {
@@ -116,5 +125,69 @@ describe('FranchisesPage', () => {
     fireEvent.click(deleteButtons[0]);
 
     expect(franchiseApi.deleteFranchise).not.toHaveBeenCalled();
+  });
+
+  it('deletes franchise and refreshes list on confirm', async () => {
+    franchiseApi.getFranchises
+      .mockResolvedValueOnce(mockFranchises)
+      .mockResolvedValueOnce([{ id: 'f2', name: 'Beta', manager_name: '' }]);
+    franchiseApi.deleteFranchise.mockResolvedValue();
+
+    vi.stubGlobal('confirm', vi.fn(() => true));
+
+    renderPage('/admin/franchises');
+
+    expect(await screen.findByText('Alpha')).toBeInTheDocument();
+    const deleteButtons = screen.getAllByText('Delete');
+    fireEvent.click(deleteButtons[0]);
+
+    await waitFor(() => expect(franchiseApi.deleteFranchise).toHaveBeenCalledWith('f1'));
+    expect(await screen.findByText('Beta')).toBeInTheDocument();
+  });
+
+  it('shows error when delete fails', async () => {
+    franchiseApi.getFranchises.mockResolvedValue(mockFranchises);
+    franchiseApi.deleteFranchise.mockRejectedValue(new Error('Delete failed'));
+
+    vi.stubGlobal('confirm', vi.fn(() => true));
+
+    renderPage('/admin/franchises');
+
+    expect(await screen.findByText('Alpha')).toBeInTheDocument();
+    fireEvent.click(screen.getAllByText('Delete')[0]);
+
+    expect(await screen.findByText(/Failed to delete franchise: Delete failed/)).toBeInTheDocument();
+  });
+
+  it('Add Franchise button navigates to /new', async () => {
+    franchiseApi.getFranchises.mockResolvedValue(mockFranchises);
+
+    renderPage('/admin/franchises');
+
+    await screen.findByText('Alpha');
+    fireEvent.click(screen.getByText('+ Add Franchise'));
+
+    expect(await screen.findByText('Create Franchise')).toBeInTheDocument();
+  });
+
+  it('Edit button navigates to franchise detail page', async () => {
+    franchiseApi.getFranchises.mockResolvedValue(mockFranchises);
+
+    renderPage('/admin/franchises');
+
+    await screen.findByText('Alpha');
+    const editButtons = screen.getAllByText('Edit');
+    fireEvent.click(editButtons[0]);
+
+    expect(await screen.findByText('Franchise detail')).toBeInTheDocument();
+  });
+
+  it('cancel on new franchise form navigates back to list', async () => {
+    renderPage('/admin/franchises/new');
+
+    expect(await screen.findByText('Create Franchise')).toBeInTheDocument();
+    fireEvent.click(screen.getByText('Cancel'));
+
+    expect(await screen.findByText('Franchises')).toBeInTheDocument();
   });
 });

--- a/test/server/admin.test.js
+++ b/test/server/admin.test.js
@@ -849,6 +849,76 @@ describe('handleAdminRequest', () => {
         );
     });
 
+    it('GET /franchises/:id returns single franchise', async () => {
+        const url = new URL('http://localhost/api/admin/franchises/f1');
+        mockPool.query.mockResolvedValueOnce({ rows: [{ id: 'f1', name: 'Alpha' }], rowCount: 1 });
+
+        await handleAdminRequest(mockReq, mockRes, { url, pool: mockPool, sendJson: mockSendJson });
+
+        expect(mockSendJson).toHaveBeenCalledWith(
+            mockReq,
+            mockRes,
+            200,
+            expect.objectContaining({ ok: true, data: expect.objectContaining({ id: 'f1' }) })
+        );
+    });
+
+    it('GET /franchises/:id returns 404 when not found', async () => {
+        const url = new URL('http://localhost/api/admin/franchises/missing');
+        mockPool.query.mockResolvedValueOnce({ rows: [], rowCount: 0 });
+
+        await handleAdminRequest(mockReq, mockRes, { url, pool: mockPool, sendJson: mockSendJson });
+
+        expect(mockSendJson).toHaveBeenCalledWith(
+            mockReq,
+            mockRes,
+            404,
+            expect.objectContaining({ ok: false, error: 'Franchise not found' })
+        );
+    });
+
+    it('GET /franchises/:id/teams returns team list', async () => {
+        const url = new URL('http://localhost/api/admin/franchises/f1/teams');
+        const teams = [{ team_id: 't1', team_name: 'Alpha U9', season: '2024-25' }];
+        mockPool.query.mockResolvedValueOnce({ rows: teams });
+
+        await handleAdminRequest(mockReq, mockRes, { url, pool: mockPool, sendJson: mockSendJson });
+
+        expect(mockSendJson).toHaveBeenCalledWith(
+            mockReq,
+            mockRes,
+            200,
+            expect.objectContaining({ ok: true, data: teams })
+        );
+    });
+
+    it('GET /franchises/:id/teams returns 500 on DB error', async () => {
+        const url = new URL('http://localhost/api/admin/franchises/f1/teams');
+        mockPool.query.mockRejectedValueOnce(new Error('Query failed'));
+
+        await handleAdminRequest(mockReq, mockRes, { url, pool: mockPool, sendJson: mockSendJson });
+
+        expect(mockSendJson).toHaveBeenCalledWith(
+            mockReq,
+            mockRes,
+            500,
+            expect.objectContaining({ ok: false })
+        );
+    });
+
+    it('GET /franchises/:id/unknown-sub-path returns 404', async () => {
+        const url = new URL('http://localhost/api/admin/franchises/f1/bogus');
+
+        await handleAdminRequest(mockReq, mockRes, { url, pool: mockPool, sendJson: mockSendJson });
+
+        expect(mockSendJson).toHaveBeenCalledWith(
+            mockReq,
+            mockRes,
+            404,
+            expect.objectContaining({ ok: false })
+        );
+    });
+
     it('GET /fixtures returns 400 when missing tournamentId', async () => {
         const url = new URL('http://localhost/api/admin/fixtures?groupId=U11B');
         await handleAdminRequest(mockReq, mockRes, { url, pool: mockPool, sendJson: mockSendJson });

--- a/test/server/auth.test.js
+++ b/test/server/auth.test.js
@@ -313,6 +313,7 @@ vi.mock('../../server/admin.mjs', () => ({
 
 vi.mock('../../server/mailer.mjs', () => ({
   sendMagicLink: vi.fn().mockResolvedValue(undefined),
+  buildMagicLink: vi.fn((token) => `http://localhost:5173/admin/login/callback?token=${token}`),
 }));
 
 process.env.PROVIDER_MODE = 'db';


### PR DESCRIPTION
## Summary
- New `/admin/franchises/:id` page with editable profile form (name, logo URL, manager details, home venue dropdown)
- Read-only teams registry grouped by season, shown as collapsible accordions
- DB migration `016` adds `manager_bio` and `home_venue_id` columns to `franchise_directory`
- New server routes: `GET /admin/franchises/:id` and `GET /admin/franchises/:id/teams`
- Franchise names on the list page now link to the detail page

## Test plan
- [ ] 698 tests passing (`npm run verify`)
- [ ] New `FranchiseDetailPage.test.jsx` — 9 tests covering form pre-fill, save, error, accordion, back nav
- [ ] `FranchisesPage.test.jsx` updated — removed obsolete edit-in-list tests, added link assertion
- [ ] `auth.test.js` — `buildMagicLink` added to mailer mock

🤖 Generated with [Claude Code](https://claude.com/claude-code)