### PR TITLE
Tournament Wizard v2: scroll container + scroll-to-top

### DIFF
--- a/src/views/admin/TournamentNewWizard.jsx
+++ b/src/views/admin/TournamentNewWizard.jsx
@@ -697,6 +697,7 @@ export default function TournamentNewWizard() {
   const [step, setStep] = useState(0);
   const [canProceed, setCanProceed] = useState(false);
   const [maxStep, setMaxStep] = useState(0);
+  const mainRef = React.useRef(null);
   const [step1, setStep1] = useState({
     _continue: 0,
     name: "",
@@ -764,6 +765,11 @@ export default function TournamentNewWizard() {
     setMaxStep((m) => Math.max(m, step));
   }, [step]);
 
+  React.useEffect(() => {
+    if (!mainRef.current) return;
+    mainRef.current.scrollTop = 0;
+  }, [step]);
+
   const main = step === 0 ? (
     <Step1
       value={{ ...step1, activeDivisions }}
@@ -812,7 +818,7 @@ export default function TournamentNewWizard() {
     <div className="hj-tw2-shell">
       <TopStepper step={step} maxStep={maxStep} onStepChange={setStep} />
       <div className="hj-tw2-body">
-        {main}
+        <div ref={mainRef}>{main}</div>
         <SummarySidebar
           tournamentName={step1.name}
           venuesCount={step1.selectedVenues.length}

--- a/src/views/admin/tournamentNewWizard.css
+++ b/src/views/admin/tournamentNewWizard.css
@@ -7,11 +7,23 @@
   font-family: var(--hj-font-family-sans, system-ui, -apple-system, Segoe UI, Roboto, sans-serif);
 }
 
+.hj-tw2-shell {
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr);
+}
+
 .hj-tw2-body {
   display: grid;
   grid-template-columns: minmax(0, 1fr) 320px;
   gap: var(--hj-space-4);
   margin-top: var(--hj-space-3);
+  min-height: 0;
+}
+
+.hj-tw2-main {
+  min-height: 0;
+  overflow: auto;
+  max-height: calc(100dvh - 160px);
 }
 
 .hj-tw2-topstep {


### PR DESCRIPTION
Implements the wizard shell scroll container and resets scroll position on step change for /admin/tournament/new.

Changes:
- Make main panel scrollable within the wizard shell
- Scroll main panel to top on step changes

How to test:
- Visit /admin/tournament/new
- Fill Step 1 and navigate Next/Back; confirm the main panel scrolls and returns to top on step changes

Risk: low