### PR TITLE
Tournament Wizard v2: stepper connector colours

### DIFF
--- a/src/views/admin/tournamentNewWizard.css
+++ b/src/views/admin/tournamentNewWizard.css
@@ -110,6 +110,14 @@
   color: var(--hj-color-success-ink);
 }
 
+.hj-tw2-topstep-item--done .hj-tw2-topstep-rail {
+  background: var(--hj-color-success);
+}
+
+.hj-tw2-topstep-item--current .hj-tw2-topstep-rail {
+  background: var(--hj-color-brand-strong);
+}
+
 .hj-tw2-stepper {
   background: var(--hj-color-surface);
   border: 1px solid var(--hj-color-border-subtle);


### PR DESCRIPTION
Prototype parity: adjust top stepper connector rail colours for done/current states.

Changes:
- Done step connector uses success colour
- Current step connector uses brand strong colour

How to test:
- /admin/tournament/new
- Progress to step 2 and step 3, confirm connector rail colouring updates

Risk: low