### PR TITLE
fix: skip lifecycle scripts in Docker build (unblocks Northflank)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM node:20-alpine
 WORKDIR /app
 
 COPY package.json package-lock.json .npmrc ./
-RUN npm ci --omit=dev
+RUN npm ci --omit=dev --ignore-scripts
 
 COPY . .
 


### PR DESCRIPTION
## Summary
- Adds `--ignore-scripts` to `npm ci` in the Dockerfile
- The `prepare` lifecycle hook (`install-hooks.mjs`) was running during Docker builds and failing inside Northflank's build environment, causing every build to fail since 2026-04-16
- Server deployments have no need for git hooks

## Root cause
`package.json` gained a `prepare` script in PR #269 that installs git hooks. Docker builds don't need git hooks, and the hook installation was failing silently or hard-failing in Northflank's build context.

## Test plan
- [ ] Northflank build for `hj-api` succeeds after this merges
- [ ] Server starts and admin API endpoints respond correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)