### PR TITLE
Tournament Wizard v2: stepper hover + focus polish

### DIFF
--- a/src/views/admin/tournamentNewWizard.css
+++ b/src/views/admin/tournamentNewWizard.css
@@ -61,6 +61,16 @@
   opacity: 0.6;
 }
 
+.hj-tw2-topstep-item:focus-visible {
+  outline: 2px solid var(--hj-color-brand-strong);
+  outline-offset: 3px;
+  border-radius: var(--hj-radius-sm);
+}
+
+.hj-tw2-topstep-item:hover:not(.is-locked) .hj-tw2-topstep-label {
+  color: var(--hj-color-ink);
+}
+
 .hj-tw2-topstep-node {
   width: 26px;
   height: 26px;


### PR DESCRIPTION
Prototype parity: improve top stepper hover/focus-visible styles.

Changes:
- focus-visible outline on step buttons
- hover label colour for unlocked steps

How to test:
- /admin/tournament/new
- Tab through stepper buttons (see focus ring)
- Hover unlocked steps (label colour updates)

Risk: low