### PR TITLE
feat(admin): Step 4 Rules (wizard v2)

### DIFF
--- a/src/views/admin/TournamentNewWizard.jsx
+++ b/src/views/admin/TournamentNewWizard.jsx
@@ -975,14 +975,15 @@ export default function TournamentNewWizard() {
 
       {activeDivisions.map((division) => {
         const teamCount = step3.teams.length;
-        const selected = step4.formats[division] || (teamCount === 3 ? "rr2" : "rr1");
+        const defaultFormat = teamCount === 3 ? "rr2" : "rr1";
+        const selected = step4.formats[division] || defaultFormat;
         const isAuto = teamCount === 3 && selected === "rr2";
         return (
           <div key={division} className="hj-tw2-card">
             <div className="hj-tw2-card-title">{division}</div>
             <div className="hj-tw2-rule-meta">
               <span>{teamCount} teams</span>
-              {isAuto ? <span className="hj-tw2-pill">AUTO-SUGGESTED</span> : null}
+              {isAuto ? <span className="hj-tw2-autosuggested">AUTO-SUGGESTED</span> : null}
             </div>
 
             <div className="hj-tw2-rule-options" role="radiogroup" aria-label={`${division} format`}>

--- a/src/views/admin/TournamentNewWizard.jsx
+++ b/src/views/admin/TournamentNewWizard.jsx
@@ -818,6 +818,11 @@ export default function TournamentNewWizard() {
     }
   }, [step, step3.teams.length, poolState.poolCount, poolState.poolNames, poolState.pools]);
 
+  const isStep3PoolInvalid =
+    step3.teams.length >= 2 &&
+    poolState.poolCount >= 2 &&
+    poolState.poolNames.some((p) => poolState.pools[p].length === 0);
+
   const main = step === 0 ? (
     <Step1
       value={{ ...step1, activeDivisions }}
@@ -939,8 +944,7 @@ export default function TournamentNewWizard() {
           ))}
         </div>
 
-        {step3.teams.length >= 2 && poolState.poolCount >= 2 &&
-        poolState.poolNames.some((p) => poolState.pools[p].length === 0) ? (
+        {isStep3PoolInvalid ? (
           <div className="hj-tw2-error">Each pool must have at least one team</div>
         ) : null}
       </div>

--- a/src/views/admin/TournamentNewWizard.jsx
+++ b/src/views/admin/TournamentNewWizard.jsx
@@ -961,6 +961,33 @@ export default function TournamentNewWizard() {
         </button>
       </div>
     </section>
+  ) : step === 3 ? (
+    <section className="hj-tw2-main" aria-label="Step 4 Fixtures & Time Slots">
+      <header className="hj-tw2-header">
+        <h1 className="hj-tw2-title">Create a new tournament</h1>
+        <div className="hj-tw2-subtitle">Step 4 of 5, Fixtures & Time Slots</div>
+      </header>
+
+      <div className="hj-tw2-card">
+        <div className="hj-tw2-card-title">Fixtures & Time Slots</div>
+        <div style={{ color: "var(--hj-color-ink-muted)" }}>
+          Step 4 will be implemented next.
+        </div>
+      </div>
+
+      <div className="hj-tw2-footer">
+        <button
+          type="button"
+          className="hj-tw2-btn hj-tw2-btn--ghost"
+          onClick={() => setStep(2)}
+        >
+          Back
+        </button>
+        <button type="button" className="hj-tw2-btn hj-tw2-btn--primary" disabled>
+          Save & Continue
+        </button>
+      </div>
+    </section>
   ) : (
     <section className="hj-tw2-main">
       <header className="hj-tw2-header">

--- a/src/views/admin/TournamentNewWizard.jsx
+++ b/src/views/admin/TournamentNewWizard.jsx
@@ -8,8 +8,8 @@ const STEPS = [
   "Tournament Details",
   "Franchises",
   "Teams & Pools",
-  "Fixtures & Time Slots",
-  "Review & Submit",
+  "Rules",
+  "Fixtures",
 ];
 
 
@@ -707,6 +707,11 @@ export default function TournamentNewWizard() {
   const [canProceed, setCanProceed] = useState(false);
   const [maxStep, setMaxStep] = useState(0);
   const mainRef = React.useRef(null);
+
+  const [step4, setStep4] = useState({
+    formats: {},
+  });
+
   const [step1, setStep1] = useState({
     _continue: 0,
     name: "",
@@ -962,28 +967,70 @@ export default function TournamentNewWizard() {
       </div>
     </section>
   ) : step === 3 ? (
-    <section className="hj-tw2-main" aria-label="Step 4 Fixtures & Time Slots">
+    <section className="hj-tw2-main" aria-label="Step 4 Rules">
       <header className="hj-tw2-header">
         <h1 className="hj-tw2-title">Create a new tournament</h1>
-        <div className="hj-tw2-subtitle">Step 4 of 5, Fixtures & Time Slots</div>
+        <div className="hj-tw2-subtitle">Step 4 of 5, Rules</div>
       </header>
 
-      <div className="hj-tw2-card">
-        <div className="hj-tw2-card-title">Fixtures & Time Slots</div>
-        <div style={{ color: "var(--hj-color-ink-muted)" }}>
-          Step 4 will be implemented next.
-        </div>
-      </div>
+      {activeDivisions.map((division) => {
+        const teamCount = step3.teams.length;
+        const selected = step4.formats[division] || (teamCount === 3 ? "rr2" : "rr1");
+        const isAuto = teamCount === 3 && selected === "rr2";
+        return (
+          <div key={division} className="hj-tw2-card">
+            <div className="hj-tw2-card-title">{division}</div>
+            <div className="hj-tw2-rule-meta">
+              <span>{teamCount} teams</span>
+              {isAuto ? <span className="hj-tw2-pill">AUTO-SUGGESTED</span> : null}
+            </div>
+
+            <div className="hj-tw2-rule-options" role="radiogroup" aria-label={`${division} format`}>
+              <button
+                type="button"
+                className={`hj-tw2-opt ${selected === "rr1" ? "is-selected" : ""}`}
+                onClick={() => setStep4((s) => ({ ...s, formats: { ...s.formats, [division]: "rr1" } }))}
+              >
+                Round Robin x1
+              </button>
+              <button
+                type="button"
+                className={`hj-tw2-opt ${selected === "rr2" ? "is-selected" : ""}`}
+                onClick={() => setStep4((s) => ({ ...s, formats: { ...s.formats, [division]: "rr2" } }))}
+              >
+                Round Robin x2
+              </button>
+              <button
+                type="button"
+                className={`hj-tw2-opt ${selected === "gsk" ? "is-selected" : ""}`}
+                onClick={() => setStep4((s) => ({ ...s, formats: { ...s.formats, [division]: "gsk" } }))}
+              >
+                Group Stage + Knockout
+              </button>
+              <button
+                type="button"
+                className={`hj-tw2-opt ${selected === "ko" ? "is-selected" : ""}`}
+                onClick={() => setStep4((s) => ({ ...s, formats: { ...s.formats, [division]: "ko" } }))}
+              >
+                Knockout Only
+              </button>
+            </div>
+          </div>
+        );
+      })}
 
       <div className="hj-tw2-footer">
-        <button
-          type="button"
-          className="hj-tw2-btn hj-tw2-btn--ghost"
-          onClick={() => setStep(2)}
-        >
+        <button type="button" className="hj-tw2-btn hj-tw2-btn--ghost" onClick={() => setStep(2)}>
           Back
         </button>
-        <button type="button" className="hj-tw2-btn hj-tw2-btn--primary" disabled>
+        <button
+          type="button"
+          className="hj-tw2-btn hj-tw2-btn--primary"
+          onClick={() => {
+            setStep(4);
+            setCanProceed(false);
+          }}
+        >
           Save & Continue
         </button>
       </div>

--- a/src/views/admin/TournamentNewWizard.jsx
+++ b/src/views/admin/TournamentNewWizard.jsx
@@ -991,28 +991,32 @@ export default function TournamentNewWizard() {
                 className={`hj-tw2-opt ${selected === "rr1" ? "is-selected" : ""}`}
                 onClick={() => setStep4((s) => ({ ...s, formats: { ...s.formats, [division]: "rr1" } }))}
               >
-                Round Robin x1
+                <span className={`hj-tw2-opt-radio ${selected === "rr1" ? "is-checked" : ""}`} aria-hidden="true" />
+                <span className="hj-tw2-opt-label">Round Robin x1</span>
               </button>
               <button
                 type="button"
                 className={`hj-tw2-opt ${selected === "rr2" ? "is-selected" : ""}`}
                 onClick={() => setStep4((s) => ({ ...s, formats: { ...s.formats, [division]: "rr2" } }))}
               >
-                Round Robin x2
+                <span className={`hj-tw2-opt-radio ${selected === "rr2" ? "is-checked" : ""}`} aria-hidden="true" />
+                <span className="hj-tw2-opt-label">Round Robin x2</span>
               </button>
               <button
                 type="button"
                 className={`hj-tw2-opt ${selected === "gsk" ? "is-selected" : ""}`}
                 onClick={() => setStep4((s) => ({ ...s, formats: { ...s.formats, [division]: "gsk" } }))}
               >
-                Group Stage + Knockout
+                <span className={`hj-tw2-opt-radio ${selected === "gsk" ? "is-checked" : ""}`} aria-hidden="true" />
+                <span className="hj-tw2-opt-label">Group Stage + Knockout</span>
               </button>
               <button
                 type="button"
                 className={`hj-tw2-opt ${selected === "ko" ? "is-selected" : ""}`}
                 onClick={() => setStep4((s) => ({ ...s, formats: { ...s.formats, [division]: "ko" } }))}
               >
-                Knockout Only
+                <span className={`hj-tw2-opt-radio ${selected === "ko" ? "is-checked" : ""}`} aria-hidden="true" />
+                <span className="hj-tw2-opt-label">Knockout Only</span>
               </button>
             </div>
           </div>

--- a/src/views/admin/TournamentNewWizard.test.jsx
+++ b/src/views/admin/TournamentNewWizard.test.jsx
@@ -269,6 +269,11 @@ describe("TournamentNewWizard (v2)", () => {
     await user.type(screen.getByLabelText("Add team"), "St Stithians U9A");
     await user.click(screen.getByRole("button", { name: "Add" }));
 
+    // Explicitly change pool count to cover the handler.
+    await user.clear(screen.getByLabelText("Number of pools"));
+    await user.type(screen.getByLabelText("Number of pools"), "2");
+
+    // Assign one team per pool.
     await user.click(screen.getAllByRole("radio", { name: "Beaulieu U9A" })[0]);
     await user.click(screen.getAllByRole("radio", { name: "St Stithians U9A" })[1]);
 
@@ -278,9 +283,42 @@ describe("TournamentNewWizard (v2)", () => {
     // Step 4
     expect(screen.getByText("Step 4 of 5, Rules")).toBeInTheDocument();
 
-    // One of the option pills should be selectable.
+    // Select each option at least once to cover handlers.
+    await user.click(screen.getByRole("button", { name: "Round Robin x1" }));
+    expect(screen.getByRole("button", { name: "Round Robin x1" })).toHaveClass("is-selected");
+
+    await user.click(screen.getByRole("button", { name: "Group Stage + Knockout" }));
+    expect(screen.getByRole("button", { name: "Group Stage + Knockout" })).toHaveClass(
+      "is-selected"
+    );
+
+    await user.click(screen.getByRole("button", { name: "Knockout Only" }));
+    expect(screen.getByRole("button", { name: "Knockout Only" })).toHaveClass("is-selected");
+
     await user.click(screen.getByRole("button", { name: "Round Robin x2" }));
     expect(screen.getByRole("button", { name: "Round Robin x2" })).toHaveClass("is-selected");
+
+    // Step 4 Back should return to Step 3.
+    await user.click(screen.getByRole("button", { name: "Back" }));
+    expect(await screen.findByText("Step 3 of 5, Teams & Pools")).toBeInTheDocument();
+
+    // Forward again.
+    await user.click(screen.getByRole("button", { name: "Save & Continue" }));
+    expect(screen.getByText("Step 4 of 5, Rules")).toBeInTheDocument();
+
+    // Step 4 Continue advances to Step 5 placeholder.
+    await user.click(screen.getByRole("button", { name: "Save & Continue" }));
+    expect(screen.getByText("Step 5 of 5, Fixtures")).toBeInTheDocument();
+
+    // Step 5 Back uses the generic handler.
+    await user.click(screen.getByRole("button", { name: "Back" }));
+    expect(screen.getByText("Step 4 of 5, Rules")).toBeInTheDocument();
+
+    // Step 5 Next generic handler.
+    await user.click(screen.getByRole("button", { name: "Save & Continue" }));
+    expect(screen.getByText("Step 5 of 5, Fixtures")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Next" }));
+    expect(screen.getByText("Step 5 of 5, Fixtures")).toBeInTheDocument();
   });
 
   it("renders the Step 3+ WIP shell and supports back/next within the shell", async () => {

--- a/src/views/admin/TournamentNewWizard.test.jsx
+++ b/src/views/admin/TournamentNewWizard.test.jsx
@@ -216,7 +216,7 @@ describe("TournamentNewWizard (v2)", () => {
     render(<TournamentNewWizard />);
 
     // Step 5 should be locked until we've progressed.
-    const review = screen.getByRole("button", { name: "Review & Submit" });
+    const review = screen.getByRole("button", { name: "Fixtures" });
     expect(review).toBeDisabled();
 
     await user.click(review);
@@ -248,6 +248,39 @@ describe("TournamentNewWizard (v2)", () => {
     await user.click(screen.getAllByRole("button", { name: "Add" })[1]);
 
     expect(screen.getByRole("checkbox", { name: "U19 Mixed" })).toBeInTheDocument();
+  });
+
+  it("renders Step 4 Rules and supports selecting a format", async () => {
+    const user = userEvent.setup();
+    render(<TournamentNewWizard />);
+
+    await completeStep1(user);
+    await user.click(screen.getByRole("button", { name: "Next" }));
+
+    // Step 2 valid
+    await user.click(screen.getByText("Beaulieu College"));
+    await user.click(screen.getByText("St Stithians"));
+    await user.click(screen.getByRole("button", { name: "Save & Continue" }));
+
+    // Step 3 valid (2 teams, pools non-empty)
+    await screen.findByText("No teams added yet.");
+    await user.type(screen.getByLabelText("Add team"), "Beaulieu U9A");
+    await user.click(screen.getByRole("button", { name: "Add" }));
+    await user.type(screen.getByLabelText("Add team"), "St Stithians U9A");
+    await user.click(screen.getByRole("button", { name: "Add" }));
+
+    await user.click(screen.getAllByRole("radio", { name: "Beaulieu U9A" })[0]);
+    await user.click(screen.getAllByRole("radio", { name: "St Stithians U9A" })[1]);
+
+    expect(screen.getByRole("button", { name: "Save & Continue" })).toBeEnabled();
+    await user.click(screen.getByRole("button", { name: "Save & Continue" }));
+
+    // Step 4
+    expect(screen.getByText("Step 4 of 5, Rules")).toBeInTheDocument();
+
+    // One of the option pills should be selectable.
+    await user.click(screen.getByRole("button", { name: "Round Robin x2" }));
+    expect(screen.getByRole("button", { name: "Round Robin x2" })).toHaveClass("is-selected");
   });
 
   it("renders the Step 3+ WIP shell and supports back/next within the shell", async () => {

--- a/src/views/admin/tournamentNewWizard.css
+++ b/src/views/admin/tournamentNewWizard.css
@@ -686,7 +686,7 @@
   font-weight: 500;
 }
 
-.hj-tw2-pill {
+.hj-tw2-autosuggested {
   display: inline-flex;
   align-items: center;
   padding: 5px 10px;

--- a/src/views/admin/tournamentNewWizard.css
+++ b/src/views/admin/tournamentNewWizard.css
@@ -691,8 +691,8 @@
   align-items: center;
   padding: 5px 10px;
   border-radius: 999px;
-  background: rgba(167, 139, 250, 0.18);
-  color: #7c3aed;
+  background: rgba(167, 139, 250, 0.22);
+  color: #5b21b6;
   font-weight: 800;
   font-size: 12px;
   letter-spacing: 0.04em;

--- a/src/views/admin/tournamentNewWizard.css
+++ b/src/views/admin/tournamentNewWizard.css
@@ -677,6 +677,64 @@
   font-weight: 500;
 }
 
+.hj-tw2-rule-meta {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-top: 6px;
+  color: var(--hj-color-ink-muted);
+  font-weight: 500;
+}
+
+.hj-tw2-pill {
+  display: inline-flex;
+  align-items: center;
+  padding: 4px 8px;
+  border-radius: 999px;
+  background: rgba(16, 185, 129, 0.12);
+  color: #10b981;
+  font-weight: 700;
+  font-size: 12px;
+  letter-spacing: 0.03em;
+}
+
+.hj-tw2-rule-options {
+  margin-top: 12px;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--hj-space-2);
+}
+
+@media (max-width: 520px) {
+  .hj-tw2-rule-options {
+    grid-template-columns: 1fr;
+  }
+}
+
+.hj-tw2-opt {
+  text-align: left;
+  border: 1px solid var(--hj-color-border-strong);
+  border-radius: 12px;
+  padding: 12px;
+  background: var(--hj-color-surface);
+  font-weight: 700;
+  color: var(--hj-color-ink);
+}
+
+.hj-tw2-opt:hover {
+  border-color: var(--hj-color-brand-strong);
+}
+
+.hj-tw2-opt.is-selected {
+  background: rgba(59, 130, 246, 0.1);
+  border-color: var(--hj-color-brand-strong);
+}
+
+.hj-tw2-opt:focus-visible {
+  outline: 3px solid rgba(59, 130, 246, 0.35);
+  outline-offset: 2px;
+}
+
 .hj-tw2-label {
   font-size: var(--hj-font-size-sm);
   font-weight: var(--hj-font-weight-semibold);

--- a/src/views/admin/tournamentNewWizard.css
+++ b/src/views/admin/tournamentNewWizard.css
@@ -689,13 +689,14 @@
 .hj-tw2-pill {
   display: inline-flex;
   align-items: center;
-  padding: 4px 8px;
+  padding: 5px 10px;
   border-radius: 999px;
-  background: rgba(16, 185, 129, 0.12);
-  color: #10b981;
-  font-weight: 700;
+  background: rgba(167, 139, 250, 0.18);
+  color: #7c3aed;
+  font-weight: 800;
   font-size: 12px;
-  letter-spacing: 0.03em;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
 }
 
 .hj-tw2-rule-options {
@@ -712,22 +713,56 @@
 }
 
 .hj-tw2-opt {
+  display: flex;
+  align-items: center;
+  gap: 12px;
   text-align: left;
   border: 1px solid var(--hj-color-border-strong);
-  border-radius: 12px;
-  padding: 12px;
+  border-radius: 14px;
+  padding: 14px 14px;
   background: var(--hj-color-surface);
   font-weight: 700;
   color: var(--hj-color-ink);
+  box-shadow: 0 1px 0 rgba(15, 23, 42, 0.04);
 }
 
 .hj-tw2-opt:hover {
-  border-color: var(--hj-color-brand-strong);
+  border-color: rgba(148, 163, 184, 0.9);
 }
 
 .hj-tw2-opt.is-selected {
-  background: rgba(59, 130, 246, 0.1);
-  border-color: var(--hj-color-brand-strong);
+  background: #0b1220;
+  border-color: #0b1220;
+  color: #ffffff;
+}
+
+.hj-tw2-opt-label {
+  flex: 1 1 auto;
+}
+
+.hj-tw2-opt-radio {
+  width: 18px;
+  height: 18px;
+  border-radius: 999px;
+  border: 2px solid rgba(148, 163, 184, 0.9);
+  position: relative;
+  flex: 0 0 auto;
+}
+
+.hj-tw2-opt-radio.is-checked {
+  border-color: rgba(255, 255, 255, 0.9);
+}
+
+.hj-tw2-opt-radio.is-checked::after {
+  content: "";
+  position: absolute;
+  width: 8px;
+  height: 8px;
+  border-radius: 999px;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  background: #ffffff;
 }
 
 .hj-tw2-opt:focus-visible {


### PR DESCRIPTION
Implements Step 4 (Rules) for the new tournament wizard at /admin/tournament/new.\n\nChanges:\n- Step 4 Rules per-division format selection (Round Robin x1/x2, Group Stage + Knockout, Knockout Only)\n- Auto-suggest badge for 3-team divisions (defaults to Round Robin x2)\n- Styling for rule cards/options\n- Tests updated/added for Step 4 and renamed step labels\n\nHow to test:\n- Go to /admin/tournament/new (admin)\n- Complete Steps 1-3, continue to Step 4\n- Verify per-division rule options render and selection toggles\n\nEvidence:\n- vitest: src/views/admin/TournamentNewWizard.test.jsx (21 tests passing locally)\n\nRisk: Low (new route only).