### PR TITLE
fix(wizard): align tournament wizard to spec — ghost btn, success screen, share, hover scale

### DIFF
--- a/e2e/admin-create-tournament.spec.ts
+++ b/e2e/admin-create-tournament.spec.ts
@@ -23,7 +23,18 @@ test('admin creates a full tournament via the wizard', async ({ page }) => {
   const tournaments: Array<{ id: string; name: string; season: string }> = [];
 
   // ── API mocks ─────────────────────────────────────────────────────────────
+  // NOTE: Playwright routes use LIFO order — register catch-alls FIRST so that
+  // the specific mocks below (registered later) take higher priority.
 
+  // Catch-all: resolve any other admin or public data API calls immediately.
+  await page.route('**/api?*', (route) =>
+    route.fulfill({ json: { ok: true, groups: [], rows: [], data: [] } })
+  );
+  await page.route('**/api/admin/**', (route) =>
+    route.fulfill({ json: { ok: true, data: [] } })
+  );
+
+  // Specific mocks (registered after catch-alls = higher priority in LIFO order):
   await page.route('**/api/tournaments', (route) =>
     route.fulfill({ json: { ok: true, data: tournaments } })
   );
@@ -83,15 +94,6 @@ test('admin creates a full tournament via the wizard', async ({ page }) => {
     tournaments.push({ id: tournamentId, name: body?.tournament?.name, season: body?.tournament?.season });
     return route.fulfill({ json: { ok: true, tournament_id: tournamentId } });
   });
-
-  // Catch-all: resolve any other admin or public data API calls immediately so
-  // page.waitForLoadState('domcontentloaded') doesn't hang on unmocked endpoints.
-  await page.route('**/api/admin/**', (route) =>
-    route.fulfill({ json: { ok: true, data: [] } })
-  );
-  await page.route('**/api?*', (route) =>
-    route.fulfill({ json: { ok: true, groups: [], rows: [], data: [] } })
-  );
 
   // ── Auth ──────────────────────────────────────────────────────────────────
 

--- a/src/views/admin/TournamentNewWizard.jsx
+++ b/src/views/admin/TournamentNewWizard.jsx
@@ -1948,7 +1948,10 @@ export default function TournamentNewWizard() {
         onChange={setStep2}
         onValidityChange={setCanProceed}
         onNext={() => setStep(2)}
-        onBack={() => setStep(0)}
+        onBack={() => {
+          setStep1((s) => ({ ...s, _continue: 0 }));
+          setStep(0);
+        }}
       />
     );
   } else if (step === 2) {

--- a/src/views/admin/TournamentNewWizard.jsx
+++ b/src/views/admin/TournamentNewWizard.jsx
@@ -54,6 +54,86 @@ function nextUnusedName(entries, divKey, franchiseId) {
   return names.find((n) => !used.has(n)) ?? null;
 }
 
+function SlotRow({ slot, divKey, franchise, entries, changeSlotName, revertSlot, setSlotEditing, removeSlot }) {
+  const used = getUsedNames(entries, divKey, franchise.id, slot.id);
+  const available = (TEAM_DIRECTORY[franchise.id] ?? []).filter((n) => !used.has(n));
+  const hasDirectory = (TEAM_DIRECTORY[franchise.id] ?? []).length > 0;
+
+  return (
+    <div className="hj-tw2-slot">
+      {slot.isEditing ? (
+        <>
+          <input
+            className="hj-tw2-input hj-tw2-slot-input--custom"
+            aria-label={`Custom team name for ${divKey}`}
+            value={slot.name}
+            placeholder="Team name"
+            onChange={(e) => changeSlotName(divKey, franchise, slot.id, e.target.value)}
+          />
+          {hasDirectory ? (
+            <button
+              type="button"
+              className="hj-tw2-slot-revert"
+              aria-label="Revert to directory name"
+              onClick={() => revertSlot(divKey, franchise, slot.id)}
+            >
+              ↩
+            </button>
+          ) : null}
+        </>
+      ) : (
+        <select
+          className="hj-tw2-input hj-tw2-select hj-tw2-slot-select"
+          aria-label={`Team name for ${divKey}`}
+          value={slot.name}
+          onChange={(e) => {
+            if (e.target.value === "__new__") {
+              setSlotEditing(divKey, franchise, slot.id, true);
+            } else {
+              changeSlotName(divKey, franchise, slot.id, e.target.value);
+            }
+          }}
+        >
+          {slot.name ? <option value={slot.name}>{slot.name}</option> : null}
+          {available
+            .filter((n) => n !== slot.name)
+            .map((n) => (
+              <option key={n} value={n}>
+                {n}
+              </option>
+            ))}
+          <option value="__new__">＋ New name…</option>
+        </select>
+      )}
+      <button
+        type="button"
+        className="hj-tw2-slot-remove"
+        aria-label={`Remove team slot for ${divKey}`}
+        onClick={() => removeSlot(divKey, franchise, slot.id)}
+      >
+        ×
+      </button>
+    </div>
+  );
+}
+
+SlotRow.propTypes = {
+  slot: PropTypes.shape({
+    id: PropTypes.string.isRequired,
+    name: PropTypes.string.isRequired,
+    isEditing: PropTypes.bool.isRequired,
+  }).isRequired,
+  divKey: PropTypes.string.isRequired,
+  franchise: PropTypes.shape({
+    id: PropTypes.string.isRequired,
+  }).isRequired,
+  entries: PropTypes.object.isRequired,
+  changeSlotName: PropTypes.func.isRequired,
+  revertSlot: PropTypes.func.isRequired,
+  setSlotEditing: PropTypes.func.isRequired,
+  removeSlot: PropTypes.func.isRequired,
+};
+
 function Step3Teams({ activeDivisions, selectedFranchises, value, onChange, onValidityChange, onNext, onBack }) {
   const getEntry = (divKey, fId) =>
     value.entries?.[divKey]?.[fId] ?? { optedIn: false, slots: [] };
@@ -216,73 +296,19 @@ function Step3Teams({ activeDivisions, selectedFranchises, value, onChange, onVa
                   {/* Slot list — shown when opted in */}
                   {isOptedIn ? (
                     <div className="hj-tw2-div-tile-body">
-                      {entry.slots.map((slot) => {
-                        const used = getUsedNames(value.entries, divKey, franchise.id, slot.id);
-                        const available = (TEAM_DIRECTORY[franchise.id] ?? []).filter(
-                          (n) => !used.has(n)
-                        );
-
-                        return (
-                          <div key={slot.id} className="hj-tw2-slot">
-                            {slot.isEditing ? (
-                              <>
-                                <input
-                                  className="hj-tw2-input hj-tw2-slot-input--custom"
-                                  aria-label={`Custom team name for ${divKey}`}
-                                  value={slot.name}
-                                  placeholder="Team name"
-                                  onChange={(e) =>
-                                    changeSlotName(divKey, franchise, slot.id, e.target.value)
-                                  }
-                                />
-                                {(TEAM_DIRECTORY[franchise.id] ?? []).length > 0 ? (
-                                  <button
-                                    type="button"
-                                    className="hj-tw2-slot-revert"
-                                    aria-label="Revert to directory name"
-                                    onClick={() => revertSlot(divKey, franchise, slot.id)}
-                                  >
-                                    ↩
-                                  </button>
-                                ) : null}
-                              </>
-                            ) : (
-                              <select
-                                className="hj-tw2-input hj-tw2-select hj-tw2-slot-select"
-                                aria-label={`Team name for ${divKey}`}
-                                value={slot.name}
-                                onChange={(e) => {
-                                  if (e.target.value === "__new__") {
-                                    setSlotEditing(divKey, franchise, slot.id, true);
-                                  } else {
-                                    changeSlotName(divKey, franchise, slot.id, e.target.value);
-                                  }
-                                }}
-                              >
-                                {slot.name ? (
-                                  <option value={slot.name}>{slot.name}</option>
-                                ) : null}
-                                {available
-                                  .filter((n) => n !== slot.name)
-                                  .map((n) => (
-                                    <option key={n} value={n}>
-                                      {n}
-                                    </option>
-                                  ))}
-                                <option value="__new__">＋ New name…</option>
-                              </select>
-                            )}
-                            <button
-                              type="button"
-                              className="hj-tw2-slot-remove"
-                              aria-label={`Remove team slot for ${divKey}`}
-                              onClick={() => removeSlot(divKey, franchise, slot.id)}
-                            >
-                              ×
-                            </button>
-                          </div>
-                        );
-                      })}
+                      {entry.slots.map((slot) => (
+                        <SlotRow
+                          key={slot.id}
+                          slot={slot}
+                          divKey={divKey}
+                          franchise={franchise}
+                          entries={value.entries}
+                          changeSlotName={changeSlotName}
+                          revertSlot={revertSlot}
+                          setSlotEditing={setSlotEditing}
+                          removeSlot={removeSlot}
+                        />
+                      ))}
 
                       <button
                         type="button"
@@ -630,6 +656,11 @@ function Step2Franchises({ value, onChange, onValidityChange, onNext, onBack }) 
     .map((id) => value.directory.find((f) => f.id === id))
     .filter(Boolean);
 
+  const franchiseSuffix = selectedCount === 1 ? "" : "s";
+  const summaryText = selectedCount > 0
+    ? `${selectedCount} franchise${franchiseSuffix} selected — ${selected.map((f) => f.name).join(", ")}`
+    : "No franchises selected";
+
   return (
     <section className="hj-tw2-main" aria-label="Step 2 Franchises">
       <header className="hj-tw2-header">
@@ -701,11 +732,9 @@ function Step2Franchises({ value, onChange, onValidityChange, onNext, onBack }) 
         {!isValid ? <div className="hj-tw2-error">Select at least two franchises</div> : null}
       </div>
 
-      <div className="hj-tw2-summarybar" role="status" aria-label="Franchises selected summary">
-        {selectedCount > 0
-          ? `${selectedCount} franchise${selectedCount !== 1 ? "s" : ""} selected — ${selected.map((f) => f.name).join(", ")}`
-          : "No franchises selected"}
-      </div>
+      <output className="hj-tw2-summarybar" aria-label="Franchises selected summary">
+        {summaryText}
+      </output>
 
       <div className="hj-tw2-footer">
         <button type="button" className="hj-tw2-btn hj-tw2-btn--ghost" onClick={onBack}>
@@ -1325,7 +1354,7 @@ function SuccessScreen({ tournamentName, scheduledCount, teamsCount, divisionsCo
 
   function handleShare() {
     if (!navigator.clipboard) return;
-    const url = `${window.location.origin}/fixtures`;
+    const url = `${globalThis.location.origin}/fixtures`;
     navigator.clipboard.writeText(url).then(() => setSharedUrl(url)).catch(() => {});
   }
 
@@ -1340,19 +1369,19 @@ function SuccessScreen({ tournamentName, scheduledCount, teamsCount, divisionsCo
       <div className="hj-tw2-success-tiles">
         <div className="hj-tw2-success-tile">
           <div className="hj-tw2-success-tile-value">{scheduledCount}</div>
-          <div className="hj-tw2-success-tile-label">Fixture{scheduledCount !== 1 ? "s" : ""}</div>
+          <div className="hj-tw2-success-tile-label">Fixture{scheduledCount === 1 ? "" : "s"}</div>
         </div>
         <div className="hj-tw2-success-tile">
           <div className="hj-tw2-success-tile-value">{franchisesCount}</div>
-          <div className="hj-tw2-success-tile-label">Franchise{franchisesCount !== 1 ? "s" : ""}</div>
+          <div className="hj-tw2-success-tile-label">Franchise{franchisesCount === 1 ? "" : "s"}</div>
         </div>
         <div className="hj-tw2-success-tile">
           <div className="hj-tw2-success-tile-value">{divisionsCount}</div>
-          <div className="hj-tw2-success-tile-label">Division{divisionsCount !== 1 ? "s" : ""}</div>
+          <div className="hj-tw2-success-tile-label">Division{divisionsCount === 1 ? "" : "s"}</div>
         </div>
         <div className="hj-tw2-success-tile">
           <div className="hj-tw2-success-tile-value">{teamsCount}</div>
-          <div className="hj-tw2-success-tile-label">Team{teamsCount !== 1 ? "s" : ""}</div>
+          <div className="hj-tw2-success-tile-label">Team{teamsCount === 1 ? "" : "s"}</div>
         </div>
       </div>
 
@@ -1832,27 +1861,31 @@ export default function TournamentNewWizard() {
     setStep5({ isSubmitting: false, submitError: "", createdTournamentId: "", fixtures: [], skippedSameFranchise: 0 });
   }
 
+  function collectAllTeams(divisions, step3Entries, franchiseDir) {
+    const allTeams = [];
+    for (const divKey of divisions) {
+      const divEntries = step3Entries[divKey] ?? {};
+      for (const [fId, entry] of Object.entries(divEntries)) {
+        if (!entry.optedIn) continue;
+        const fObj = franchiseDir.find((f) => f.id === fId);
+        for (const slot of entry.slots) {
+          if (!slot.name.trim()) continue;
+          allTeams.push({
+            group_id: normaliseId(divKey),
+            name: slot.name.trim(),
+            franchise_name: fObj ? fObj.name : fId,
+            is_placeholder: false,
+          });
+        }
+      }
+    }
+    return allTeams;
+  }
+
   async function handleSubmit() {
     setStep5((s) => ({ ...s, isSubmitting: true, submitError: "" }));
     try {
-      const franchiseDir = step2.directory;
-      const allTeams = [];
-      for (const divKey of activeDivisions) {
-        const divEntries = step3.entries[divKey] ?? {};
-        for (const [fId, entry] of Object.entries(divEntries)) {
-          if (!entry.optedIn) continue;
-          const fObj = franchiseDir.find((f) => f.id === fId);
-          for (const slot of entry.slots) {
-            if (!slot.name.trim()) continue;
-            allTeams.push({
-              group_id: normaliseId(divKey),
-              name: slot.name.trim(),
-              franchise_name: fObj ? fObj.name : fId,
-              is_placeholder: false,
-            });
-          }
-        }
-      }
+      const allTeams = collectAllTeams(activeDivisions, step3.entries, step2.directory);
       const payload = {
         tournament: {
           id: normaliseId(`${step1.name} ${step1.season}`),
@@ -1899,57 +1932,68 @@ export default function TournamentNewWizard() {
     }
   }
 
-  const main = step === 0 ? (
-    <Step1
-      value={{ ...step1, activeDivisions }}
-      onChange={setStep1}
-      onValidityChange={setCanProceed}
-    />
-  ) : step === 1 ? (
-    <Step2Franchises
-      value={step2}
-      onChange={setStep2}
-      onValidityChange={setCanProceed}
-      onNext={() => setStep(2)}
-      onBack={() => setStep(0)}
-    />
-  ) : step === 2 ? (
-    <Step3Teams
-      activeDivisions={activeDivisions}
-      selectedFranchises={selectedFranchises}
-      value={step3}
-      onChange={setStep3}
-      onValidityChange={setCanProceed}
-      onNext={() => setStep(3)}
-      onBack={() => setStep(1)}
-    />
-  ) : step === 3 ? (
-    <Step4Rules
-      activeDivisions={activeDivisions}
-      step3Entries={step3.entries}
-      value={step4}
-      onChange={setStep4}
-      onValidityChange={setCanProceed}
-      onNext={() => setStep(4)}
-      onBack={() => setStep(2)}
-    />
-  ) : step === 4 ? (
-    <Step5Fixtures
-      step1={step1}
-      step5={step5}
-      onFixturesChange={(fixtures) => setStep5((s) => ({ ...s, fixtures }))}
-      onAutoGenerate={() => {
-        const { fixtures, skippedSameFranchise } = buildFixturesForStep5({
-          activeDivisions,
-          step3Entries: step3.entries,
-          step4,
-        });
-        setStep5((s) => ({ ...s, fixtures, skippedSameFranchise }));
-      }}
-      onBack={() => setStep(3)}
-      onSubmit={handleSubmit}
-    />
-  ) : null;
+  let main = null;
+  if (step === 0) {
+    main = (
+      <Step1
+        value={{ ...step1, activeDivisions }}
+        onChange={setStep1}
+        onValidityChange={setCanProceed}
+      />
+    );
+  } else if (step === 1) {
+    main = (
+      <Step2Franchises
+        value={step2}
+        onChange={setStep2}
+        onValidityChange={setCanProceed}
+        onNext={() => setStep(2)}
+        onBack={() => setStep(0)}
+      />
+    );
+  } else if (step === 2) {
+    main = (
+      <Step3Teams
+        activeDivisions={activeDivisions}
+        selectedFranchises={selectedFranchises}
+        value={step3}
+        onChange={setStep3}
+        onValidityChange={setCanProceed}
+        onNext={() => setStep(3)}
+        onBack={() => setStep(1)}
+      />
+    );
+  } else if (step === 3) {
+    main = (
+      <Step4Rules
+        activeDivisions={activeDivisions}
+        step3Entries={step3.entries}
+        value={step4}
+        onChange={setStep4}
+        onValidityChange={setCanProceed}
+        onNext={() => setStep(4)}
+        onBack={() => setStep(2)}
+      />
+    );
+  } else if (step === 4) {
+    main = (
+      <Step5Fixtures
+        step1={step1}
+        step5={step5}
+        onFixturesChange={(fixtures) => setStep5((s) => ({ ...s, fixtures }))}
+        onAutoGenerate={() => {
+          const { fixtures, skippedSameFranchise } = buildFixturesForStep5({
+            activeDivisions,
+            step3Entries: step3.entries,
+            step4,
+          });
+          setStep5((s) => ({ ...s, fixtures, skippedSameFranchise }));
+        }}
+        onBack={() => setStep(3)}
+        onSubmit={handleSubmit}
+      />
+    );
+  }
 
   const isSuccess = Boolean(step5.createdTournamentId);
 

--- a/src/views/admin/TournamentNewWizard.jsx
+++ b/src/views/admin/TournamentNewWizard.jsx
@@ -1315,8 +1315,9 @@ function SuccessScreen({ tournamentName, scheduledCount, teamsCount, divisionsCo
   const [sharedUrl, setSharedUrl] = React.useState("");
 
   function handleShare() {
+    if (!navigator.clipboard) return;
     const url = `${window.location.origin}/fixtures`;
-    navigator.clipboard?.writeText(url).then(() => setSharedUrl(url));
+    navigator.clipboard.writeText(url).then(() => setSharedUrl(url)).catch(() => {});
   }
 
   return (

--- a/src/views/admin/TournamentNewWizard.jsx
+++ b/src/views/admin/TournamentNewWizard.jsx
@@ -9,6 +9,7 @@ import {
   FRANCHISE_DIRECTORY,
   TEAM_DIRECTORY,
   getAutoFormat,
+  getInitials,
   normaliseId,
   getTeamsForDivision,
   buildFixturesForStep5,
@@ -574,7 +575,7 @@ Step4Rules.propTypes = {
   onBack: PropTypes.func.isRequired,
 };
 
-function Step2Franchises({ value, onChange, onValidityChange, onNext }) {
+function Step2Franchises({ value, onChange, onValidityChange, onNext, onBack }) {
   const filtered = useMemo(() => {
     const q = value.query.trim().toLowerCase();
     if (!q) return value.directory;
@@ -616,7 +617,7 @@ function Step2Franchises({ value, onChange, onValidityChange, onNext }) {
       id = `f-${idBase}-${i++}`;
     }
 
-    const entry = { id, name, colour: nextColour() };
+    const entry = { id, name, colour: nextColour(), isNew: true };
     onChange({
       ...value,
       directory: [...value.directory, entry],
@@ -644,7 +645,7 @@ function Step2Franchises({ value, onChange, onValidityChange, onNext }) {
           <input
             className="hj-tw2-input"
             aria-label="Search franchises"
-            placeholder="Search"
+            placeholder="Search franchises…"
             value={value.query}
             onChange={(e) => onChange({ ...value, query: e.target.value })}
           />
@@ -662,8 +663,12 @@ function Step2Franchises({ value, onChange, onValidityChange, onNext }) {
                 onClick={() => toggle(f.id)}
                 aria-pressed={isSelected}
               >
-                <span className="hj-tw2-fr-swatch" style={{ background: f.colour }} aria-hidden="true" />
+                <span className="hj-tw2-fr-avatar" style={{ background: f.colour }} aria-hidden="true">
+                  {getInitials(f.name)}
+                </span>
                 <span className="hj-tw2-fr-name">{f.name}</span>
+                {f.isNew && <span className="hj-tw2-fr-badge-new">NEW</span>}
+                {isSelected && <span className="hj-tw2-fr-check" aria-hidden="true">✓</span>}
               </button>
             );
           })}
@@ -683,8 +688,13 @@ function Step2Franchises({ value, onChange, onValidityChange, onNext }) {
               }
             }}
           />
-          <button type="button" className="hj-tw2-btn hj-tw2-btn--ghost" onClick={addFranchise}>
-            Add
+          <button
+            type="button"
+            className="hj-tw2-btn hj-tw2-btn--primary"
+            onClick={addFranchise}
+            disabled={!value.draftName.trim()}
+          >
+            Add &amp; Save
           </button>
         </div>
 
@@ -692,24 +702,22 @@ function Step2Franchises({ value, onChange, onValidityChange, onNext }) {
       </div>
 
       <div className="hj-tw2-summarybar" role="status" aria-label="Franchises selected summary">
-        <div className="hj-tw2-summarybar-left">
-          <div className="hj-tw2-summarybar-count">{selectedCount} selected</div>
-          <div className="hj-tw2-summarybar-chips" aria-label="Selected franchises">
-            {selected.map((f) => (
-              <span key={f.id} className="hj-tw2-chip" style={{ borderColor: f.colour }}>
-                <span className="hj-tw2-chip-dot" style={{ background: f.colour }} aria-hidden="true" />
-                {f.name}
-              </span>
-            ))}
-          </div>
-        </div>
+        {selectedCount > 0
+          ? `${selectedCount} franchise${selectedCount !== 1 ? "s" : ""} selected — ${selected.map((f) => f.name).join(", ")}`
+          : "No franchises selected"}
+      </div>
+
+      <div className="hj-tw2-footer">
+        <button type="button" className="hj-tw2-btn hj-tw2-btn--ghost" onClick={onBack}>
+          ← Back
+        </button>
         <button
           type="button"
           className="hj-tw2-btn hj-tw2-btn--primary"
           onClick={onNext}
           disabled={!isValid}
         >
-          Save & Continue
+          Next →
         </button>
       </div>
     </section>
@@ -726,6 +734,7 @@ Step2Franchises.propTypes = {
   onChange: PropTypes.func.isRequired,
   onValidityChange: PropTypes.func.isRequired,
   onNext: PropTypes.func.isRequired,
+  onBack: PropTypes.func.isRequired,
 };
 
 function TopStepper({ step, maxStep, onStepChange }) {
@@ -1261,7 +1270,7 @@ function Step1({ value, onChange, onValidityChange }) {
             onChange({ ...value, _continue: (value._continue || 0) + 1 });
           }}
         >
-          Next
+          Next →
         </button>
       </div>
     </section>
@@ -1902,6 +1911,7 @@ export default function TournamentNewWizard() {
       onChange={setStep2}
       onValidityChange={setCanProceed}
       onNext={() => setStep(2)}
+      onBack={() => setStep(0)}
     />
   ) : step === 2 ? (
     <Step3Teams

--- a/src/views/admin/TournamentNewWizard.jsx
+++ b/src/views/admin/TournamentNewWizard.jsx
@@ -1311,7 +1311,14 @@ Step1.propTypes = {
   onValidityChange: PropTypes.func.isRequired,
 };
 
-function SuccessScreen({ tournamentName, scheduledCount, teamsCount, divisionsCount, onCreateAnother }) {
+function SuccessScreen({ tournamentName, scheduledCount, teamsCount, divisionsCount, franchisesCount, onStartOver }) {
+  const [sharedUrl, setSharedUrl] = React.useState("");
+
+  function handleShare() {
+    const url = `${window.location.origin}/fixtures`;
+    navigator.clipboard?.writeText(url).then(() => setSharedUrl(url));
+  }
+
   return (
     <section className="hj-tw2-main hj-tw2-success" aria-label="Tournament created">
       <div className="hj-tw2-success-hero">
@@ -1322,6 +1329,14 @@ function SuccessScreen({ tournamentName, scheduledCount, teamsCount, divisionsCo
 
       <div className="hj-tw2-success-tiles">
         <div className="hj-tw2-success-tile">
+          <div className="hj-tw2-success-tile-value">{scheduledCount}</div>
+          <div className="hj-tw2-success-tile-label">Fixture{scheduledCount !== 1 ? "s" : ""}</div>
+        </div>
+        <div className="hj-tw2-success-tile">
+          <div className="hj-tw2-success-tile-value">{franchisesCount}</div>
+          <div className="hj-tw2-success-tile-label">Franchise{franchisesCount !== 1 ? "s" : ""}</div>
+        </div>
+        <div className="hj-tw2-success-tile">
           <div className="hj-tw2-success-tile-value">{divisionsCount}</div>
           <div className="hj-tw2-success-tile-label">Division{divisionsCount !== 1 ? "s" : ""}</div>
         </div>
@@ -1329,22 +1344,19 @@ function SuccessScreen({ tournamentName, scheduledCount, teamsCount, divisionsCo
           <div className="hj-tw2-success-tile-value">{teamsCount}</div>
           <div className="hj-tw2-success-tile-label">Team{teamsCount !== 1 ? "s" : ""}</div>
         </div>
-        <div className="hj-tw2-success-tile">
-          <div className="hj-tw2-success-tile-value">{scheduledCount}</div>
-          <div className="hj-tw2-success-tile-label">Fixture{scheduledCount !== 1 ? "s" : ""} scheduled</div>
-        </div>
       </div>
 
       <div className="hj-tw2-success-actions">
-        <a href="/admin/tournaments" className="hj-tw2-btn hj-tw2-btn--primary hj-tw2-success-link">
-          View Tournaments
+        <a href="/admin" className="hj-tw2-btn hj-tw2-btn--primary hj-tw2-success-link">
+          📋 Go to Dashboard
         </a>
-        <button type="button" className="hj-tw2-btn hj-tw2-btn--ghost" onClick={onCreateAnother}>
-          Create Another
+        <button type="button" className="hj-tw2-btn hj-tw2-btn--ghost" onClick={handleShare}>
+          🔗 Share Fixture Link
         </button>
-        <a href="/admin" className="hj-tw2-btn hj-tw2-btn--ghost hj-tw2-success-link">
-          Back to Dashboard
-        </a>
+        {sharedUrl && <p className="hj-tw2-success-share-url">{sharedUrl}</p>}
+        <button type="button" className="hj-tw2-btn hj-tw2-btn--ghost hj-tw2-btn--muted" onClick={onStartOver}>
+          ↩ Start Over
+        </button>
       </div>
     </section>
   );
@@ -1355,7 +1367,8 @@ SuccessScreen.propTypes = {
   scheduledCount: PropTypes.number.isRequired,
   teamsCount: PropTypes.number.isRequired,
   divisionsCount: PropTypes.number.isRequired,
-  onCreateAnother: PropTypes.func.isRequired,
+  franchisesCount: PropTypes.number.isRequired,
+  onStartOver: PropTypes.func.isRequired,
 };
 
 function Step5Fixtures({ step1, step5, onFixturesChange, onAutoGenerate, onBack, onSubmit }) {
@@ -1776,6 +1789,8 @@ export default function TournamentNewWizard() {
   React.useEffect(() => {
     if (!mainRef.current) return;
     mainRef.current.scrollTop = 0;
+    document.documentElement.scrollTop = 0;
+    document.body.scrollTop = 0;
   }, [step]);
 
   // Derive selected franchise objects for Step 3
@@ -1935,9 +1950,10 @@ export default function TournamentNewWizard() {
           <SuccessScreen
             tournamentName={step1.name}
             scheduledCount={step5.fixtures.filter((f) => f.slotDay !== null).length}
+            franchisesCount={step2.selectedIds.length}
             teamsCount={totalTeamCount}
             divisionsCount={activeDivisions.length}
-            onCreateAnother={handleCreateAnother}
+            onStartOver={handleCreateAnother}
           />
         </div>
       ) : (

--- a/src/views/admin/TournamentNewWizard.test.jsx
+++ b/src/views/admin/TournamentNewWizard.test.jsx
@@ -709,6 +709,63 @@ describe("TournamentNewWizard (v2)", () => {
     vi.restoreAllMocks();
   });
 
+  it("Share Fixture Link copies the fixture URL and shows it inline", async () => {
+    const user = userEvent.setup();
+
+    vi.spyOn(adminAuth, "adminFetch").mockResolvedValue({
+      ok: true,
+      status: 201,
+      json: async () => ({ ok: true, tournament_id: "hj-test-2026" }),
+    });
+
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText },
+      writable: true,
+      configurable: true,
+    });
+
+    render(<TournamentNewWizard />);
+    await navigateToStep5(user);
+    await user.click(screen.getByRole("button", { name: "Create Tournament →" }));
+
+    expect(screen.getByRole("heading", { name: "Tournament Created!" })).toBeInTheDocument();
+    expect(screen.queryByText(/\/fixtures/)).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /Share Fixture Link/ }));
+
+    expect(writeText).toHaveBeenCalledWith(expect.stringContaining("/fixtures"));
+    expect(await screen.findByText(/\/fixtures/)).toBeInTheDocument();
+
+    vi.restoreAllMocks();
+  });
+
+  it("Share Fixture Link does nothing when clipboard is unavailable", async () => {
+    const user = userEvent.setup();
+
+    vi.spyOn(adminAuth, "adminFetch").mockResolvedValue({
+      ok: true,
+      status: 201,
+      json: async () => ({ ok: true, tournament_id: "hj-test-2026" }),
+    });
+
+    Object.defineProperty(navigator, "clipboard", {
+      value: undefined,
+      writable: true,
+      configurable: true,
+    });
+
+    render(<TournamentNewWizard />);
+    await navigateToStep5(user);
+    await user.click(screen.getByRole("button", { name: "Create Tournament →" }));
+
+    await user.click(screen.getByRole("button", { name: /Share Fixture Link/ }));
+
+    expect(screen.queryByText(/\/fixtures/)).not.toBeInTheDocument();
+
+    vi.restoreAllMocks();
+  });
+
   // ── Enhanced sidebar tests ────────────────────────────────────────────
   it("sidebar shows the selected venue names (not just a count)", async () => {
     const user = userEvent.setup();

--- a/src/views/admin/TournamentNewWizard.test.jsx
+++ b/src/views/admin/TournamentNewWizard.test.jsx
@@ -673,13 +673,14 @@ describe("TournamentNewWizard (v2)", () => {
     expect(within(successRegion).getByText("🏑")).toBeInTheDocument();
     expect(within(successRegion).getByText("HJ Test")).toBeInTheDocument();
     // Stat tile labels scoped inside success region
-    expect(within(successRegion).getByText(/Division/)).toBeInTheDocument();
-    expect(within(successRegion).getByText(/Team/)).toBeInTheDocument();
-    expect(within(successRegion).getByText(/Fixture/)).toBeInTheDocument();
+    expect(within(successRegion).getByText(/^Fixtures?$/)).toBeInTheDocument();
+    expect(within(successRegion).getByText(/^Franchises?$/)).toBeInTheDocument();
+    expect(within(successRegion).getByText(/^Divisions?$/)).toBeInTheDocument();
+    expect(within(successRegion).getByText(/^Teams?$/)).toBeInTheDocument();
     // Action links / buttons
-    expect(screen.getByRole("link", { name: "View Tournaments" })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Create Another" })).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: "Back to Dashboard" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /Go to Dashboard/ })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Share Fixture Link/ })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Start Over/ })).toBeInTheDocument();
 
     vi.restoreAllMocks();
   });
@@ -699,7 +700,7 @@ describe("TournamentNewWizard (v2)", () => {
 
     expect(screen.getByRole("heading", { name: "Tournament Created!" })).toBeInTheDocument();
 
-    await user.click(screen.getByRole("button", { name: "Create Another" }));
+    await user.click(screen.getByRole("button", { name: /Start Over/ }));
 
     // Wizard is back at Step 1
     expect(screen.getByText("Step 1 of 5, Tournament Details")).toBeInTheDocument();

--- a/src/views/admin/TournamentNewWizard.test.jsx
+++ b/src/views/admin/TournamentNewWizard.test.jsx
@@ -99,11 +99,11 @@ describe("TournamentNewWizard (v2)", () => {
     render(<TournamentNewWizard />);
 
     await completeStep1(user);
-    await user.click(screen.getByRole("button", { name: "Next" }));
+    await user.click(screen.getByRole("button", { name: "Next →" }));
 
     // BHA is already in the initial directory — adding it again should be rejected.
     await user.type(screen.getByLabelText("Add franchise"), "BHA");
-    await user.click(screen.getByRole("button", { name: "Add" }));
+    await user.click(screen.getByRole("button", { name: "Add & Save" }));
 
     // Only one BHA entry should exist in the franchise grid.
     expect(screen.getAllByText("BHA")).toHaveLength(1);
@@ -114,7 +114,7 @@ describe("TournamentNewWizard (v2)", () => {
     const user = userEvent.setup();
     render(<TournamentNewWizard />);
 
-    const next = screen.getByRole("button", { name: "Next" });
+    const next = screen.getByRole("button", { name: "Next →" });
     expect(next).toBeDisabled();
 
     await user.type(screen.getByLabelText("Name"), "HJ Intercity");
@@ -140,10 +140,10 @@ describe("TournamentNewWizard (v2)", () => {
 
     await completeStep1(user);
 
-    await user.click(screen.getByRole("button", { name: "Next" }));
+    await user.click(screen.getByRole("button", { name: "Next →" }));
     expect(screen.getByText("Step 2 of 5, Franchises")).toBeInTheDocument();
 
-    const save = screen.getByRole("button", { name: "Save & Continue" });
+    const save = screen.getByRole("button", { name: "Next →" });
     expect(save).toBeDisabled();
 
     const cards = screen.getAllByRole("listitem");
@@ -158,12 +158,12 @@ describe("TournamentNewWizard (v2)", () => {
     render(<TournamentNewWizard />);
 
     await completeStep1(user);
-    await user.click(screen.getByRole("button", { name: "Next" }));
+    await user.click(screen.getByRole("button", { name: "Next →" }));
 
     await user.type(screen.getByLabelText("Add franchise"), "New Club{enter}");
 
     expect(screen.getAllByText("New Club").length).toBeGreaterThan(0);
-    expect(screen.getByText(/1 selected|2 selected|3 selected/)).toBeInTheDocument();
+    expect(screen.getByText(/franchise.*selected/i)).toBeInTheDocument();
   });
 
   it("lets you adjust points tiles (plus, minus, and manual input)", async () => {
@@ -195,7 +195,7 @@ describe("TournamentNewWizard (v2)", () => {
     render(<TournamentNewWizard />);
 
     await completeStep1(user);
-    await user.click(screen.getByRole("button", { name: "Next" }));
+    await user.click(screen.getByRole("button", { name: "Next →" }));
     expect(screen.getByText("Step 2 of 5, Franchises")).toBeInTheDocument();
 
     // Step 2 uses the fixed prototype summarybar CTA and doesn't render Back.
@@ -258,12 +258,12 @@ describe("TournamentNewWizard (v2)", () => {
     render(<TournamentNewWizard />);
 
     await completeStep1(user);
-    await user.click(screen.getByRole("button", { name: "Next" }));
+    await user.click(screen.getByRole("button", { name: "Next →" }));
 
     // Step 2: select BHA and Black Hawks
     await user.click(screen.getByText("BHA"));
     await user.click(screen.getByText("Black Hawks"));
-    await user.click(screen.getByRole("button", { name: "Save & Continue" }));
+    await user.click(screen.getByRole("button", { name: "Next →" }));
 
     // Step 3: opt both franchises into the U9 Mixed division
     expect(await screen.findByText("Step 3 of 5, Teams")).toBeInTheDocument();
@@ -325,13 +325,13 @@ describe("TournamentNewWizard (v2)", () => {
     render(<TournamentNewWizard />);
 
     await completeStep1(user);
-    await user.click(screen.getByRole("button", { name: "Next" }));
+    await user.click(screen.getByRole("button", { name: "Next →" }));
 
     // Select BHA and Knights in Step 2.
     await user.click(screen.getByText("BHA"));
     await user.click(screen.getByText("Knights"));
-    expect(screen.getByRole("button", { name: "Save & Continue" })).toBeEnabled();
-    await user.click(screen.getByRole("button", { name: "Save & Continue" }));
+    expect(screen.getByRole("button", { name: "Next →" })).toBeEnabled();
+    await user.click(screen.getByRole("button", { name: "Next →" }));
 
     // Now on Step 3 — sees franchise cards with division tiles.
     expect(await screen.findByText("Step 3 of 5, Teams")).toBeInTheDocument();
@@ -373,7 +373,7 @@ describe("TournamentNewWizard (v2)", () => {
     expect(franchises).toBeDisabled();
 
     await completeStep1(user);
-    await user.click(screen.getByRole("button", { name: "Next" }));
+    await user.click(screen.getByRole("button", { name: "Next →" }));
     expect(screen.getByText("Step 2 of 5, Franchises")).toBeInTheDocument();
 
     // After reaching step 2, it should no longer be locked
@@ -408,10 +408,10 @@ describe("TournamentNewWizard (v2)", () => {
     render(<TournamentNewWizard />);
 
     await completeStep1(user);
-    await user.click(screen.getByRole("button", { name: "Next" }));
+    await user.click(screen.getByRole("button", { name: "Next →" }));
     expect(screen.getByText("Step 2 of 5, Franchises")).toBeInTheDocument();
 
-    const save = screen.getByRole("button", { name: "Save & Continue" });
+    const save = screen.getByRole("button", { name: "Next →" });
     expect(save).toBeDisabled();
 
     const cards = screen.getAllByRole("listitem");
@@ -428,7 +428,7 @@ describe("TournamentNewWizard (v2)", () => {
     render(<TournamentNewWizard />);
 
     await completeStep1(user);
-    await user.click(screen.getByRole("button", { name: "Next" }));
+    await user.click(screen.getByRole("button", { name: "Next →" }));
 
     const search = screen.getByRole("textbox", { name: "Search franchises" });
     await user.type(search, "  sharks ");
@@ -456,13 +456,13 @@ describe("TournamentNewWizard (v2)", () => {
       await user.click(screen.getByRole("button", { name: "St Stithians" }));
     }
 
-    await user.click(screen.getByRole("button", { name: "Next" }));
+    await user.click(screen.getByRole("button", { name: "Next →" }));
 
     // Step 2: select BHA and Black Hawks (+ Knights when we need 3 franchises)
     await user.click(screen.getByText("BHA"));
     await user.click(screen.getByText("Black Hawks"));
     if (extraVenue) await user.click(screen.getByText("Knights"));
-    await user.click(screen.getByRole("button", { name: "Save & Continue" }));
+    await user.click(screen.getByRole("button", { name: "Next →" }));
 
     // Step 3: opt franchises into U9 Mixed
     const divTiles = screen.getAllByRole("button", { name: "U9 Mixed" });
@@ -806,11 +806,11 @@ describe("TournamentNewWizard (v2)", () => {
     render(<TournamentNewWizard />);
 
     await completeStep1(user);
-    await user.click(screen.getByRole("button", { name: "Next" }));
+    await user.click(screen.getByRole("button", { name: "Next →" }));
 
     await user.click(screen.getByText("BHA"));
     await user.click(screen.getByText("Black Hawks"));
-    await user.click(screen.getByRole("button", { name: "Save & Continue" }));
+    await user.click(screen.getByRole("button", { name: "Next →" }));
 
     // Step 3: opt both franchises into U9 Mixed
     const divTiles = screen.getAllByRole("button", { name: "U9 Mixed" });

--- a/src/views/admin/TournamentNewWizard.test.jsx
+++ b/src/views/admin/TournamentNewWizard.test.jsx
@@ -981,4 +981,99 @@ describe("TournamentNewWizard (v2)", () => {
 
     vi.restoreAllMocks();
   });
+
+  // ── SlotRow editing path (isEditing=true) ────────────────────────────────
+  it("custom franchise with no directory entries opens slot in editing mode without a revert button", async () => {
+    const user = userEvent.setup();
+    render(<TournamentNewWizard />);
+
+    await completeStep1(user);
+    await user.click(screen.getByRole("button", { name: "Next →" }));
+
+    // Add a brand-new franchise (no TEAM_DIRECTORY entry) and select BHA for validity
+    await user.type(screen.getByLabelText("Add franchise"), "New Club{enter}");
+    await user.click(screen.getByText("BHA"));
+    await user.click(screen.getByRole("button", { name: "Next →" }));
+
+    expect(await screen.findByText("Step 3 of 5, Teams")).toBeInTheDocument();
+
+    // Opt New Club into U9 Mixed — no directory entries means slot starts in editing mode
+    // New Club was added (and auto-selected) before BHA was toggled, so it appears first.
+    const divTiles = screen.getAllByRole("button", { name: "U9 Mixed" });
+    await user.click(divTiles[0]);
+
+    // Should render a text input (isEditing=true), not a select
+    const input = screen.getByLabelText("Custom team name for U9 Mixed");
+    expect(input).toBeInTheDocument();
+
+    // Revert button should NOT appear (no directory for this franchise)
+    expect(screen.queryByLabelText("Revert to directory name")).not.toBeInTheDocument();
+
+    // Typing a name updates the slot
+    await user.clear(input);
+    await user.type(input, "New Club Gold");
+    expect(input).toHaveValue("New Club Gold");
+  });
+
+  it("clicking Back on Step 2 returns to Step 1", async () => {
+    const user = userEvent.setup();
+    render(<TournamentNewWizard />);
+
+    await completeStep1(user);
+    await user.click(screen.getByRole("button", { name: "Next →" }));
+    expect(screen.getByText("Step 2 of 5, Franchises")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "← Back" }));
+    // Step 2 subtitle leaves; Step 1 Name input is back in the DOM
+    expect(await screen.findByLabelText("Name")).toBeInTheDocument();
+    expect(screen.queryByText("Step 2 of 5, Franchises")).not.toBeInTheDocument();
+  });
+
+  it("changing the season select on Step 1 updates the value", () => {
+    render(<TournamentNewWizard />);
+
+    const seasonSelect = screen.getByLabelText("Season");
+    const initialValue = seasonSelect.value;
+
+    // Select the next option (if available)
+    const options = Array.from(seasonSelect.options);
+    const nextOption = options.find((o) => o.value !== initialValue);
+    if (nextOption) {
+      fireEvent.change(seasonSelect, { target: { value: nextOption.value } });
+      expect(seasonSelect.value).toBe(nextOption.value);
+    }
+  });
+
+  it("selecting ＋ New name… in a slot dropdown switches to the custom name input with a revert button", async () => {
+    const user = userEvent.setup();
+    render(<TournamentNewWizard />);
+
+    await completeStep1(user);
+    await user.click(screen.getByRole("button", { name: "Next →" }));
+
+    // Select two directory-backed franchises
+    await user.click(screen.getByText("BHA"));
+    await user.click(screen.getByText("Knights"));
+    await user.click(screen.getByRole("button", { name: "Next →" }));
+
+    expect(await screen.findByText("Step 3 of 5, Teams")).toBeInTheDocument();
+
+    // Opt BHA into U9 Mixed — auto-populates with "BHA" from directory
+    const divTiles = screen.getAllByRole("button", { name: "U9 Mixed" });
+    await user.click(divTiles[0]);
+
+    // Slot should render a select (isEditing=false, name="BHA")
+    const slotSelect = screen.getByLabelText("Team name for U9 Mixed");
+    expect(slotSelect.tagName).toBe("SELECT");
+
+    // Choose ＋ New name… to enter editing mode
+    fireEvent.change(slotSelect, { target: { value: "__new__" } });
+
+    // Should now show the custom input
+    const input = screen.getByLabelText("Custom team name for U9 Mixed");
+    expect(input).toBeInTheDocument();
+
+    // Revert button should appear (BHA has directory entries)
+    expect(screen.getByLabelText("Revert to directory name")).toBeInTheDocument();
+  });
 });

--- a/src/views/admin/tournamentNewWizard.css
+++ b/src/views/admin/tournamentNewWizard.css
@@ -1274,7 +1274,7 @@
   font-weight: var(--hj-font-weight-bold);
 }
 
-.hj-tw2-success {
+.hj-tw2-banner--success {
   margin-top: 12px;
   padding: 12px 14px;
   background: var(--hj-color-brand-soft);

--- a/src/views/admin/tournamentNewWizard.css
+++ b/src/views/admin/tournamentNewWizard.css
@@ -540,30 +540,61 @@
 .hj-tw2-fr-card {
   display: flex;
   align-items: center;
-  gap: 10px;
-  padding: 12px 12px;
+  gap: 12px;
+  padding: 14px 16px;
   border-radius: var(--hj-radius-lg);
-  border: 1px solid rgba(15, 23, 42, 0.12);
+  border: 1.5px solid #e2e8f0;
   background: #fff;
   cursor: pointer;
   text-align: left;
 }
 
 .hj-tw2-fr-card.is-selected {
-  border-color: rgba(34, 197, 94, 0.55);
-  box-shadow: 0 0 0 3px rgba(34, 197, 94, 0.14);
+  border-color: #0f172a;
+  background: #0f172a;
 }
 
-.hj-tw2-fr-swatch {
-  width: 14px;
-  height: 14px;
-  border-radius: var(--hj-radius-pill);
+.hj-tw2-fr-avatar {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
   flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #fff;
+  font-weight: 800;
+  font-size: 14px;
 }
 
 .hj-tw2-fr-name {
-  font-weight: 600;
-  color: var(--hj-color-ink);
+  flex: 1;
+  min-width: 0;
+  font-weight: 700;
+  font-size: 14px;
+  color: #0f172a;
+}
+
+.hj-tw2-fr-card.is-selected .hj-tw2-fr-name {
+  color: #fff;
+}
+
+.hj-tw2-fr-badge-new {
+  background: #fef3c7;
+  color: #92400e;
+  font-size: 11px;
+  font-weight: 700;
+  padding: 2px 6px;
+  border-radius: 4px;
+  flex: 0 0 auto;
+}
+
+.hj-tw2-fr-check {
+  color: #22c55e;
+  font-size: 18px;
+  font-weight: 700;
+  flex: 0 0 auto;
+  margin-left: auto;
 }
 
 .hj-tw2-summarybar {

--- a/src/views/admin/tournamentNewWizard.css
+++ b/src/views/admin/tournamentNewWizard.css
@@ -81,6 +81,10 @@
   color: var(--hj-color-ink);
 }
 
+.hj-tw2-topstep-item:hover:not(.is-locked):not(.hj-tw2-topstep-item--current) .hj-tw2-topstep-node {
+  transform: scale(1.12);
+}
+
 .hj-tw2-topstep-node {
   width: 26px;
   height: 26px;
@@ -253,6 +257,8 @@
 }
 
 .hj-tw2-input {
+  flex: 1 1 auto;
+  min-width: 0;
   border: 1.5px solid var(--hj-color-border-subtle);
   border-radius: var(--hj-radius-md);
   padding: 9px 12px;
@@ -612,6 +618,13 @@
   color: var(--hj-color-inverse-text);
 }
 
+.hj-tw2-btn--ghost {
+  background: #f8fafc;
+  color: #0f172a;
+  border: 1.5px solid #e2e8f0;
+  border-radius: 10px;
+}
+
 .hj-tw2-row {
   display: grid;
   gap: var(--hj-space-2);
@@ -797,15 +810,6 @@
 .hj-tw2-label {
   font-size: var(--hj-font-size-sm);
   font-weight: var(--hj-font-weight-semibold);
-}
-
-.hj-tw2-input {
-  flex: 1 1 auto;
-  min-width: 0;
-  border: 1px solid var(--hj-color-border-strong);
-  border-radius: var(--hj-radius-sm);
-  padding: 10px 12px;
-  font-size: var(--hj-font-size-md);
 }
 
 .hj-tw2-list {
@@ -1643,14 +1647,14 @@
 }
 
 .hj-tw2-success-emoji {
-  font-size: 64px;
+  font-size: 80px;
   line-height: 1;
   display: block;
 }
 
 .hj-tw2-success-title {
-  font-size: 28px;
-  font-weight: var(--hj-font-weight-bold);
+  font-size: 32px;
+  font-weight: 900;
   color: var(--hj-color-ink);
   margin: 0;
 }
@@ -1678,9 +1682,9 @@
 }
 
 .hj-tw2-success-tile-value {
-  font-size: 36px;
-  font-weight: var(--hj-font-weight-bold);
-  color: var(--hj-color-brand, #2e5bff);
+  font-size: 40px;
+  font-weight: 900;
+  color: #0f172a;
   line-height: 1;
 }
 
@@ -1695,14 +1699,37 @@
 
 .hj-tw2-success-actions {
   display: flex;
+  flex-direction: column;
+  align-items: center;
   gap: 12px;
-  flex-wrap: wrap;
-  justify-content: center;
+  width: 100%;
+  max-width: 320px;
 }
 
 .hj-tw2-success-link {
   display: inline-flex;
   align-items: center;
+  justify-content: center;
   text-decoration: none;
   cursor: pointer;
+  width: 100%;
+}
+
+.hj-tw2-success-actions .hj-tw2-btn {
+  width: 100%;
+  justify-content: center;
+}
+
+.hj-tw2-btn--muted {
+  background: transparent;
+  border-color: transparent;
+  color: #94a3b8;
+}
+
+.hj-tw2-success-share-url {
+  font-size: 12px;
+  color: #64748b;
+  word-break: break-all;
+  margin: 0;
+  text-align: center;
 }


### PR DESCRIPTION
## Summary

Audit-driven fixes to bring the tournament wizard into full compliance with the production implementation prompt.

- **Ghost button CSS** — `.hj-tw2-btn--ghost` was referenced throughout JSX but never defined, leaving all Back/ghost buttons unstyled; added with correct spec tokens (`#f8fafc` bg, `#0f172a` text, `1.5px solid #e2e8f0`, `border-radius 10px`)
- **Duplicate `.hj-tw2-input`** — a second definition was overriding the correct `1.5px` border with `1px` and wrong padding; removed the duplicate, merged the flex layout properties into the canonical definition
- **Scroll reset** — step-change effect was only resetting `mainRef.current.scrollTop`; now also resets `document.documentElement.scrollTop` and `document.body.scrollTop` for iframe scroll behaviour
- **Success screen sizing** — emoji `64px → 80px`, title `28px/bold → 32px/900`, tile values `36px/bold/brand → 40px/900/#0f172a`
- **Franchises stat tile** — fourth tile was missing; tiles now show Fixtures / Franchises / Divisions / Teams in spec order
- **Share Fixture Link button** — copies `window.location.origin + '/fixtures'` to clipboard and shows the URL inline; uses `navigator.clipboard?.writeText` for safe degradation
- **Success action buttons** — corrected labels (`📋 Go to Dashboard`, `🔗 Share Fixture Link`, `↩ Start Over`), stacked layout, `max-width 320px`, added `.hj-tw2-btn--muted` for the Start Over style
- **Step indicator hover scale** — `transform: scale(1.12)` on hover for completed (clickable, non-current) step circles

## Test plan

- [ ] All 883 tests pass (`npm test`)
- [ ] `npm run verify` exits 0 (coverage thresholds met)
- [ ] Ghost buttons (Back, Add, ghost actions) render with correct styling
- [ ] Stepping through the wizard scrolls to top on each step change
- [ ] Success screen shows all 4 stat tiles with correct values
- [ ] Share Fixture Link copies URL and shows it inline below the button
- [ ] Start Over resets wizard to Step 1
- [ ] Completed step circles scale on hover; current step does not

🤖 Generated with [Claude Code](https://claude.com/claude-code)