### PR TITLE
Wizard v2: Step 3 Pools assignment

### DIFF
--- a/src/views/admin/TournamentNewWizard.jsx
+++ b/src/views/admin/TournamentNewWizard.jsx
@@ -756,6 +756,8 @@ export default function TournamentNewWizard() {
   const [step3, setStep3] = useState({
     teamNameDraft: "",
     teams: [],
+    poolCount: 2,
+    pools: {},
   });
 
   const activeDivisions = useMemo(() => {
@@ -784,13 +786,32 @@ export default function TournamentNewWizard() {
     mainRef.current.scrollTop = 0;
   }, [step]);
 
+  const poolState = useMemo(() => {
+    const poolCount = Math.max(1, Math.min(12, Number(step3.poolCount) || 1));
+    const poolNames = Array.from({ length: poolCount }, (_, i) => `Pool ${String.fromCharCode(65 + i)}`);
+
+    const pools = {};
+    for (const p of poolNames) pools[p] = [];
+
+    for (const t of step3.teams) {
+      const desired = step3.pools[t.id];
+      const chosen = poolNames.includes(desired) ? desired : poolNames[0];
+      pools[chosen].push(t.id);
+    }
+
+    return { poolCount, poolNames, pools };
+  }, [step3.poolCount, step3.pools, step3.teams]);
+
   React.useEffect(() => {
     if (step === 0) return;
     if (step === 1) return;
     if (step === 2) {
-      setCanProceed(step3.teams.length >= 2);
+      const hasMinTeams = step3.teams.length >= 2;
+      const hasAtLeastTwoPools = poolState.poolCount >= 2;
+      const hasNoEmptyPools = poolState.poolNames.every((p) => poolState.pools[p].length > 0);
+      setCanProceed(hasMinTeams && hasAtLeastTwoPools && hasNoEmptyPools);
     }
-  }, [step, step3.teams.length]);
+  }, [step, step3.teams.length, poolState.poolCount, poolState.poolNames, poolState.pools]);
 
   const main = step === 0 ? (
     <Step1
@@ -866,9 +887,57 @@ export default function TournamentNewWizard() {
 
       <div className="hj-tw2-card">
         <div className="hj-tw2-card-title">Pools</div>
-        <div style={{ color: "var(--hj-color-ink-muted)" }}>
-          Pool assignment will be implemented next.
+
+        <div className="hj-tw2-row hj-tw2-row--tight">
+          <label className="hj-tw2-label" htmlFor="tw2-pool-count">
+            Number of pools
+          </label>
+          <input
+            id="tw2-pool-count"
+            className="hj-tw2-input hj-tw2-input--small"
+            type="number"
+            min={2}
+            max={12}
+            value={step3.poolCount}
+            onChange={(e) => {
+              const next = Number(e.target.value);
+              setStep3((s) => ({ ...s, poolCount: next }));
+            }}
+          />
         </div>
+
+        <div className="hj-tw2-pools" role="group" aria-label="Pool assignments">
+          {poolState.poolNames.map((poolName) => (
+            <div key={poolName} className="hj-tw2-pool">
+              <div className="hj-tw2-pool-title">{poolName}</div>
+              <div className="hj-tw2-pool-body">
+                {step3.teams.map((t) => (
+                  <label key={t.id} className="hj-tw2-pool-row">
+                    <input
+                      type="radio"
+                      aria-label={t.name}
+                      name={`team-${t.id}-pool`}
+                      value={poolName}
+                      checked={(step3.pools[t.id] || poolState.poolNames[0]) === poolName}
+                      onChange={() => {
+                        setStep3((s) => ({
+                          ...s,
+                          pools: { ...s.pools, [t.id]: poolName },
+                        }));
+                      }}
+                    />
+                    <span className="hj-tw2-pool-team">{t.name}</span>
+                  </label>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+
+        {step3.teams.length >= 2 && poolState.poolCount >= 2 &&
+        poolState.poolNames.some((p) => poolState.pools[p].length === 0) ? (
+          <div className="hj-tw2-error">Each pool must have at least one team</div>
+        ) : null}
       </div>
 
       <div className="hj-tw2-footer">

--- a/src/views/admin/TournamentNewWizard.test.jsx
+++ b/src/views/admin/TournamentNewWizard.test.jsx
@@ -268,14 +268,22 @@ describe("TournamentNewWizard (v2)", () => {
     // We should now be on Step 3.
     expect(await screen.findByText("No teams added yet.")).toBeInTheDocument();
 
-    // Add two teams to satisfy Step 3 validity.
+    // Add two teams.
     await user.type(screen.getByLabelText("Add team"), "Beaulieu U12A");
     await user.click(screen.getByRole("button", { name: "Add" }));
     await user.type(screen.getByLabelText("Add team"), "St Stithians U12A");
     await user.click(screen.getByRole("button", { name: "Add" }));
 
-    expect(screen.getByText("Beaulieu U12A")).toBeInTheDocument();
-    expect(screen.getByText("St Stithians U12A")).toBeInTheDocument();
+    expect(screen.getAllByText("Beaulieu U12A").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("St Stithians U12A").length).toBeGreaterThan(0);
+
+    // Step 3 now requires pools to be non-empty.
+    expect(screen.getByRole("button", { name: "Save & Continue" })).toBeDisabled();
+
+    // Assign each team to a different pool.
+    await user.click(screen.getAllByRole("radio", { name: "Beaulieu U12A" })[0]);
+    await user.click(screen.getAllByRole("radio", { name: "St Stithians U12A" })[1]);
+
     expect(screen.getByRole("button", { name: "Save & Continue" })).toBeEnabled();
 
     // Cover TopStepper onClick allowed path (idx <= maxStep):

--- a/src/views/admin/tournamentNewWizard.css
+++ b/src/views/admin/tournamentNewWizard.css
@@ -623,6 +623,60 @@
   align-items: center;
 }
 
+.hj-tw2-row--tight {
+  gap: var(--hj-space-2);
+  align-items: center;
+}
+
+.hj-tw2-input--small {
+  max-width: 120px;
+}
+
+.hj-tw2-pools {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--hj-space-3);
+  margin-top: var(--hj-space-3);
+}
+
+@media (max-width: 880px) {
+  .hj-tw2-pools {
+    grid-template-columns: 1fr;
+  }
+}
+
+.hj-tw2-pool {
+  border: 1px solid var(--hj-color-border-subtle);
+  border-radius: 12px;
+  overflow: hidden;
+  background: var(--hj-color-surface);
+}
+
+.hj-tw2-pool-title {
+  padding: 10px 12px;
+  font-weight: 700;
+  color: var(--hj-color-ink);
+  background: rgba(255, 255, 255, 0.04);
+  border-bottom: 1px solid var(--hj-color-border-subtle);
+}
+
+.hj-tw2-pool-body {
+  padding: 10px 12px;
+  display: grid;
+  gap: var(--hj-space-2);
+}
+
+.hj-tw2-pool-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  color: var(--hj-color-ink);
+}
+
+.hj-tw2-pool-team {
+  font-weight: 500;
+}
+
 .hj-tw2-label {
   font-size: var(--hj-font-size-sm);
   font-weight: var(--hj-font-weight-semibold);


### PR DESCRIPTION
## What changed\n- Finish Step 3 Pools: pool count + assignment UI\n- Step 3 validation now requires: at least 2 teams, at least 2 pools, and no empty pools\n- Add/update unit tests for the new Step 3 rules\n\n## How to test\n1. Go to /admin/tournament/new\n2. Complete Step 1 and Step 2\n3. On Step 3, add teams and assign them across pools\n4. Confirm Save & Continue only enables when each pool has at least one team\n\n## Evidence\n- npm run lint (no errors; existing exhaustive-deps warnings only)\n- npm test -- src/views/admin/TournamentNewWizard.test.jsx (20 tests passed)\n\n## Risk\nLow (new wizard route only)