### PR TITLE
feat: wire up is_active as tournament liveness source of truth

### DIFF
--- a/e2e/admin-create-tournament.spec.ts
+++ b/e2e/admin-create-tournament.spec.ts
@@ -105,7 +105,7 @@ test('admin creates a full tournament via the wizard', async ({ page }) => {
 
   // ── Navigate to wizard ────────────────────────────────────────────────────
 
-  await page.goto('admin/tournaments');
+  await page.goto('admin/tournaments/new');
   await page.waitForLoadState('networkidle');
   await expect(page.getByRole('heading', { name: 'Tournament Setup Wizard' })).toBeVisible();
 

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "build": "vite build",
     "lint": "eslint .",
     "verify": "npm run lint && npm run test:coverage",
+    "sonar:check": "sonar-scanner -Dsonar.organization=lbdc -Dsonar.projectKey=skippies-io_hockey-app -Dsonar.host.url=https://sonarcloud.io -Dsonar.token=$SONAR_TOKEN -Dsonar.pullrequest.key=$(gh pr view --json number -q .number) -Dsonar.pullrequest.branch=$(git branch --show-current) -Dsonar.pullrequest.base=main -Dsonar.qualitygate.wait=true -Dsonar.qualitygate.timeout=180",
     "prepare": "node scripts/install-hooks.mjs",
     "smoke:apps": "node scripts/smoke.mjs --provider apps",
     "smoke:db": "node scripts/smoke.mjs --provider db",

--- a/server/admin.mjs
+++ b/server/admin.mjs
@@ -509,6 +509,60 @@ export async function handleAdminRequest(req, res, { url, pool, sendJson, caches
   // CORS headers for admin (if needed specifically, though index.mjs handles it generally, 
   // we might need to ensure OPTIONS passes through or headers conform)
 
+  // GET  /api/admin/tournaments          — list all tournaments (optional ?active=true filter)
+  // PATCH /api/admin/tournaments/:id     — update is_active flag
+  if (path === "/tournaments" || path.startsWith("/tournaments/")) {
+    if (!pool) return sendJson(req, res, 501, { ok: false, error: "DB not configured" });
+
+    // GET /api/admin/tournaments
+    if (path === "/tournaments" && method === "GET") {
+      try {
+        const activeOnly = url.searchParams.get("active") === "true";
+        const result = await pool.query(
+          `SELECT id, name, season, is_active, logo_url, created_at
+           FROM tournament
+           ${activeOnly ? "WHERE is_active = true" : ""}
+           ORDER BY is_active DESC, created_at DESC`
+        );
+        return sendJson(req, res, 200, { ok: true, data: result.rows });
+      } catch (err) {
+        console.error("Admin API Error:", err);
+        return sendJson(req, res, 500, { ok: false, error: err.message });
+      }
+    }
+
+    // PATCH /api/admin/tournaments/:id
+    const tournamentMatch = path.match(/^\/tournaments\/([^/]+)$/);
+    if (tournamentMatch && method === "PATCH") {
+      const id = tournamentMatch[1];
+      try {
+        const body = await readBody(req);
+        if (!body || typeof body.is_active !== "boolean") {
+          return sendJson(req, res, 400, { ok: false, error: "is_active (boolean) is required" });
+        }
+        const result = await pool.query(
+          `UPDATE tournament SET is_active = $2 WHERE id = $1
+           RETURNING id, name, season, is_active, logo_url`,
+          [id, body.is_active]
+        );
+        if (result.rowCount === 0) {
+          return sendJson(req, res, 404, { ok: false, error: "Tournament not found" });
+        }
+        logAudit("tournament.update_active", {
+          entity_type: "tournament",
+          entity_id: id,
+          meta: { is_active: body.is_active },
+        });
+        return sendJson(req, res, 200, { ok: true, data: result.rows[0] });
+      } catch (err) {
+        console.error("Admin API Error:", err);
+        return sendJson(req, res, 500, { ok: false, error: err.message });
+      }
+    }
+
+    return sendJson(req, res, 405, { ok: false, error: "Method not allowed" });
+  }
+
   if (path === "/tournament-exists") {
     if (method !== "GET") {
       return sendJson(req, res, 405, { ok: false, error: "Method not allowed" });

--- a/server/admin.mjs
+++ b/server/admin.mjs
@@ -89,6 +89,16 @@ function requireGetWithDb(method, pool, req, res, sendJson) {
   return true;
 }
 
+function requireTournamentGetDb(method, pool, url, req, res, sendJson) {
+  if (!requireGetWithDb(method, pool, req, res, sendJson)) return null;
+  const tournamentId = normalizeSpaces(url.searchParams.get("tournamentId"));
+  if (!tournamentId) {
+    sendJson(req, res, 400, { ok: false, error: "tournamentId is required" });
+    return null;
+  }
+  return tournamentId;
+}
+
 async function writeAuditLog(pool, entry) {
   if (!pool) return;
   if (!entry?.actor_email || !entry?.action) return;
@@ -580,12 +590,9 @@ export async function handleAdminRequest(req, res, { url, pool, sendJson, caches
   }
 
   // GET /api/admin/groups?tournamentId=X
-  // Returns groups for a tournament with their team counts (non-placeholder only).
   if (path === "/groups") {
-    if (method !== "GET") return sendJson(req, res, 405, { ok: false, error: "Method not allowed" });
-    if (!pool) return sendJson(req, res, 501, { ok: false, error: "DB not configured" });
-    const tournamentId = normalizeSpaces(url.searchParams.get("tournamentId"));
-    if (!tournamentId) return sendJson(req, res, 400, { ok: false, error: "tournamentId is required" });
+    const tournamentId = requireTournamentGetDb(method, pool, url, req, res, sendJson);
+    if (!tournamentId) return;
     try {
       const result = await pool.query(
         `SELECT g.id, g.label,
@@ -607,21 +614,14 @@ export async function handleAdminRequest(req, res, { url, pool, sendJson, caches
   }
 
   // GET /api/admin/unscored-fixtures?tournamentId=X
-  // Returns fixtures whose scheduled date+time has passed (server NOW()) and have no scores entered.
   if (path === "/unscored-fixtures") {
-    if (method !== "GET") return sendJson(req, res, 405, { ok: false, error: "Method not allowed" });
-    if (!pool) return sendJson(req, res, 501, { ok: false, error: "DB not configured" });
-    const tournamentId = normalizeSpaces(url.searchParams.get("tournamentId"));
-    if (!tournamentId) return sendJson(req, res, 400, { ok: false, error: "tournamentId is required" });
+    const tournamentId = requireTournamentGetDb(method, pool, url, req, res, sendJson);
+    if (!tournamentId) return;
     try {
       const result = await pool.query(
-        `SELECT
-           f.id AS fixture_id,
-           f.group_id,
-           to_char(f.date, 'YYYY-MM-DD') AS date,
-           f.time,
-           t1.name AS team1,
-           t2.name AS team2
+        `SELECT f.id AS fixture_id, f.group_id,
+                to_char(f.date, 'YYYY-MM-DD') AS date, f.time,
+                t1.name AS team1, t2.name AS team2
          FROM fixture f
          JOIN team t1 ON t1.tournament_id = f.tournament_id AND t1.id = f.team1_id
          JOIN team t2 ON t2.tournament_id = f.tournament_id AND t2.id = f.team2_id
@@ -633,11 +633,7 @@ export async function handleAdminRequest(req, res, { url, pool, sendJson, caches
          ORDER BY f.date DESC, f.time DESC`,
         [tournamentId]
       );
-      return sendJson(req, res, 200, {
-        ok: true,
-        data: result.rows,
-        server_time: new Date().toISOString(),
-      });
+      return sendJson(req, res, 200, { ok: true, data: result.rows, server_time: new Date().toISOString() });
     } catch (err) {
       console.error("Admin API Error:", err);
       return sendJson(req, res, 500, { ok: false, error: err.message });

--- a/server/admin.mjs
+++ b/server/admin.mjs
@@ -579,6 +579,71 @@ export async function handleAdminRequest(req, res, { url, pool, sendJson, caches
     }
   }
 
+  // GET /api/admin/groups?tournamentId=X
+  // Returns groups for a tournament with their team counts (non-placeholder only).
+  if (path === "/groups") {
+    if (method !== "GET") return sendJson(req, res, 405, { ok: false, error: "Method not allowed" });
+    if (!pool) return sendJson(req, res, 501, { ok: false, error: "DB not configured" });
+    const tournamentId = normalizeSpaces(url.searchParams.get("tournamentId"));
+    if (!tournamentId) return sendJson(req, res, 400, { ok: false, error: "tournamentId is required" });
+    try {
+      const result = await pool.query(
+        `SELECT g.id, g.label,
+                COUNT(t.id) FILTER (WHERE t.is_placeholder = false) AS team_count,
+                COUNT(f.id) AS fixture_count
+         FROM groups g
+         LEFT JOIN team t ON t.group_id = g.id AND t.tournament_id = g.tournament_id
+         LEFT JOIN fixture f ON f.group_id = g.id AND f.tournament_id = g.tournament_id
+         WHERE g.tournament_id = $1
+         GROUP BY g.id, g.label
+         ORDER BY g.label`,
+        [tournamentId]
+      );
+      return sendJson(req, res, 200, { ok: true, data: result.rows });
+    } catch (err) {
+      console.error("Admin API Error:", err);
+      return sendJson(req, res, 500, { ok: false, error: err.message });
+    }
+  }
+
+  // GET /api/admin/unscored-fixtures?tournamentId=X
+  // Returns fixtures whose scheduled date+time has passed (server NOW()) and have no scores entered.
+  if (path === "/unscored-fixtures") {
+    if (method !== "GET") return sendJson(req, res, 405, { ok: false, error: "Method not allowed" });
+    if (!pool) return sendJson(req, res, 501, { ok: false, error: "DB not configured" });
+    const tournamentId = normalizeSpaces(url.searchParams.get("tournamentId"));
+    if (!tournamentId) return sendJson(req, res, 400, { ok: false, error: "tournamentId is required" });
+    try {
+      const result = await pool.query(
+        `SELECT
+           f.id AS fixture_id,
+           f.group_id,
+           to_char(f.date, 'YYYY-MM-DD') AS date,
+           f.time,
+           t1.name AS team1,
+           t2.name AS team2
+         FROM fixture f
+         JOIN team t1 ON t1.tournament_id = f.tournament_id AND t1.id = f.team1_id
+         JOIN team t2 ON t2.tournament_id = f.tournament_id AND t2.id = f.team2_id
+         LEFT JOIN result r ON r.tournament_id = f.tournament_id AND r.fixture_id = f.id
+         WHERE f.tournament_id = $1
+           AND t1.is_placeholder = false AND t2.is_placeholder = false
+           AND (f.date::timestamp + f.time::time) < NOW()
+           AND (r.score1 IS NULL AND r.score2 IS NULL)
+         ORDER BY f.date DESC, f.time DESC`,
+        [tournamentId]
+      );
+      return sendJson(req, res, 200, {
+        ok: true,
+        data: result.rows,
+        server_time: new Date().toISOString(),
+      });
+    } catch (err) {
+      console.error("Admin API Error:", err);
+      return sendJson(req, res, 500, { ok: false, error: err.message });
+    }
+  }
+
   if (path === "/divisions") {
     if (method !== "GET") {
       return sendJson(req, res, 405, { ok: false, error: "Method not allowed" });

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,5 +1,5 @@
-sonar.projectKey=hockey-app
-sonar.organization=skippies-io
+sonar.projectKey=skippies-io_hockey-app
+sonar.organization=lbdc
 sonar.cpd.exclusions=scripts/**
 sonar.coverage.exclusions=scripts/**,test/**,**/*.test.*,**/*.spec.*,**/*.stories.*,vite.config.js,.storybook/**
 sonar.exclusions=scripts/**, **/*.test.jsx, **/*.test.js, **/*.spec.js, **/*.spec.ts, **/*.stories.jsx, e2e/**, .github/**, docs/api.html, db/**, .storybook/**

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -39,6 +39,7 @@ import AdminLoginCallback from "./views/admin/AdminLoginCallback";
 import AnnouncementsPage from "./views/admin/AnnouncementsPage";
 import TournamentWizard from "./views/admin/TournamentWizard";
 import AdminTournamentsPage from "./views/admin/AdminTournamentsPage";
+import AdminDashboard from "./views/admin/AdminDashboard";
 import FixturesPage from "./views/admin/FixturesPage";
 import TechDesk from "./views/admin/TechDesk";
 import VenuesPage from "./views/admin/VenuesPage";
@@ -529,15 +530,7 @@ export default function App() {
           {/* Protected admin routes */}
           <Route element={<AdminRoute />}>
             <Route element={<AdminLayout />}>
-              <Route
-                index
-                element={
-                  <div style={{ padding: '2rem' }}>
-                    <h1>Admin Dashboard</h1>
-                    <p>Welcome to the Hockey Admin Console.</p>
-                  </div>
-                }
-              />
+              <Route index element={<AdminDashboard />} />
               <Route path="tournaments" element={<AdminTournamentsPage />} />
               <Route path="tournaments/new" element={<TournamentWizard />} />
               <Route path="announcements" element={<AnnouncementsPage />} />

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -38,6 +38,7 @@ import AdminLogin from "./views/admin/AdminLogin";
 import AdminLoginCallback from "./views/admin/AdminLoginCallback";
 import AnnouncementsPage from "./views/admin/AnnouncementsPage";
 import TournamentWizard from "./views/admin/TournamentWizard";
+import AdminTournamentsPage from "./views/admin/AdminTournamentsPage";
 import FixturesPage from "./views/admin/FixturesPage";
 import TechDesk from "./views/admin/TechDesk";
 import VenuesPage from "./views/admin/VenuesPage";
@@ -537,7 +538,8 @@ export default function App() {
                   </div>
                 }
               />
-              <Route path="tournaments" element={<TournamentWizard />} />
+              <Route path="tournaments" element={<AdminTournamentsPage />} />
+              <Route path="tournaments/new" element={<TournamentWizard />} />
               <Route path="announcements" element={<AnnouncementsPage />} />
               <Route path="venues/*" element={<VenuesPage />} />
               <Route path="franchises" element={<FranchisesPage />} />

--- a/src/lib/tournamentApi.js
+++ b/src/lib/tournamentApi.js
@@ -1,0 +1,28 @@
+import { adminFetch } from './adminAuth';
+
+const endpoint = () => `/admin/tournaments`;
+
+async function parseJson(res) {
+  const json = await res.json().catch(() => ({}));
+  if (!res.ok || json.ok === false) {
+    throw new Error(json.error || `HTTP ${res.status}`);
+  }
+  return json;
+}
+
+export async function getAdminTournaments({ activeOnly = false } = {}) {
+  const url = activeOnly ? `${endpoint()}?active=true` : endpoint();
+  const res = await adminFetch(url);
+  const json = await parseJson(res);
+  return json.data || [];
+}
+
+export async function setTournamentActive(id, isActive) {
+  const res = await adminFetch(`${endpoint()}/${id}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ is_active: isActive }),
+  });
+  const json = await parseJson(res);
+  return json.data;
+}

--- a/src/lib/tournamentApi.js
+++ b/src/lib/tournamentApi.js
@@ -17,6 +17,30 @@ export async function getAdminTournaments({ activeOnly = false } = {}) {
   return json.data || [];
 }
 
+export async function getAdminAnnouncements() {
+  const res = await adminFetch(`/admin/announcements`);
+  const json = await parseJson(res);
+  return json.data || [];
+}
+
+export async function getAdminTeams(tournamentId) {
+  const res = await adminFetch(`/admin/teams?tournamentId=${encodeURIComponent(tournamentId)}`);
+  const json = await parseJson(res);
+  return json.data || [];
+}
+
+export async function getAdminGroups(tournamentId) {
+  const res = await adminFetch(`/admin/groups?tournamentId=${encodeURIComponent(tournamentId)}`);
+  const json = await parseJson(res);
+  return json.data || [];
+}
+
+export async function getUnscoredFixtures(tournamentId) {
+  const res = await adminFetch(`/admin/unscored-fixtures?tournamentId=${encodeURIComponent(tournamentId)}`);
+  const json = await parseJson(res);
+  return { fixtures: json.data || [], serverTime: json.server_time };
+}
+
 export async function setTournamentActive(id, isActive) {
   const res = await adminFetch(`${endpoint()}/${id}`, {
     method: 'PATCH',

--- a/src/lib/tournamentApi.test.js
+++ b/src/lib/tournamentApi.test.js
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('./adminAuth', () => ({
+  adminFetch: vi.fn(),
+}));
+
+const { adminFetch } = await import('./adminAuth');
+
+function okJson(data) {
+  return Promise.resolve({
+    ok: true,
+    status: 200,
+    json: () => Promise.resolve({ ok: true, data }),
+  });
+}
+
+function failJson(status, error) {
+  return Promise.resolve({
+    ok: false,
+    status,
+    json: () => Promise.resolve({ ok: false, error }),
+  });
+}
+
+describe('tournamentApi', () => {
+  beforeEach(() => { vi.clearAllMocks(); vi.resetModules(); });
+  afterEach(() => { vi.clearAllMocks(); });
+
+  it('getAdminTournaments fetches all tournaments', async () => {
+    adminFetch.mockResolvedValueOnce(okJson([{ id: 't1', is_active: true }]));
+    const api = await import('./tournamentApi');
+    const result = await api.getAdminTournaments();
+    expect(adminFetch).toHaveBeenCalledWith('/admin/tournaments');
+    expect(result).toEqual([{ id: 't1', is_active: true }]);
+  });
+
+  it('getAdminTournaments with activeOnly appends query param', async () => {
+    adminFetch.mockResolvedValueOnce(okJson([{ id: 't1', is_active: true }]));
+    const api = await import('./tournamentApi');
+    await api.getAdminTournaments({ activeOnly: true });
+    expect(adminFetch).toHaveBeenCalledWith('/admin/tournaments?active=true');
+  });
+
+  it('getAdminTournaments returns empty array when data absent', async () => {
+    adminFetch.mockResolvedValueOnce(Promise.resolve({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ ok: true }),
+    }));
+    const api = await import('./tournamentApi');
+    const result = await api.getAdminTournaments();
+    expect(result).toEqual([]);
+  });
+
+  it('setTournamentActive PATCHes with is_active true', async () => {
+    adminFetch.mockResolvedValueOnce(okJson({ id: 't1', is_active: true }));
+    const api = await import('./tournamentApi');
+    const result = await api.setTournamentActive('t1', true);
+    expect(adminFetch).toHaveBeenCalledWith('/admin/tournaments/t1', expect.objectContaining({ method: 'PATCH' }));
+    expect(result).toEqual({ id: 't1', is_active: true });
+  });
+
+  it('setTournamentActive PATCHes with is_active false', async () => {
+    adminFetch.mockResolvedValueOnce(okJson({ id: 't1', is_active: false }));
+    const api = await import('./tournamentApi');
+    const result = await api.setTournamentActive('t1', false);
+    const body = JSON.parse(adminFetch.mock.calls[0][1].body);
+    expect(body).toEqual({ is_active: false });
+    expect(result).toEqual({ id: 't1', is_active: false });
+  });
+
+  it('throws when server responds not ok', async () => {
+    adminFetch.mockResolvedValueOnce(failJson(404, 'Tournament not found'));
+    const api = await import('./tournamentApi');
+    await expect(api.setTournamentActive('missing', false)).rejects.toThrow('Tournament not found');
+  });
+});

--- a/src/lib/tournamentApi.test.js
+++ b/src/lib/tournamentApi.test.js
@@ -74,4 +74,73 @@ describe('tournamentApi', () => {
     const api = await import('./tournamentApi');
     await expect(api.setTournamentActive('missing', false)).rejects.toThrow('Tournament not found');
   });
+
+  it('getAdminAnnouncements fetches announcements', async () => {
+    adminFetch.mockResolvedValueOnce(okJson([{ id: 'a1', title: 'Notice' }]));
+    const api = await import('./tournamentApi');
+    const result = await api.getAdminAnnouncements();
+    expect(adminFetch).toHaveBeenCalledWith('/admin/announcements');
+    expect(result).toEqual([{ id: 'a1', title: 'Notice' }]);
+  });
+
+  it('getAdminAnnouncements returns empty array when data absent', async () => {
+    adminFetch.mockResolvedValueOnce(Promise.resolve({
+      ok: true, status: 200, json: () => Promise.resolve({ ok: true }),
+    }));
+    const api = await import('./tournamentApi');
+    expect(await api.getAdminAnnouncements()).toEqual([]);
+  });
+
+  it('getAdminTeams fetches teams for a tournament', async () => {
+    adminFetch.mockResolvedValueOnce(okJson([{ id: 'tm1', name: 'Alpha' }]));
+    const api = await import('./tournamentApi');
+    const result = await api.getAdminTeams('t1');
+    expect(adminFetch).toHaveBeenCalledWith('/admin/teams?tournamentId=t1');
+    expect(result).toEqual([{ id: 'tm1', name: 'Alpha' }]);
+  });
+
+  it('getAdminTeams returns empty array when data absent', async () => {
+    adminFetch.mockResolvedValueOnce(Promise.resolve({
+      ok: true, status: 200, json: () => Promise.resolve({ ok: true }),
+    }));
+    const api = await import('./tournamentApi');
+    expect(await api.getAdminTeams('t1')).toEqual([]);
+  });
+
+  it('getAdminGroups fetches groups for a tournament', async () => {
+    adminFetch.mockResolvedValueOnce(okJson([{ id: 'g1', label: 'U9' }]));
+    const api = await import('./tournamentApi');
+    const result = await api.getAdminGroups('t1');
+    expect(adminFetch).toHaveBeenCalledWith('/admin/groups?tournamentId=t1');
+    expect(result).toEqual([{ id: 'g1', label: 'U9' }]);
+  });
+
+  it('getAdminGroups returns empty array when data absent', async () => {
+    adminFetch.mockResolvedValueOnce(Promise.resolve({
+      ok: true, status: 200, json: () => Promise.resolve({ ok: true }),
+    }));
+    const api = await import('./tournamentApi');
+    expect(await api.getAdminGroups('t1')).toEqual([]);
+  });
+
+  it('getUnscoredFixtures fetches unscored fixtures', async () => {
+    const serverTime = new Date().toISOString();
+    adminFetch.mockResolvedValueOnce(Promise.resolve({
+      ok: true, status: 200,
+      json: () => Promise.resolve({ ok: true, data: [{ fixture_id: 'f1' }], server_time: serverTime }),
+    }));
+    const api = await import('./tournamentApi');
+    const result = await api.getUnscoredFixtures('t1');
+    expect(adminFetch).toHaveBeenCalledWith('/admin/unscored-fixtures?tournamentId=t1');
+    expect(result).toEqual({ fixtures: [{ fixture_id: 'f1' }], serverTime });
+  });
+
+  it('getUnscoredFixtures returns empty fixtures when data absent', async () => {
+    adminFetch.mockResolvedValueOnce(Promise.resolve({
+      ok: true, status: 200, json: () => Promise.resolve({ ok: true }),
+    }));
+    const api = await import('./tournamentApi');
+    const result = await api.getUnscoredFixtures('t1');
+    expect(result).toEqual({ fixtures: [], serverTime: undefined });
+  });
 });

--- a/src/lib/tournamentApi.test.js
+++ b/src/lib/tournamentApi.test.js
@@ -14,6 +14,12 @@ function okJson(data) {
   });
 }
 
+function noDataJson() {
+  return Promise.resolve({
+    ok: true, status: 200, json: () => Promise.resolve({ ok: true }),
+  });
+}
+
 function failJson(status, error) {
   return Promise.resolve({
     ok: false,
@@ -42,11 +48,7 @@ describe('tournamentApi', () => {
   });
 
   it('getAdminTournaments returns empty array when data absent', async () => {
-    adminFetch.mockResolvedValueOnce(Promise.resolve({
-      ok: true,
-      status: 200,
-      json: () => Promise.resolve({ ok: true }),
-    }));
+    adminFetch.mockResolvedValueOnce(noDataJson());
     const api = await import('./tournamentApi');
     const result = await api.getAdminTournaments();
     expect(result).toEqual([]);
@@ -84,9 +86,7 @@ describe('tournamentApi', () => {
   });
 
   it('getAdminAnnouncements returns empty array when data absent', async () => {
-    adminFetch.mockResolvedValueOnce(Promise.resolve({
-      ok: true, status: 200, json: () => Promise.resolve({ ok: true }),
-    }));
+    adminFetch.mockResolvedValueOnce(noDataJson());
     const api = await import('./tournamentApi');
     expect(await api.getAdminAnnouncements()).toEqual([]);
   });
@@ -100,9 +100,7 @@ describe('tournamentApi', () => {
   });
 
   it('getAdminTeams returns empty array when data absent', async () => {
-    adminFetch.mockResolvedValueOnce(Promise.resolve({
-      ok: true, status: 200, json: () => Promise.resolve({ ok: true }),
-    }));
+    adminFetch.mockResolvedValueOnce(noDataJson());
     const api = await import('./tournamentApi');
     expect(await api.getAdminTeams('t1')).toEqual([]);
   });
@@ -116,9 +114,7 @@ describe('tournamentApi', () => {
   });
 
   it('getAdminGroups returns empty array when data absent', async () => {
-    adminFetch.mockResolvedValueOnce(Promise.resolve({
-      ok: true, status: 200, json: () => Promise.resolve({ ok: true }),
-    }));
+    adminFetch.mockResolvedValueOnce(noDataJson());
     const api = await import('./tournamentApi');
     expect(await api.getAdminGroups('t1')).toEqual([]);
   });
@@ -136,9 +132,7 @@ describe('tournamentApi', () => {
   });
 
   it('getUnscoredFixtures returns empty fixtures when data absent', async () => {
-    adminFetch.mockResolvedValueOnce(Promise.resolve({
-      ok: true, status: 200, json: () => Promise.resolve({ ok: true }),
-    }));
+    adminFetch.mockResolvedValueOnce(noDataJson());
     const api = await import('./tournamentApi');
     const result = await api.getUnscoredFixtures('t1');
     expect(result).toEqual({ fixtures: [], serverTime: undefined });

--- a/src/views/Tournaments.jsx
+++ b/src/views/Tournaments.jsx
@@ -9,7 +9,7 @@ export default function Tournaments() {
   const [items, setItems] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
-  const { activeTournamentId, setActiveTournamentId } = useTournament() || {};
+  const { activeTournamentId: selectedTournamentId, setActiveTournamentId: setSelectedTournamentId } = useTournament() || {};
   const navigate = useNavigate();
 
   useEffect(() => {
@@ -48,8 +48,8 @@ export default function Tournaments() {
   }
 
   function handleView(tournamentId) {
-    if (setActiveTournamentId) {
-      setActiveTournamentId(tournamentId);
+    if (setSelectedTournamentId) {
+      setSelectedTournamentId(tournamentId);
     }
     navigate('/');
   }
@@ -64,7 +64,7 @@ export default function Tournaments() {
 
       <div style={{ display: 'grid', gap: 'var(--hj-space-4)', gridTemplateColumns: 'repeat(auto-fill, minmax(280px, 1fr))' }}>
         {items.map((t) => {
-          const isActive = t.id === activeTournamentId;
+          const isActive = t.id === selectedTournamentId;
           return (
             <div key={t.id} className="hj-card" style={{ display: 'flex', flexDirection: 'column', gap: 'var(--hj-space-2)' }}>
               <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--hj-space-3)' }}>

--- a/src/views/admin/AdminDashboard.jsx
+++ b/src/views/admin/AdminDashboard.jsx
@@ -51,6 +51,21 @@ function EmptyState({ children }) {
   return <p style={{ margin: 0, color: 'var(--hj-color-text-secondary)', fontSize: 'var(--hj-font-size-sm)' }}>{children}</p>;
 }
 
+StatBlock.propTypes = { count: PropTypes.number.isRequired, label: PropTypes.string.isRequired, to: PropTypes.string.isRequired };
+function StatBlock({ count, label, to }) {
+  return (
+    <div>
+      <span style={{ fontSize: 'var(--hj-font-size-xl)', fontWeight: 'var(--hj-font-weight-bold)' }}>{count}</span>
+      <span style={{ fontSize: 'var(--hj-font-size-sm)', color: 'var(--hj-color-text-secondary)', marginLeft: 'var(--hj-space-1)' }}>
+        {label}{count !== 1 ? 's' : ''}
+      </span>
+      <Link to={to} style={{ display: 'block', fontSize: 'var(--hj-font-size-xs)', color: 'var(--hj-color-brand-primary)' }}>
+        View {label}s
+      </Link>
+    </div>
+  );
+}
+
 // ── Widget 1: Live Tournaments ───────────────────────────────────────────────
 
 function LiveTournamentsWidget() {
@@ -304,24 +319,8 @@ function TeamsWidget({ tournaments }) {
                 </div>
               )}
               <div style={{ display: 'flex', gap: 'var(--hj-space-5)' }}>
-                <div>
-                  <span style={{ fontSize: 'var(--hj-font-size-xl)', fontWeight: 'var(--hj-font-weight-bold)' }}>{s.franchiseCount}</span>
-                  <span style={{ fontSize: 'var(--hj-font-size-sm)', color: 'var(--hj-color-text-secondary)', marginLeft: 'var(--hj-space-1)' }}>
-                    franchise{s.franchiseCount !== 1 ? 's' : ''}
-                  </span>
-                  <Link to="/admin/franchises" style={{ display: 'block', fontSize: 'var(--hj-font-size-xs)', color: 'var(--hj-color-brand-primary)' }}>
-                    View franchises
-                  </Link>
-                </div>
-                <div>
-                  <span style={{ fontSize: 'var(--hj-font-size-xl)', fontWeight: 'var(--hj-font-weight-bold)' }}>{s.teamCount}</span>
-                  <span style={{ fontSize: 'var(--hj-font-size-sm)', color: 'var(--hj-color-text-secondary)', marginLeft: 'var(--hj-space-1)' }}>
-                    team{s.teamCount !== 1 ? 's' : ''}
-                  </span>
-                  <Link to="/admin/teams" style={{ display: 'block', fontSize: 'var(--hj-font-size-xs)', color: 'var(--hj-color-brand-primary)' }}>
-                    View teams
-                  </Link>
-                </div>
+                <StatBlock count={s.franchiseCount} label="franchise" to="/admin/franchises" />
+                <StatBlock count={s.teamCount} label="team" to="/admin/teams" />
               </div>
             </div>
           ))}

--- a/src/views/admin/AdminDashboard.jsx
+++ b/src/views/admin/AdminDashboard.jsx
@@ -345,7 +345,7 @@ export default function AdminDashboard() {
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--hj-space-6)' }}>
-      <h1 style={{ margin: 0 }}>Dashboard</h1>
+      <h1 style={{ margin: 0 }}>Admin Dashboard</h1>
 
       {/* Row 1 */}
       <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(320px, 1fr))', gap: 'var(--hj-space-5)' }}>

--- a/src/views/admin/AdminDashboard.jsx
+++ b/src/views/admin/AdminDashboard.jsx
@@ -1,0 +1,364 @@
+import React, { useEffect, useState } from 'react';
+import PropTypes from 'prop-types';
+import { Link } from 'react-router-dom';
+import {
+  getAdminTournaments,
+  getAdminAnnouncements,
+  getAdminGroups,
+  getAdminTeams,
+  getUnscoredFixtures,
+} from '../../lib/tournamentApi';
+
+// ── shared card shell ────────────────────────────────────────────────────────
+
+const tournamentShape = PropTypes.arrayOf(PropTypes.shape({
+  id: PropTypes.string.isRequired,
+  name: PropTypes.string.isRequired,
+}));
+
+function WidgetCard({ title, children }) {
+  return (
+    <div style={{
+      background: 'var(--hj-color-surface-1)',
+      border: '1px solid var(--hj-color-border-subtle)',
+      borderRadius: 'var(--hj-radius-md)',
+      padding: 'var(--hj-space-5)',
+      display: 'flex',
+      flexDirection: 'column',
+      gap: 'var(--hj-space-3)',
+    }}>
+      <h2 style={{ margin: 0, fontSize: 'var(--hj-font-size-md)', fontWeight: 'var(--hj-font-weight-semibold)' }}>
+        {title}
+      </h2>
+      {children}
+    </div>
+  );
+}
+
+WidgetCard.propTypes = { title: PropTypes.string.isRequired, children: PropTypes.node.isRequired };
+
+function WidgetLoading() {
+  return <p style={{ margin: 0, color: 'var(--hj-color-text-secondary)', fontSize: 'var(--hj-font-size-sm)' }}>Loading…</p>;
+}
+
+WidgetError.propTypes = { message: PropTypes.string.isRequired };
+function WidgetError({ message }) {
+  return <p role="alert" style={{ margin: 0, color: '#c00', fontSize: 'var(--hj-font-size-sm)' }}>{message}</p>;
+}
+
+EmptyState.propTypes = { children: PropTypes.node.isRequired };
+function EmptyState({ children }) {
+  return <p style={{ margin: 0, color: 'var(--hj-color-text-secondary)', fontSize: 'var(--hj-font-size-sm)' }}>{children}</p>;
+}
+
+// ── Widget 1: Live Tournaments ───────────────────────────────────────────────
+
+function LiveTournamentsWidget() {
+  const [tournaments, setTournaments] = useState(null);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    getAdminTournaments({ activeOnly: true })
+      .then(setTournaments)
+      .catch((e) => setError(e.message));
+  }, []);
+
+  return (
+    <WidgetCard title="Live Tournaments">
+      {tournaments === null && !error && <WidgetLoading />}
+      {error && <WidgetError message={error} />}
+      {tournaments !== null && tournaments.length === 0 && (
+        <EmptyState>
+          No live tournaments.{' '}
+          <Link to="/admin/tournaments" style={{ color: 'var(--hj-color-brand-primary)' }}>
+            Go to Tournaments
+          </Link>{' '}
+          to activate one.
+        </EmptyState>
+      )}
+      {tournaments !== null && tournaments.length > 0 && (
+        <ul style={{ margin: 0, padding: 0, listStyle: 'none', display: 'flex', flexDirection: 'column', gap: 'var(--hj-space-2)' }}>
+          {tournaments.map((t) => (
+            <li key={t.id} style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+              <div>
+                <span style={{ fontWeight: 'var(--hj-font-weight-semibold)' }}>{t.name}</span>
+                {t.season && (
+                  <span style={{ marginLeft: 'var(--hj-space-2)', color: 'var(--hj-color-text-secondary)', fontSize: 'var(--hj-font-size-sm)' }}>
+                    {t.season}
+                  </span>
+                )}
+              </div>
+              <Link to="/admin/tournaments" style={{ fontSize: 'var(--hj-font-size-sm)', color: 'var(--hj-color-brand-primary)' }}>
+                Manage
+              </Link>
+            </li>
+          ))}
+        </ul>
+      )}
+    </WidgetCard>
+  );
+}
+
+// ── Widget 2: Announcements ──────────────────────────────────────────────────
+
+const SEVERITY_STYLE = {
+  info:    { background: '#dbeafe', color: '#1e40af' },
+  success: { background: '#dcfce7', color: '#15803d' },
+  warning: { background: '#fef9c3', color: '#92400e' },
+  alert:   { background: '#fee2e2', color: '#991b1b' },
+};
+
+function AnnouncementsWidget() {
+  const [items, setItems] = useState(null);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    getAdminAnnouncements()
+      .then((all) => {
+        const now = Date.now();
+        setItems(
+          all.filter(
+            (a) => a.is_published && (!a.expires_at || new Date(a.expires_at).getTime() > now)
+          )
+        );
+      })
+      .catch((e) => setError(e.message));
+  }, []);
+
+  return (
+    <WidgetCard title="Announcements">
+      {items === null && !error && <WidgetLoading />}
+      {error && <WidgetError message={error} />}
+      {items !== null && items.length === 0 && <EmptyState>No active announcements.</EmptyState>}
+      {items !== null && items.length > 0 && (
+        <ul style={{ margin: 0, padding: 0, listStyle: 'none', display: 'flex', flexDirection: 'column', gap: 'var(--hj-space-2)' }}>
+          {items.map((a) => {
+            const sty = SEVERITY_STYLE[a.severity] || SEVERITY_STYLE.info;
+            return (
+              <li key={a.id} style={{ display: 'flex', alignItems: 'flex-start', gap: 'var(--hj-space-2)' }}>
+                <span style={{ ...sty, borderRadius: 'var(--hj-radius-sm)', padding: '2px 7px', fontSize: 'var(--hj-font-size-xs)', fontWeight: 600, whiteSpace: 'nowrap' }}>
+                  {a.severity}
+                </span>
+                <span style={{ flex: 1, fontSize: 'var(--hj-font-size-sm)' }}>{a.title}</span>
+                {a.expires_at && (
+                  <span style={{ fontSize: 'var(--hj-font-size-xs)', color: 'var(--hj-color-text-secondary)', whiteSpace: 'nowrap' }}>
+                    Expires {new Date(a.expires_at).toLocaleDateString()}
+                  </span>
+                )}
+              </li>
+            );
+          })}
+        </ul>
+      )}
+      <Link to="/admin/announcements" style={{ fontSize: 'var(--hj-font-size-sm)', color: 'var(--hj-color-brand-primary)', alignSelf: 'flex-start' }}>
+        Manage announcements →
+      </Link>
+    </WidgetCard>
+  );
+}
+
+// ── Widget 3: Setup Health ───────────────────────────────────────────────────
+
+SetupHealthWidget.propTypes = { tournaments: tournamentShape };
+SetupHealthWidget.defaultProps = { tournaments: null };
+function SetupHealthWidget({ tournaments }) {
+  const [checks, setChecks] = useState(null);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    if (!tournaments || tournaments.length === 0) { setChecks([]); return; }
+
+    const fetches = tournaments.map(async (t) => {
+      const [groups, teams] = await Promise.all([
+        getAdminGroups(t.id),
+        getAdminTeams(t.id),
+      ]);
+      const issues = [];
+      if (groups.length === 0) {
+        issues.push({ id: 'no-groups', msg: `${t.name}: no groups defined`, link: '/admin/tournaments/new' });
+      } else if (teams.length === 0) {
+        issues.push({ id: 'no-teams', msg: `${t.name}: groups exist but no teams assigned`, link: '/admin/teams' });
+      } else {
+        const totalFixtures = groups.reduce((s, g) => s + Number(g.fixture_count || 0), 0);
+        if (totalFixtures === 0) {
+          issues.push({ id: 'no-fixtures', msg: `${t.name}: teams exist but no fixtures generated`, link: '/admin/fixtures' });
+        }
+      }
+      return issues;
+    });
+
+    Promise.all(fetches)
+      .then((all) => setChecks(all.flat()))
+      .catch((e) => setError(e.message));
+  }, [tournaments]);
+
+  return (
+    <WidgetCard title="Setup Health">
+      {checks === null && !error && <WidgetLoading />}
+      {error && <WidgetError message={error} />}
+      {checks !== null && checks.length === 0 && (
+        <p style={{ margin: 0, color: 'var(--hj-color-success, #16a34a)', fontSize: 'var(--hj-font-size-sm)', fontWeight: 'var(--hj-font-weight-semibold)' }}>
+          ✓ Setup looks good
+        </p>
+      )}
+      {checks !== null && checks.length > 0 && (
+        <ul style={{ margin: 0, padding: 0, listStyle: 'none', display: 'flex', flexDirection: 'column', gap: 'var(--hj-space-2)' }}>
+          {checks.map((c) => (
+            <li key={c.id} style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', fontSize: 'var(--hj-font-size-sm)' }}>
+              <span style={{ color: '#92400e' }}>⚠ {c.msg}</span>
+              <Link to={c.link} style={{ color: 'var(--hj-color-brand-primary)', whiteSpace: 'nowrap', marginLeft: 'var(--hj-space-3)' }}>
+                Fix →
+              </Link>
+            </li>
+          ))}
+        </ul>
+      )}
+    </WidgetCard>
+  );
+}
+
+// ── Widget 4: Open / Unscored Games ─────────────────────────────────────────
+
+UnscoredGamesWidget.propTypes = { tournaments: tournamentShape };
+UnscoredGamesWidget.defaultProps = { tournaments: null };
+function UnscoredGamesWidget({ tournaments }) {
+  const [fixtures, setFixtures] = useState(null);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    if (!tournaments || tournaments.length === 0) { setFixtures([]); return; }
+
+    Promise.all(tournaments.map((t) => getUnscoredFixtures(t.id)))
+      .then((results) => {
+        const all = results.flatMap((r, i) =>
+          r.fixtures.map((f) => ({ ...f, tournamentId: tournaments[i].id }))
+        );
+        setFixtures(all);
+      })
+      .catch((e) => setError(e.message));
+  }, [tournaments]);
+
+  return (
+    <WidgetCard title="Open / Unscored Games">
+      {fixtures === null && !error && <WidgetLoading />}
+      {error && <WidgetError message={error} />}
+      {fixtures !== null && fixtures.length === 0 && (
+        <EmptyState>All played fixtures have scores entered.</EmptyState>
+      )}
+      {fixtures !== null && fixtures.length > 0 && (
+        <ul style={{ margin: 0, padding: 0, listStyle: 'none', display: 'flex', flexDirection: 'column', gap: 'var(--hj-space-2)' }}>
+          {fixtures.map((f) => (
+            <li key={`${f.tournamentId}-${f.fixture_id}`} style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', fontSize: 'var(--hj-font-size-sm)' }}>
+              <span>
+                <span style={{ color: 'var(--hj-color-text-secondary)', marginRight: 'var(--hj-space-2)' }}>
+                  {f.date} {f.time}
+                </span>
+                {f.team1} vs {f.team2}
+              </span>
+              <Link
+                to={`/admin/fixtures?tournamentId=${f.tournamentId}&groupId=${f.group_id}`}
+                style={{ color: 'var(--hj-color-brand-primary)', whiteSpace: 'nowrap', marginLeft: 'var(--hj-space-3)' }}
+              >
+                Enter score →
+              </Link>
+            </li>
+          ))}
+        </ul>
+      )}
+    </WidgetCard>
+  );
+}
+
+// ── Widget 5: Registered Teams & Franchises ──────────────────────────────────
+
+TeamsWidget.propTypes = { tournaments: tournamentShape };
+TeamsWidget.defaultProps = { tournaments: null };
+function TeamsWidget({ tournaments }) {
+  const [stats, setStats] = useState(null);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    if (!tournaments || tournaments.length === 0) { setStats([]); return; }
+
+    Promise.all(tournaments.map(async (t) => {
+      const teams = await getAdminTeams(t.id);
+      const franchises = new Set(teams.map((tm) => tm.franchise_name).filter(Boolean));
+      return { id: t.id, name: t.name, teamCount: teams.length, franchiseCount: franchises.size };
+    }))
+      .then(setStats)
+      .catch((e) => setError(e.message));
+  }, [tournaments]);
+
+  return (
+    <WidgetCard title="Registered Teams & Franchises">
+      {stats === null && !error && <WidgetLoading />}
+      {error && <WidgetError message={error} />}
+      {stats !== null && stats.length === 0 && <EmptyState>No live tournaments.</EmptyState>}
+      {stats !== null && stats.length > 0 && (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--hj-space-3)' }}>
+          {stats.map((s) => (
+            <div key={s.id}>
+              {stats.length > 1 && (
+                <div style={{ fontSize: 'var(--hj-font-size-sm)', fontWeight: 'var(--hj-font-weight-semibold)', marginBottom: 'var(--hj-space-1)' }}>
+                  {s.name}
+                </div>
+              )}
+              <div style={{ display: 'flex', gap: 'var(--hj-space-5)' }}>
+                <div>
+                  <span style={{ fontSize: 'var(--hj-font-size-xl)', fontWeight: 'var(--hj-font-weight-bold)' }}>{s.franchiseCount}</span>
+                  <span style={{ fontSize: 'var(--hj-font-size-sm)', color: 'var(--hj-color-text-secondary)', marginLeft: 'var(--hj-space-1)' }}>
+                    franchise{s.franchiseCount !== 1 ? 's' : ''}
+                  </span>
+                  <Link to="/admin/franchises" style={{ display: 'block', fontSize: 'var(--hj-font-size-xs)', color: 'var(--hj-color-brand-primary)' }}>
+                    View franchises
+                  </Link>
+                </div>
+                <div>
+                  <span style={{ fontSize: 'var(--hj-font-size-xl)', fontWeight: 'var(--hj-font-weight-bold)' }}>{s.teamCount}</span>
+                  <span style={{ fontSize: 'var(--hj-font-size-sm)', color: 'var(--hj-color-text-secondary)', marginLeft: 'var(--hj-space-1)' }}>
+                    team{s.teamCount !== 1 ? 's' : ''}
+                  </span>
+                  <Link to="/admin/teams" style={{ display: 'block', fontSize: 'var(--hj-font-size-xs)', color: 'var(--hj-color-brand-primary)' }}>
+                    View teams
+                  </Link>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </WidgetCard>
+  );
+}
+
+// ── Dashboard ────────────────────────────────────────────────────────────────
+
+export default function AdminDashboard() {
+  const [liveTournaments, setLiveTournaments] = useState(null);
+
+  // Fetch live tournaments once; share with widgets that need them
+  useEffect(() => {
+    getAdminTournaments({ activeOnly: true })
+      .then(setLiveTournaments)
+      .catch(() => setLiveTournaments([]));
+  }, []);
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--hj-space-6)' }}>
+      <h1 style={{ margin: 0 }}>Dashboard</h1>
+
+      {/* Row 1 */}
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(320px, 1fr))', gap: 'var(--hj-space-5)' }}>
+        <LiveTournamentsWidget />
+        <AnnouncementsWidget />
+      </div>
+
+      {/* Row 2 */}
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(320px, 1fr))', gap: 'var(--hj-space-5)' }}>
+        <SetupHealthWidget tournaments={liveTournaments} />
+        <UnscoredGamesWidget tournaments={liveTournaments} />
+        <TeamsWidget tournaments={liveTournaments} />
+      </div>
+    </div>
+  );
+}

--- a/src/views/admin/AdminDashboard.test.jsx
+++ b/src/views/admin/AdminDashboard.test.jsx
@@ -1,0 +1,177 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { MemoryRouter } from 'react-router-dom';
+import AdminDashboard from './AdminDashboard';
+import * as tournamentApi from '../../lib/tournamentApi';
+
+vi.mock('../../lib/tournamentApi');
+
+const liveTournaments = [
+  { id: 't1', name: 'Spring Cup', season: '2024-25', is_active: true },
+];
+
+const activeAnnouncement = {
+  id: 'a1',
+  title: 'Ice resurfacing at 10am',
+  severity: 'info',
+  is_published: true,
+  expires_at: null,
+};
+
+const expiredAnnouncement = {
+  id: 'a2',
+  title: 'Old notice',
+  severity: 'warning',
+  is_published: true,
+  expires_at: new Date(Date.now() - 1000).toISOString(),
+};
+
+const unpublishedAnnouncement = {
+  id: 'a3',
+  title: 'Draft',
+  severity: 'info',
+  is_published: false,
+  expires_at: null,
+};
+
+function renderDashboard() {
+  return render(
+    <MemoryRouter>
+      <AdminDashboard />
+    </MemoryRouter>
+  );
+}
+
+describe('AdminDashboard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    tournamentApi.getAdminTournaments.mockResolvedValue(liveTournaments);
+    tournamentApi.getAdminAnnouncements.mockResolvedValue([activeAnnouncement]);
+    tournamentApi.getAdminGroups.mockResolvedValue([
+      { id: 'g1', label: 'U9', team_count: '4', fixture_count: '6' },
+    ]);
+    tournamentApi.getAdminTeams.mockResolvedValue([
+      { id: 'tm1', name: 'Alpha U9', franchise_name: 'Alpha FC' },
+      { id: 'tm2', name: 'Beta U9', franchise_name: 'Beta FC' },
+    ]);
+    tournamentApi.getUnscoredFixtures.mockResolvedValue({ fixtures: [], serverTime: new Date().toISOString() });
+  });
+
+  it('renders the Dashboard heading', () => {
+    renderDashboard();
+    expect(screen.getByRole('heading', { name: 'Dashboard' })).toBeInTheDocument();
+  });
+
+  // Widget 1
+  it('shows live tournament name', async () => {
+    renderDashboard();
+    expect(await screen.findByText('Spring Cup')).toBeInTheDocument();
+  });
+
+  it('shows empty state when no live tournaments', async () => {
+    tournamentApi.getAdminTournaments.mockResolvedValue([]);
+    renderDashboard();
+    expect(await screen.findByText(/No live tournaments/)).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Go to Tournaments' })).toBeInTheDocument();
+  });
+
+  it('shows widget error when live tournaments fetch fails', async () => {
+    tournamentApi.getAdminTournaments.mockRejectedValue(new Error('Network error'));
+    renderDashboard();
+    expect(await screen.findByText('Network error')).toBeInTheDocument();
+  });
+
+  // Widget 2
+  it('shows published non-expired announcement', async () => {
+    renderDashboard();
+    expect(await screen.findByText('Ice resurfacing at 10am')).toBeInTheDocument();
+  });
+
+  it('filters out expired and unpublished announcements', async () => {
+    tournamentApi.getAdminAnnouncements.mockResolvedValue([
+      activeAnnouncement,
+      expiredAnnouncement,
+      unpublishedAnnouncement,
+    ]);
+    renderDashboard();
+    await screen.findByText('Ice resurfacing at 10am');
+    expect(screen.queryByText('Old notice')).not.toBeInTheDocument();
+    expect(screen.queryByText('Draft')).not.toBeInTheDocument();
+  });
+
+  it('shows empty state when no active announcements', async () => {
+    tournamentApi.getAdminAnnouncements.mockResolvedValue([expiredAnnouncement]);
+    renderDashboard();
+    expect(await screen.findByText('No active announcements.')).toBeInTheDocument();
+  });
+
+  it('shows announcements widget error on fetch failure', async () => {
+    tournamentApi.getAdminAnnouncements.mockRejectedValue(new Error('Ann error'));
+    renderDashboard();
+    expect(await screen.findByText('Ann error')).toBeInTheDocument();
+  });
+
+  // Widget 3
+  it('shows Setup looks good when no issues', async () => {
+    renderDashboard();
+    expect(await screen.findByText(/Setup looks good/)).toBeInTheDocument();
+  });
+
+  it('shows warning when no groups exist', async () => {
+    tournamentApi.getAdminGroups.mockResolvedValue([]);
+    tournamentApi.getAdminTeams.mockResolvedValue([]);
+    renderDashboard();
+    expect(await screen.findByText(/no groups defined/)).toBeInTheDocument();
+  });
+
+  it('shows warning when groups exist but no teams', async () => {
+    tournamentApi.getAdminGroups.mockResolvedValue([
+      { id: 'g1', label: 'U9', team_count: '0', fixture_count: '0' },
+    ]);
+    tournamentApi.getAdminTeams.mockResolvedValue([]);
+    renderDashboard();
+    expect(await screen.findByText(/no teams assigned/)).toBeInTheDocument();
+  });
+
+  it('shows warning when teams exist but no fixtures', async () => {
+    tournamentApi.getAdminGroups.mockResolvedValue([
+      { id: 'g1', label: 'U9', team_count: '2', fixture_count: '0' },
+    ]);
+    renderDashboard();
+    expect(await screen.findByText(/no fixtures generated/)).toBeInTheDocument();
+  });
+
+  // Widget 4
+  it('shows all-scored empty state when no unscored fixtures', async () => {
+    renderDashboard();
+    expect(await screen.findByText('All played fixtures have scores entered.')).toBeInTheDocument();
+  });
+
+  it('shows unscored fixture with team names', async () => {
+    tournamentApi.getUnscoredFixtures.mockResolvedValue({
+      fixtures: [{ fixture_id: 'f1', group_id: 'g1', date: '2024-03-01', time: '10:00', team1: 'Alpha', team2: 'Beta' }],
+      serverTime: new Date().toISOString(),
+    });
+    renderDashboard();
+    expect(await screen.findByText(/Alpha vs Beta/)).toBeInTheDocument();
+  });
+
+  // Widget 5
+  it('shows team and franchise counts', async () => {
+    renderDashboard();
+    await waitFor(() => {
+      expect(screen.getAllByText('2').length).toBeGreaterThanOrEqual(2);
+    });
+    expect(screen.getByText('franchises')).toBeInTheDocument();
+    expect(screen.getByText('teams')).toBeInTheDocument();
+  });
+
+  it('shows no live tournaments state in teams widget when none active', async () => {
+    tournamentApi.getAdminTournaments.mockResolvedValue([]);
+    renderDashboard();
+    await waitFor(() => {
+      expect(screen.getAllByText('No live tournaments.').length).toBeGreaterThan(0);
+    });
+  });
+});

--- a/src/views/admin/AdminDashboard.test.jsx
+++ b/src/views/admin/AdminDashboard.test.jsx
@@ -60,7 +60,7 @@ describe('AdminDashboard', () => {
 
   it('renders the Dashboard heading', () => {
     renderDashboard();
-    expect(screen.getByRole('heading', { name: 'Dashboard' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Admin Dashboard' })).toBeInTheDocument();
   });
 
   // Widget 1

--- a/src/views/admin/AdminTournamentsPage.jsx
+++ b/src/views/admin/AdminTournamentsPage.jsx
@@ -1,0 +1,129 @@
+import React, { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { getAdminTournaments, setTournamentActive } from '../../lib/tournamentApi';
+
+export default function AdminTournamentsPage() {
+  const navigate = useNavigate();
+  const [tournaments, setTournaments] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState(null);
+  const [togglingId, setTogglingId] = useState(null);
+  const [toggleError, setToggleError] = useState(null);
+
+  useEffect(() => {
+    let alive = true;
+    getAdminTournaments()
+      .then((data) => { if (alive) setTournaments(data); })
+      .catch((err) => { if (alive) setLoadError(err.message); })
+      .finally(() => { if (alive) setLoading(false); });
+    return () => { alive = false; };
+  }, []);
+
+  const handleToggle = async (tournament) => {
+    const next = !tournament.is_active;
+
+    if (next) {
+      const otherActive = tournaments.find((t) => t.id !== tournament.id && t.is_active);
+      if (otherActive) {
+        const ok = window.confirm(
+          `"${otherActive.name}" is already marked live. Activate "${tournament.name}" as well?`
+        );
+        if (!ok) return;
+      }
+    }
+
+    setTogglingId(tournament.id);
+    setToggleError(null);
+    // Optimistic update
+    setTournaments((prev) =>
+      prev.map((t) => (t.id === tournament.id ? { ...t, is_active: next } : t))
+    );
+
+    try {
+      const updated = await setTournamentActive(tournament.id, next);
+      setTournaments((prev) =>
+        prev.map((t) => (t.id === updated.id ? { ...t, ...updated } : t))
+      );
+    } catch (err) {
+      // Rollback
+      setTournaments((prev) =>
+        prev.map((t) => (t.id === tournament.id ? { ...t, is_active: tournament.is_active } : t))
+      );
+      setToggleError(err.message);
+    } finally {
+      setTogglingId(null);
+    }
+  };
+
+  if (loading) return <div style={{ padding: 'var(--hj-space-4)' }}>Loading…</div>;
+  if (loadError) return <div role="alert" style={{ color: '#c00', padding: 'var(--hj-space-4)' }}>{loadError}</div>;
+
+  return (
+    <div style={{ maxWidth: 760 }}>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 'var(--hj-space-6)' }}>
+        <h1 style={{ margin: 0 }}>Tournaments</h1>
+        <button
+          type="button"
+          className="admin-btn-primary"
+          onClick={() => navigate('/admin/tournaments/new')}
+        >
+          + Create tournament
+        </button>
+      </div>
+
+      {toggleError && (
+        <div role="alert" style={{ color: '#c00', marginBottom: 'var(--hj-space-4)', fontSize: 'var(--hj-font-size-sm)' }}>
+          {toggleError}
+        </div>
+      )}
+
+      {tournaments.length === 0 && (
+        <p style={{ color: 'var(--hj-color-text-secondary)' }}>No tournaments yet.</p>
+      )}
+
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--hj-space-3)' }}>
+        {tournaments.map((t) => (
+          <div
+            key={t.id}
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'space-between',
+              padding: 'var(--hj-space-4)',
+              border: '1px solid var(--hj-color-border-subtle)',
+              borderRadius: 'var(--hj-radius-md)',
+              background: 'var(--hj-color-surface-1)',
+            }}
+          >
+            <div>
+              <div style={{ fontWeight: 'var(--hj-font-weight-semibold)', marginBottom: 'var(--hj-space-1)' }}>
+                {t.name}
+              </div>
+              <div style={{ fontSize: 'var(--hj-font-size-sm)', color: 'var(--hj-color-text-secondary)' }}>
+                {t.season || '—'} · ID: {t.id}
+              </div>
+            </div>
+
+            <label
+              style={{ display: 'flex', alignItems: 'center', gap: 'var(--hj-space-2)', cursor: togglingId === t.id ? 'wait' : 'pointer' }}
+              title={t.is_active ? 'Click to deactivate' : 'Click to activate'}
+            >
+              <span style={{ fontSize: 'var(--hj-font-size-sm)', color: t.is_active ? 'var(--hj-color-success, #16a34a)' : 'var(--hj-color-text-secondary)' }}>
+                {t.is_active ? 'Live' : 'Inactive'}
+              </span>
+              <input
+                type="checkbox"
+                role="switch"
+                aria-label={`Tournament is live: ${t.name}`}
+                checked={t.is_active}
+                disabled={togglingId === t.id}
+                onChange={() => handleToggle(t)}
+                style={{ width: 18, height: 18, cursor: 'inherit', accentColor: 'var(--hj-color-brand-primary)' }}
+              />
+            </label>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/views/admin/AdminTournamentsPage.test.jsx
+++ b/src/views/admin/AdminTournamentsPage.test.jsx
@@ -1,0 +1,118 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import AdminTournamentsPage from './AdminTournamentsPage';
+import * as tournamentApi from '../../lib/tournamentApi';
+
+vi.mock('../../lib/tournamentApi');
+
+const mockTournaments = [
+  { id: 't1', name: 'Spring Cup', season: '2024-25', is_active: true, logo_url: null },
+  { id: 't2', name: 'Fall Classic', season: '2023-24', is_active: false, logo_url: null },
+];
+
+function renderPage() {
+  return render(
+    <MemoryRouter initialEntries={['/admin/tournaments']}>
+      <Routes>
+        <Route path="/admin/tournaments" element={<AdminTournamentsPage />} />
+        <Route path="/admin/tournaments/new" element={<div>Create wizard</div>} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+describe('AdminTournamentsPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    tournamentApi.getAdminTournaments.mockResolvedValue(mockTournaments);
+  });
+
+  it('renders tournament list', async () => {
+    renderPage();
+    expect(await screen.findByText('Spring Cup')).toBeInTheDocument();
+    expect(screen.getByText('Fall Classic')).toBeInTheDocument();
+  });
+
+  it('shows Live for active and Inactive for inactive tournaments', async () => {
+    renderPage();
+    await screen.findByText('Spring Cup');
+    expect(screen.getByText('Live')).toBeInTheDocument();
+    expect(screen.getByText('Inactive')).toBeInTheDocument();
+  });
+
+  it('active tournament checkbox is checked, inactive is unchecked', async () => {
+    renderPage();
+    await screen.findByText('Spring Cup');
+    const [springCheckbox, fallCheckbox] = screen.getAllByRole('switch');
+    expect(springCheckbox).toBeChecked();
+    expect(fallCheckbox).not.toBeChecked();
+  });
+
+  it('toggling active tournament deactivates it (optimistic)', async () => {
+    tournamentApi.setTournamentActive.mockResolvedValue({ ...mockTournaments[0], is_active: false });
+    renderPage();
+    await screen.findByText('Spring Cup');
+
+    const [springCheckbox] = screen.getAllByRole('switch');
+    fireEvent.click(springCheckbox);
+
+    await waitFor(() => expect(tournamentApi.setTournamentActive).toHaveBeenCalledWith('t1', false));
+  });
+
+  it('warns before activating a second tournament', async () => {
+    vi.stubGlobal('confirm', vi.fn(() => false));
+    renderPage();
+    await screen.findByText('Fall Classic');
+
+    const [, fallCheckbox] = screen.getAllByRole('switch');
+    fireEvent.click(fallCheckbox);
+
+    expect(window.confirm).toHaveBeenCalledWith(expect.stringContaining('Spring Cup'));
+    expect(tournamentApi.setTournamentActive).not.toHaveBeenCalled();
+  });
+
+  it('proceeds with activation if confirm returns true', async () => {
+    vi.stubGlobal('confirm', vi.fn(() => true));
+    tournamentApi.setTournamentActive.mockResolvedValue({ ...mockTournaments[1], is_active: true });
+    renderPage();
+    await screen.findByText('Fall Classic');
+
+    const [, fallCheckbox] = screen.getAllByRole('switch');
+    fireEvent.click(fallCheckbox);
+
+    await waitFor(() => expect(tournamentApi.setTournamentActive).toHaveBeenCalledWith('t2', true));
+  });
+
+  it('rolls back optimistic update on API error', async () => {
+    tournamentApi.setTournamentActive.mockRejectedValue(new Error('Server error'));
+    renderPage();
+    await screen.findByText('Spring Cup');
+
+    const [springCheckbox] = screen.getAllByRole('switch');
+    fireEvent.click(springCheckbox);
+
+    await waitFor(() => expect(screen.getByText('Server error')).toBeInTheDocument());
+    expect(springCheckbox).toBeChecked();
+  });
+
+  it('shows empty state when no tournaments', async () => {
+    tournamentApi.getAdminTournaments.mockResolvedValue([]);
+    renderPage();
+    expect(await screen.findByText(/No tournaments yet/)).toBeInTheDocument();
+  });
+
+  it('shows load error when fetch fails', async () => {
+    tournamentApi.getAdminTournaments.mockRejectedValue(new Error('Network error'));
+    renderPage();
+    expect(await screen.findByText('Network error')).toBeInTheDocument();
+  });
+
+  it('Create tournament button navigates to wizard', async () => {
+    renderPage();
+    await screen.findByText('Spring Cup');
+    fireEvent.click(screen.getByRole('button', { name: /create tournament/i }));
+    expect(await screen.findByText('Create wizard')).toBeInTheDocument();
+  });
+});

--- a/test/server/admin.test.js
+++ b/test/server/admin.test.js
@@ -1638,6 +1638,80 @@ describe('handleAdminRequest', () => {
         );
     });
 
+    // ── /groups endpoint ─────────────────────────────────────────────────────
+
+    it('GET /groups returns groups with team and fixture counts', async () => {
+        const url = new URL('http://localhost/api/admin/groups?tournamentId=t1');
+        const rows = [
+            { id: 'g1', label: 'U9', team_count: '4', fixture_count: '6' },
+        ];
+        mockPool.query.mockResolvedValueOnce({ rows });
+
+        await handleAdminRequest(mockReq, mockRes, { url, pool: mockPool, sendJson: mockSendJson });
+
+        expect(mockSendJson).toHaveBeenCalledWith(mockReq, mockRes, 200,
+            expect.objectContaining({ ok: true, data: rows })
+        );
+    });
+
+    it('GET /groups returns 400 when tournamentId missing', async () => {
+        const url = new URL('http://localhost/api/admin/groups');
+        await handleAdminRequest(mockReq, mockRes, { url, pool: mockPool, sendJson: mockSendJson });
+        expect(mockSendJson).toHaveBeenCalledWith(mockReq, mockRes, 400,
+            expect.objectContaining({ ok: false, error: expect.stringContaining('tournamentId') })
+        );
+    });
+
+    it('GET /groups returns 501 when DB not configured', async () => {
+        const url = new URL('http://localhost/api/admin/groups?tournamentId=t1');
+        await handleAdminRequest(mockReq, mockRes, { url, pool: null, sendJson: mockSendJson });
+        expect(mockSendJson).toHaveBeenCalledWith(mockReq, mockRes, 501, expect.objectContaining({ ok: false }));
+    });
+
+    it('GET /groups returns 405 for non-GET', async () => {
+        const url = new URL('http://localhost/api/admin/groups?tournamentId=t1');
+        mockReq.method = 'POST';
+        await handleAdminRequest(mockReq, mockRes, { url, pool: mockPool, sendJson: mockSendJson });
+        expect(mockSendJson).toHaveBeenCalledWith(mockReq, mockRes, 405, expect.objectContaining({ ok: false }));
+    });
+
+    // ── /unscored-fixtures endpoint ───────────────────────────────────────────
+
+    it('GET /unscored-fixtures returns past unscored fixtures', async () => {
+        const url = new URL('http://localhost/api/admin/unscored-fixtures?tournamentId=t1');
+        const rows = [
+            { fixture_id: 'f1', group_id: 'g1', date: '2024-03-01', time: '10:00', team1: 'Alpha', team2: 'Beta' },
+        ];
+        mockPool.query.mockResolvedValueOnce({ rows });
+
+        await handleAdminRequest(mockReq, mockRes, { url, pool: mockPool, sendJson: mockSendJson });
+
+        expect(mockSendJson).toHaveBeenCalledWith(mockReq, mockRes, 200,
+            expect.objectContaining({ ok: true, data: rows, server_time: expect.any(String) })
+        );
+    });
+
+    it('GET /unscored-fixtures returns 400 when tournamentId missing', async () => {
+        const url = new URL('http://localhost/api/admin/unscored-fixtures');
+        await handleAdminRequest(mockReq, mockRes, { url, pool: mockPool, sendJson: mockSendJson });
+        expect(mockSendJson).toHaveBeenCalledWith(mockReq, mockRes, 400,
+            expect.objectContaining({ ok: false, error: expect.stringContaining('tournamentId') })
+        );
+    });
+
+    it('GET /unscored-fixtures returns 501 when DB not configured', async () => {
+        const url = new URL('http://localhost/api/admin/unscored-fixtures?tournamentId=t1');
+        await handleAdminRequest(mockReq, mockRes, { url, pool: null, sendJson: mockSendJson });
+        expect(mockSendJson).toHaveBeenCalledWith(mockReq, mockRes, 501, expect.objectContaining({ ok: false }));
+    });
+
+    it('GET /unscored-fixtures returns 500 on DB error', async () => {
+        const url = new URL('http://localhost/api/admin/unscored-fixtures?tournamentId=t1');
+        mockPool.query.mockRejectedValueOnce(new Error('DB error'));
+        await handleAdminRequest(mockReq, mockRes, { url, pool: mockPool, sendJson: mockSendJson });
+        expect(mockSendJson).toHaveBeenCalledWith(mockReq, mockRes, 500, expect.objectContaining({ ok: false }));
+    });
+
     // ── /tournament-exists endpoint ──────────────────────────────────────────
 
     it('GET /tournament-exists returns exists:false when tournament not found', async () => {

--- a/test/server/admin.test.js
+++ b/test/server/admin.test.js
@@ -1515,6 +1515,129 @@ describe('handleAdminRequest', () => {
         );
     });
 
+    // ── /tournaments admin endpoint ──────────────────────────────────────────
+
+    it('GET /tournaments returns all tournaments', async () => {
+        const url = new URL('http://localhost/api/admin/tournaments');
+        const rows = [
+            { id: 't1', name: 'Spring Cup', season: '2024-25', is_active: true, logo_url: null, created_at: '2024-01-01' },
+            { id: 't2', name: 'Fall Classic', season: '2023-24', is_active: false, logo_url: null, created_at: '2023-01-01' },
+        ];
+        mockPool.query.mockResolvedValueOnce({ rows });
+
+        await handleAdminRequest(mockReq, mockRes, { url, pool: mockPool, sendJson: mockSendJson });
+
+        expect(mockSendJson).toHaveBeenCalledWith(mockReq, mockRes, 200,
+            expect.objectContaining({ ok: true, data: rows })
+        );
+    });
+
+    it('GET /tournaments?active=true returns only active tournaments', async () => {
+        const url = new URL('http://localhost/api/admin/tournaments?active=true');
+        const rows = [{ id: 't1', name: 'Spring Cup', season: '2024-25', is_active: true, logo_url: null, created_at: '2024-01-01' }];
+        mockPool.query.mockResolvedValueOnce({ rows });
+
+        await handleAdminRequest(mockReq, mockRes, { url, pool: mockPool, sendJson: mockSendJson });
+
+        expect(mockPool.query).toHaveBeenCalledWith(expect.stringContaining('WHERE is_active = true'));
+        expect(mockSendJson).toHaveBeenCalledWith(mockReq, mockRes, 200,
+            expect.objectContaining({ ok: true, data: rows })
+        );
+    });
+
+    it('GET /tournaments returns 501 when DB not configured', async () => {
+        const url = new URL('http://localhost/api/admin/tournaments');
+        await handleAdminRequest(mockReq, mockRes, { url, pool: null, sendJson: mockSendJson });
+        expect(mockSendJson).toHaveBeenCalledWith(mockReq, mockRes, 501, expect.objectContaining({ ok: false }));
+    });
+
+    it('GET /tournaments returns 500 on DB error', async () => {
+        const url = new URL('http://localhost/api/admin/tournaments');
+        mockPool.query.mockRejectedValueOnce(new Error('DB down'));
+        await handleAdminRequest(mockReq, mockRes, { url, pool: mockPool, sendJson: mockSendJson });
+        expect(mockSendJson).toHaveBeenCalledWith(mockReq, mockRes, 500, expect.objectContaining({ ok: false }));
+    });
+
+    it('PATCH /tournaments/:id sets is_active to false', async () => {
+        const url = new URL('http://localhost/api/admin/tournaments/t1');
+        mockReq.method = 'PATCH';
+        mockReq.on = vi.fn((event, cb) => {
+            if (event === 'data') cb(Buffer.from(JSON.stringify({ is_active: false })));
+            if (event === 'end') cb();
+        });
+        mockPool.query.mockResolvedValueOnce({
+            rows: [{ id: 't1', name: 'Spring Cup', season: '2024-25', is_active: false, logo_url: null }],
+            rowCount: 1,
+        });
+
+        await handleAdminRequest(mockReq, mockRes, { url, pool: mockPool, sendJson: mockSendJson, caches: { actorEmail: 'admin@example.com' } });
+
+        expect(mockSendJson).toHaveBeenCalledWith(mockReq, mockRes, 200,
+            expect.objectContaining({ ok: true, data: expect.objectContaining({ is_active: false }) })
+        );
+    });
+
+    it('PATCH /tournaments/:id sets is_active to true', async () => {
+        const url = new URL('http://localhost/api/admin/tournaments/t2');
+        mockReq.method = 'PATCH';
+        mockReq.on = vi.fn((event, cb) => {
+            if (event === 'data') cb(Buffer.from(JSON.stringify({ is_active: true })));
+            if (event === 'end') cb();
+        });
+        mockPool.query.mockResolvedValueOnce({
+            rows: [{ id: 't2', name: 'Fall Classic', season: '2023-24', is_active: true, logo_url: null }],
+            rowCount: 1,
+        });
+
+        await handleAdminRequest(mockReq, mockRes, { url, pool: mockPool, sendJson: mockSendJson, caches: { actorEmail: 'admin@example.com' } });
+
+        expect(mockSendJson).toHaveBeenCalledWith(mockReq, mockRes, 200,
+            expect.objectContaining({ ok: true, data: expect.objectContaining({ is_active: true }) })
+        );
+    });
+
+    it('PATCH /tournaments/:id returns 400 when is_active not boolean', async () => {
+        const url = new URL('http://localhost/api/admin/tournaments/t1');
+        mockReq.method = 'PATCH';
+        mockReq.on = vi.fn((event, cb) => {
+            if (event === 'data') cb(Buffer.from(JSON.stringify({ is_active: 'yes' })));
+            if (event === 'end') cb();
+        });
+
+        await handleAdminRequest(mockReq, mockRes, { url, pool: mockPool, sendJson: mockSendJson });
+
+        expect(mockSendJson).toHaveBeenCalledWith(mockReq, mockRes, 400,
+            expect.objectContaining({ ok: false, error: expect.stringContaining('is_active') })
+        );
+    });
+
+    it('PATCH /tournaments/:id returns 404 when tournament not found', async () => {
+        const url = new URL('http://localhost/api/admin/tournaments/missing');
+        mockReq.method = 'PATCH';
+        mockReq.on = vi.fn((event, cb) => {
+            if (event === 'data') cb(Buffer.from(JSON.stringify({ is_active: false })));
+            if (event === 'end') cb();
+        });
+        mockPool.query.mockResolvedValueOnce({ rows: [], rowCount: 0 });
+
+        await handleAdminRequest(mockReq, mockRes, { url, pool: mockPool, sendJson: mockSendJson });
+
+        expect(mockSendJson).toHaveBeenCalledWith(mockReq, mockRes, 404,
+            expect.objectContaining({ ok: false, error: 'Tournament not found' })
+        );
+    });
+
+    it('PATCH /tournaments/:id returns 405 for unsupported method', async () => {
+        const url = new URL('http://localhost/api/admin/tournaments/t1');
+        mockReq.method = 'DELETE';
+
+        await handleAdminRequest(mockReq, mockRes, { url, pool: mockPool, sendJson: mockSendJson });
+
+        expect(mockSendJson).toHaveBeenCalledWith(mockReq, mockRes, 405,
+            expect.objectContaining({ ok: false })
+        );
+    });
+
     // ── /tournament-exists endpoint ──────────────────────────────────────────
 
     it('GET /tournament-exists returns exists:false when tournament not found', async () => {


### PR DESCRIPTION
## Summary
- `GET /api/admin/tournaments` — lists all tournaments; `?active=true` filters to live ones only. Public `/api/tournaments` endpoint is unchanged.
- `PATCH /api/admin/tournaments/:id` — toggles `is_active` (boolean). Audited via `logAudit`.
- `AdminTournamentsPage` — list view at `/admin/tournaments` with per-row live/inactive toggle (checkbox/switch), optimistic update, rollback on API error, and a confirm-warning if a second tournament is being activated while one is already live.
- `/admin/tournaments/new` → wizard (creation unchanged).
- `Tournaments.jsx` — renamed `activeTournamentId` → `selectedTournamentId` locally to eliminate naming collision with the DB `is_active` field. No user-visible label changes.

## Test plan
- [ ] 745 tests passing (`npm run verify`)
- [ ] `AdminTournamentsPage.test.jsx` — 10 tests: list render, Live/Inactive labels, toggle deactivate, multi-active warning (cancel + confirm), rollback on error, empty state, load error, nav to wizard
- [ ] `tournamentApi.test.js` — 6 tests: GET all, GET active filter, empty data fallback, PATCH true/false, error throw
- [ ] `admin.test.js` — 8 new server tests: GET all, GET active filter, 501/500 errors, PATCH true/false, 400 bad body, 404 not found, 405 method not allowed

🤖 Generated with [Claude Code](https://claude.com/claude-code)