### PR TITLE
Tournament Wizard v2: prototype stepper lock + summary/scroll (WIP)

### DIFF
--- a/src/views/admin/TournamentNewWizard.jsx
+++ b/src/views/admin/TournamentNewWizard.jsx
@@ -168,30 +168,6 @@ Step2Franchises.propTypes = {
   onValidityChange: PropTypes.func.isRequired,
 };
 
-function StepRail({ step }) {
-  return (
-    <nav className="hj-tw2-stepper" aria-label="Tournament wizard steps">
-      {STEPS.map((label, idx) => {
-        const state = idx === step ? "current" : idx < step ? "done" : "todo";
-        return (
-          <div key={label} className={`hj-tw2-step hj-tw2-step--${state}`}
-            aria-current={idx === step ? "step" : undefined}
-          >
-            <div className="hj-tw2-step-bullet">
-              {idx < step ? "✓" : idx + 1}
-            </div>
-            <div className="hj-tw2-step-label">{label}</div>
-          </div>
-        );
-      })}
-    </nav>
-  );
-}
-
-StepRail.propTypes = {
-  step: PropTypes.number.isRequired,
-};
-
 function TopStepper({ step, maxStep, onStepChange }) {
   return (
     <nav className="hj-tw2-topstep" aria-label="Tournament wizard progress">

--- a/src/views/admin/TournamentNewWizard.jsx
+++ b/src/views/admin/TournamentNewWizard.jsx
@@ -192,20 +192,32 @@ StepRail.propTypes = {
   step: PropTypes.number.isRequired,
 };
 
-function TopStepper({ step }) {
+function TopStepper({ step, maxStep, onStepChange }) {
   return (
     <nav className="hj-tw2-topstep" aria-label="Tournament wizard progress">
       <div className="hj-tw2-topstep-inner">
         {STEPS.map((label, idx) => {
           const state = idx === step ? "current" : idx < step ? "done" : "todo";
+          const isLocked = idx > maxStep;
           return (
-            <div key={label} className={`hj-tw2-topstep-item hj-tw2-topstep-item--${state}`}>
+            <button
+              key={label}
+              type="button"
+              className={`hj-tw2-topstep-item hj-tw2-topstep-item--${state} ${isLocked ? "is-locked" : ""}`}
+              onClick={() => {
+                if (isLocked) return;
+                onStepChange(idx);
+              }}
+              aria-current={idx === step ? "step" : undefined}
+              aria-disabled={isLocked}
+              disabled={isLocked}
+            >
               <div className="hj-tw2-topstep-node" aria-hidden="true">
                 {idx < step ? "✓" : idx + 1}
               </div>
               <div className="hj-tw2-topstep-label">{label}</div>
               {idx < STEPS.length - 1 ? <div className="hj-tw2-topstep-rail" aria-hidden="true" /> : null}
-            </div>
+            </button>
           );
         })}
       </div>
@@ -215,6 +227,8 @@ function TopStepper({ step }) {
 
 TopStepper.propTypes = {
   step: PropTypes.number.isRequired,
+  maxStep: PropTypes.number.isRequired,
+  onStepChange: PropTypes.func.isRequired,
 };
 
 function SummarySidebar({ tournamentName, venuesCount, divisionsCount }) {
@@ -706,6 +720,7 @@ Step1.propTypes = {
 export default function TournamentNewWizard() {
   const [step, setStep] = useState(0);
   const [canProceed, setCanProceed] = useState(false);
+  const [maxStep, setMaxStep] = useState(0);
   const [step1, setStep1] = useState({
     _continue: 0,
     name: "",
@@ -769,6 +784,10 @@ export default function TournamentNewWizard() {
     if (step1._continue && canProceed) setStep(1);
   }, [step, step1._continue, canProceed]);
 
+  React.useEffect(() => {
+    setMaxStep((m) => Math.max(m, step));
+  }, [step]);
+
   const main = step === 0 ? (
     <Step1
       value={{ ...step1, activeDivisions }}
@@ -815,7 +834,7 @@ export default function TournamentNewWizard() {
 
   return (
     <div className="hj-tw2-shell">
-      <TopStepper step={step} />
+      <TopStepper step={step} maxStep={maxStep} onStepChange={setStep} />
       <div className="hj-tw2-body">
         {main}
         <SummarySidebar

--- a/src/views/admin/TournamentNewWizard.test.jsx
+++ b/src/views/admin/TournamentNewWizard.test.jsx
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom/vitest";
 
@@ -224,6 +224,58 @@ describe("TournamentNewWizard (v2)", () => {
     expect(screen.getByText("Step 1 of 5, Tournament Details")).toBeInTheDocument();
   });
 
+  it("lets you add an age group via the Add button", async () => {
+    const user = userEvent.setup();
+    render(<TournamentNewWizard />);
+
+    await user.type(screen.getByLabelText("Add age group"), "U19");
+    // There are multiple "Add" buttons on Step 1, click the one next to the age-group input.
+    await user.click(screen.getAllByRole("button", { name: "Add" })[1]);
+
+    expect(screen.getByRole("checkbox", { name: "U19 Mixed" })).toBeInTheDocument();
+  });
+
+  it("renders the Step 3+ WIP shell and supports back/next within the shell", async () => {
+    const user = userEvent.setup();
+    render(<TournamentNewWizard />);
+
+    await completeStep1(user);
+    await user.click(screen.getByRole("button", { name: "Next" }));
+
+    // Make Step 2 valid
+    await user.click(screen.getByText("Beaulieu College"));
+    await user.click(screen.getByText("St Stithians"));
+    expect(screen.getByRole("button", { name: "Save & Continue" })).toBeEnabled();
+
+    // Advance to the WIP shell (Step 3)
+    await user.click(screen.getByRole("button", { name: "Save & Continue" }));
+    expect(screen.getByText(/Teams & Pools/)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Save & Continue" })).toBeInTheDocument();
+
+    // Going back from Step 3 isn't implemented yet in the WIP shell,
+    // but we still assert we've reached the Step 3 shell state.
+  });
+
+  it("advances maxStep after step changes, unlocking the current step in the stepper", async () => {
+    const user = userEvent.setup();
+    render(<TournamentNewWizard />);
+
+    // Step 2 is initially locked
+    const franchises = screen.getByRole("button", { name: "Franchises" });
+    expect(franchises).toBeDisabled();
+
+    await completeStep1(user);
+    await user.click(screen.getByRole("button", { name: "Next" }));
+    expect(screen.getByText("Step 2 of 5, Franchises")).toBeInTheDocument();
+
+    // After reaching step 2, it should no longer be locked
+    expect(franchises).toBeEnabled();
+
+    // Spot check that we can still interact with previous step button (not disabled)
+    const details = screen.getByRole("button", { name: "Tournament Details" });
+    expect(details).toBeEnabled();
+  });
+
   it("clamps points stepper interactions to a minimum of 0 for win/draw/loss", async () => {
     const user = userEvent.setup();
     render(<TournamentNewWizard />);
@@ -263,6 +315,27 @@ describe("TournamentNewWizard (v2)", () => {
 
     // Step 2 CTA is not yet wired to advance steps (step-3+ are placeholders).
     // For now, just verify the CTA becomes enabled when valid.
+  });
+
+  it("normalises franchise search results (case-insensitive, trim) and supports clearing the search", async () => {
+    const user = userEvent.setup();
+    render(<TournamentNewWizard />);
+
+    await completeStep1(user);
+    await user.click(screen.getByRole("button", { name: "Next" }));
+
+    const search = screen.getByRole("textbox", { name: "Search franchises" });
+    await user.type(search, "  st stithians ");
+
+    // Only the matching franchise card should remain visible.
+    expect(screen.getByText("St Stithians")).toBeInTheDocument();
+    expect(screen.queryByText("Beaulieu College")).not.toBeInTheDocument();
+
+    await user.clear(search);
+
+    // Clearing search restores the full directory.
+    expect(screen.getByText("Beaulieu College")).toBeInTheDocument();
+    expect(screen.getByText("St Stithians")).toBeInTheDocument();
   });
 
 

--- a/src/views/admin/TournamentNewWizard.test.jsx
+++ b/src/views/admin/TournamentNewWizard.test.jsx
@@ -224,6 +224,14 @@ describe("TournamentNewWizard (v2)", () => {
     expect(screen.getByText("Step 1 of 5, Tournament Details")).toBeInTheDocument();
   });
 
+  it("renders the vertical step rail with the correct current step", () => {
+    render(<TournamentNewWizard />);
+
+    // Step rail is not currently mounted in the shell, but this assertion
+    // keeps the intent explicit for when it is added.
+    expect(screen.queryByRole("navigation", { name: "Tournament wizard steps" })).not.toBeInTheDocument();
+  });
+
   it("does nothing when clicking a locked future step (guard clause)", async () => {
     const user = userEvent.setup();
     render(<TournamentNewWizard />);

--- a/src/views/admin/TournamentNewWizard.test.jsx
+++ b/src/views/admin/TournamentNewWizard.test.jsx
@@ -224,6 +224,21 @@ describe("TournamentNewWizard (v2)", () => {
     expect(screen.getByText("Step 1 of 5, Tournament Details")).toBeInTheDocument();
   });
 
+  it("does nothing when clicking a locked future step (guard clause)", async () => {
+    const user = userEvent.setup();
+    render(<TournamentNewWizard />);
+
+    // On initial render only step 1 is allowed. Step 3 is locked.
+    const step3 = screen.getByRole("button", { name: "Teams & Pools" });
+    expect(step3).toBeDisabled();
+
+    // Clicking a disabled button should not navigate.
+    await user.click(step3);
+
+    // Still on step 1.
+    expect(screen.getByText("Step 1 of 5, Tournament Details")).toBeInTheDocument();
+  });
+
   it("lets you add an age group via the Add button", async () => {
     const user = userEvent.setup();
     render(<TournamentNewWizard />);

--- a/src/views/admin/TournamentNewWizard.test.jsx
+++ b/src/views/admin/TournamentNewWizard.test.jsx
@@ -224,14 +224,6 @@ describe("TournamentNewWizard (v2)", () => {
     expect(screen.getByText("Step 1 of 5, Tournament Details")).toBeInTheDocument();
   });
 
-  it("renders the vertical step rail with the correct current step", () => {
-    render(<TournamentNewWizard />);
-
-    // Step rail is not currently mounted in the shell, but this assertion
-    // keeps the intent explicit for when it is added.
-    expect(screen.queryByRole("navigation", { name: "Tournament wizard steps" })).not.toBeInTheDocument();
-  });
-
   it("does nothing when clicking a locked future step (guard clause)", async () => {
     const user = userEvent.setup();
     render(<TournamentNewWizard />);

--- a/src/views/admin/TournamentNewWizard.test.jsx
+++ b/src/views/admin/TournamentNewWizard.test.jsx
@@ -211,6 +211,19 @@ describe("TournamentNewWizard (v2)", () => {
     expect(screen.getByText("Step 2 of 5, Franchises")).toBeInTheDocument();
   });
 
+  it("does not allow navigating to future steps via the stepper", async () => {
+    const user = userEvent.setup();
+    render(<TournamentNewWizard />);
+
+    // Step 5 should be locked until we've progressed.
+    const review = screen.getByRole("button", { name: "Review & Submit" });
+    expect(review).toBeDisabled();
+
+    await user.click(review);
+    // Still on step 1
+    expect(screen.getByText("Step 1 of 5, Tournament Details")).toBeInTheDocument();
+  });
+
   it("clamps points stepper interactions to a minimum of 0 for win/draw/loss", async () => {
     const user = userEvent.setup();
     render(<TournamentNewWizard />);

--- a/src/views/admin/TournamentNewWizard.test.jsx
+++ b/src/views/admin/TournamentNewWizard.test.jsx
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom/vitest";
 

--- a/src/views/admin/TournamentNewWizard.test.jsx
+++ b/src/views/admin/TournamentNewWizard.test.jsx
@@ -267,6 +267,11 @@ describe("TournamentNewWizard (v2)", () => {
     expect(screen.getByText(/Teams & Pools/)).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Save & Continue" })).toBeInTheDocument();
 
+    // Cover TopStepper onClick allowed path (idx <= maxStep):
+    // after reaching Step 3, clicking "Franchises" should navigate back to Step 2.
+    await user.click(screen.getByRole("button", { name: "Franchises" }));
+    expect(screen.getByText("Step 2 of 5, Franchises")).toBeInTheDocument();
+
     // Going back from Step 3 isn't implemented yet in the WIP shell,
     // but we still assert we've reached the Step 3 shell state.
   });

--- a/src/views/admin/tournamentNewWizard.css
+++ b/src/views/admin/tournamentNewWizard.css
@@ -37,6 +37,16 @@
   align-items: center;
   gap: var(--hj-space-2);
   min-width: 0;
+  border: 0;
+  background: transparent;
+  text-align: left;
+  padding: 0;
+  cursor: pointer;
+}
+
+.hj-tw2-topstep-item.is-locked {
+  cursor: not-allowed;
+  opacity: 0.6;
 }
 
 .hj-tw2-topstep-node {


### PR DESCRIPTION
Follow-on from merged #289.

Changes (so far):
- Lock top stepper navigation so future steps can't be clicked until reached.

Next:
- Prototype-exact step indicator (circles/connectors + locked rules)
- Navy sticky summary sidebar
- Scroll container + scrollTop on Next/Back

How to test:
- Visit /admin/tournament/new as admin
- Confirm stepper shows future steps disabled, cannot jump ahead

Risk: low