### PR TITLE
feat(wizard): close TournamentNewWizard v2 prototype gaps

### DIFF
--- a/db/migrations/017_game_timing_points.sql
+++ b/db/migrations/017_game_timing_points.sql
@@ -1,0 +1,3 @@
+ALTER TABLE tournament
+  ADD COLUMN IF NOT EXISTS game_timing JSONB,
+  ADD COLUMN IF NOT EXISTS points_config JSONB;

--- a/e2e/admin-create-tournament.spec.ts
+++ b/e2e/admin-create-tournament.spec.ts
@@ -70,9 +70,9 @@ test('admin creates a full tournament via the wizard', async ({ page }) => {
 
   // ── Step 1: Tournament Details ────────────────────────────────────────────
 
-  await page.getByRole('textbox', { name: 'Name', exact: true }).fill(tournamentName);
-  await page.getByRole('textbox', { name: 'Start date' }).fill('2026-06-07');
-  await page.getByRole('textbox', { name: 'End date' }).fill('2026-06-08');
+  await page.locator('input[aria-label="Name"]').fill(tournamentName);
+  await page.locator('input[aria-label="Start date"]').fill('2026-06-07');
+  await page.locator('input[aria-label="End date"]').fill('2026-06-08');
 
   // Select a venue (pill button)
   await page.getByRole('button', { name: 'Beaulieu College' }).click();
@@ -80,7 +80,9 @@ test('admin creates a full tournament via the wizard', async ({ page }) => {
   // Enable one division
   await page.getByRole('checkbox', { name: 'U9 Mixed' }).check();
 
-  await page.getByRole('button', { name: 'Next →' }).click();
+  const nextBtn1 = page.getByRole('button', { name: 'Next →' });
+  await expect(nextBtn1).toBeEnabled();
+  await nextBtn1.click();
 
   // ── Step 2: Franchises ────────────────────────────────────────────────────
 

--- a/e2e/admin-create-tournament.spec.ts
+++ b/e2e/admin-create-tournament.spec.ts
@@ -106,8 +106,10 @@ test('admin creates a full tournament via the wizard', async ({ page }) => {
 
   await expect(page.getByText('Step 3 of 5')).toBeVisible();
 
-  // Opt both franchises into U9 Mixed — each tile click adds a default team slot
-  const divTiles = page.getByRole('button', { name: 'U9 Mixed' });
+  // Each franchise-division tile is a .hj-tw2-div-tile-header button.
+  // With 2 franchises and 1 division there are exactly 2 tiles.
+  const divTiles = page.locator('.hj-tw2-div-tile-header');
+  await expect(divTiles.first()).toBeVisible();
   await divTiles.first().click({ force: true });
   await divTiles.nth(1).click({ force: true });
 

--- a/e2e/admin-create-tournament.spec.ts
+++ b/e2e/admin-create-tournament.spec.ts
@@ -106,6 +106,11 @@ test('admin creates a full tournament via the wizard', async ({ page }) => {
 
   await expect(page.getByText('Step 3 of 5')).toBeVisible();
 
+  // Opt both franchises into U9 Mixed — each tile click adds a default team slot
+  const divTiles = page.getByRole('button', { name: 'U9 Mixed' });
+  await divTiles.first().click({ force: true });
+  await divTiles.nth(1).click({ force: true });
+
   const nextBtn3 = page.locator('button.hj-tw2-btn--primary', { hasText: 'Next' });
   await expect(nextBtn3).toBeEnabled();
   await nextBtn3.click({ force: true });

--- a/e2e/admin-create-tournament.spec.ts
+++ b/e2e/admin-create-tournament.spec.ts
@@ -1,40 +1,32 @@
 import { test, expect } from '@playwright/test';
 
 /**
- * Full tournament creation smoke test.
+ * Full tournament creation smoke test — TournamentNewWizard v2 (5-step).
  *
  * Scenario: HJ Spring Cup 2026
- *   Venues:    Dainfern College, Beaulieu College, St Stithians
- *   Groups:
- *     - U11 Boys     (Round-robin,  3 teams, Dainfern + Beaulieu, fixtures generated)
- *     - U11 Girls    (Round-robin,  2 teams, Beaulieu, date via Girls Day shortcut)
- *     - U13 Knockout (Knockout,     3 placeholder teams via quick-add, St Stithians)
- *   Franchises: Gryphons, Purple Panthers, Knights, Blue Hawks
- *   Fixtures:   Round-robin generator for U11 Boys → 3 fixtures at Dainfern
+ *   Step 1 (Tournament Details): name, dates, Beaulieu College venue, U9 Mixed division
+ *   Step 2 (Franchises):        BHA + Black Hawks
+ *   Step 3 (Teams & Pools):     one team per franchise in U9 Mixed
+ *   Step 4 (Rules):             accept auto-selected format
+ *   Step 5 (Fixtures):          auto-generate + place one fixture
  */
 test('admin creates a full tournament via the wizard', async ({ page }) => {
-  test.setTimeout(180_000); // 50+ interactions; extra headroom for final page nav
+  test.setTimeout(180_000);
   const email = process.env.PW_ADMIN_EMAIL || 'admin@example.com';
   const token = process.env.PW_ADMIN_TOKEN || 'sess';
   const expiresAt = new Date(Date.now() + 60 * 60 * 1000).toISOString();
 
   const tournamentName = 'HJ Spring Cup 2026';
-  const season = '2026';
   const tournaments: Array<{ id: string; name: string; season: string }> = [];
 
   // ── API mocks ─────────────────────────────────────────────────────────────
-  // NOTE: Playwright routes use LIFO order — register catch-alls FIRST so that
-  // the specific mocks below (registered later) take higher priority.
 
-  // Catch-all: resolve any other admin or public data API calls immediately.
   await page.route('**/api?*', (route) =>
     route.fulfill({ json: { ok: true, groups: [], rows: [], data: [] } })
   );
   await page.route('**/api/admin/**', (route) =>
     route.fulfill({ json: { ok: true, data: [] } })
   );
-
-  // Specific mocks (registered after catch-alls = higher priority in LIFO order):
   await page.route('**/api/tournaments', (route) =>
     route.fulfill({ json: { ok: true, data: tournaments } })
   );
@@ -44,55 +36,11 @@ test('admin creates a full tournament via the wizard', async ({ page }) => {
   await page.route('**/api/announcements*', (route) =>
     route.fulfill({ json: { ok: true, data: [] } })
   );
-  await page.route('**/api/admin/venues', (route) =>
-    route.fulfill({
-      json: {
-        ok: true,
-        data: [
-          { name: 'Dainfern College' },
-          { name: 'Beaulieu College' },
-          { name: 'St Stithians' },
-        ],
-      },
-    })
-  );
-  await page.route('**/api/admin/franchises', (route) =>
-    route.fulfill({
-      json: {
-        ok: true,
-        data: [
-          { id: 'f1', name: 'Gryphons' },
-          { id: 'f2', name: 'Purple Panthers' },
-          { id: 'f3', name: 'Knights' },
-          { id: 'f4', name: 'Blue Hawks' },
-        ],
-      },
-    })
-  );
-  await page.route('**/api/admin/franchise-teams*', (route) => {
-    const url = new URL(route.request().url());
-    const franchise = url.searchParams.get('franchise') ?? '';
-    const teams: Record<string, string[]> = {
-      'Gryphons':         ['Gryphons Gold', 'Gryphons Green', 'Gryphons Blue'],
-      'Purple Panthers':  ['PP Amber', 'PP Navy', 'PP Emerald'],
-      'Knights':          ['Knights Orange', 'Knights Silver'],
-      'Blue Hawks':       ['Blue Hawks Blue', 'Blue Hawks Red'],
-    };
-    return route.fulfill({ json: { ok: true, data: teams[franchise] ?? [] } });
-  });
-  await page.route('**/api/admin/divisions', (route) =>
-    route.fulfill({
-      json: { ok: true, data: ['U11 Boys', 'U11 Girls', 'U13 Boys', 'U13 Girls'] },
-    })
-  );
-  await page.route('**/api/admin/tournament-exists*', (route) =>
-    route.fulfill({ json: { ok: true, exists: false } })
-  );
   await page.route('**/api/admin/tournament-wizard', async (route) => {
     const body = route.request().postDataJSON() as any;
-    const tournamentId = body?.tournament?.id || `hj-spring-cup-2026`;
+    const tournamentId = body?.tournament?.id || 'hj-spring-cup-2026';
     tournaments.push({ id: tournamentId, name: body?.tournament?.name, season: body?.tournament?.season });
-    return route.fulfill({ json: { ok: true, tournament_id: tournamentId } });
+    return route.fulfill({ json: { ok: true, tournament_id: tournamentId }, status: 201 });
   });
 
   // ── Auth ──────────────────────────────────────────────────────────────────
@@ -118,128 +66,65 @@ test('admin creates a full tournament via the wizard', async ({ page }) => {
 
   await page.goto('admin/tournaments/new');
   await page.waitForLoadState('domcontentloaded');
-  await expect(page.getByRole('heading', { name: 'Tournament Setup Wizard' })).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'Create a new tournament' })).toBeVisible();
 
-  // ── Step 0: Tournament details ────────────────────────────────────────────
+  // ── Step 1: Tournament Details ────────────────────────────────────────────
 
-  await page.getByLabel('Tournament Name').fill(tournamentName);
-  await page.getByLabel('Season').fill(season);
-  // ID hint should appear
-  await expect(page.getByText(/hj-spring-cup-2026/i)).toBeVisible();
+  await page.getByLabel('Name').fill(tournamentName);
+  await page.getByLabel('Start date').fill('2026-06-07');
+  await page.getByLabel('End date').fill('2026-06-08');
 
-  // ── Step 1: Groups & Pools ────────────────────────────────────────────────
+  // Select a venue (pill button)
+  await page.getByRole('button', { name: 'Beaulieu College' }).click();
 
-  await page.getByRole('button', { name: /^2\s*Groups & Pools/i }).click();
-  await expect(page.getByRole('heading', { name: 'Groups' })).toBeVisible();
+  // Enable one division
+  await page.getByRole('checkbox', { name: 'U9 Mixed' }).check();
 
-  // Group 1: U11 Boys — Round-robin, Dainfern + Beaulieu
-  const groupsSection = page.locator('section', { has: page.getByRole('heading', { name: 'Groups' }) });
-  const groupBlocks = () => groupsSection.locator('.wizard-block');
-  await groupsSection.getByLabel('Division / Age').first().fill('U11 Boys');
-  await groupsSection.getByRole('combobox', { name: 'Format' }).first().selectOption('Round-robin');
-  await groupsSection.getByLabel('Play Date').first().fill('2026-06-07');
-  await groupBlocks().nth(0).getByRole('checkbox', { name: 'Dainfern College' }).check();
-  await groupBlocks().nth(0).getByRole('checkbox', { name: 'Beaulieu College' }).check();
+  await page.getByRole('button', { name: 'Next →' }).click();
 
-  // Group 2: U11 Girls — Round-robin, Beaulieu (play date set via shortcut)
-  await page.getByRole('button', { name: 'Add Group' }).click();
-  const divisionInputs = () => groupsSection.getByLabel('Division / Age');
-  await divisionInputs().nth(1).fill('U11 Girls');
-  await groupsSection.getByRole('combobox', { name: 'Format' }).nth(1).selectOption('Round-robin');
-  await groupBlocks().nth(1).getByRole('checkbox', { name: 'Beaulieu College' }).check();
+  // ── Step 2: Franchises ────────────────────────────────────────────────────
 
-  // Group 3: U13 Knockout — St Stithians
-  await page.getByRole('button', { name: 'Add Group' }).click();
-  await divisionInputs().nth(2).fill('U13 Knockout');
-  await groupsSection.getByRole('combobox', { name: 'Format' }).nth(2).selectOption('Knockout');
-  await groupsSection.getByLabel('Play Date').nth(2).fill('2026-06-08');
-  await groupBlocks().nth(2).getByRole('checkbox', { name: 'St Stithians' }).check();
+  await expect(page.getByText('Step 2 of 5')).toBeVisible();
 
-  // Sprint 3 feature: Girls Day shortcut → applies 2026-06-07 to U11 Girls
-  const shortcutsSection = page.locator('section', { has: page.getByRole('heading', { name: 'Scheduling Shortcuts' }) });
-  await shortcutsSection.getByLabel('Girls Day').fill('2026-06-07');
-  await shortcutsSection.getByRole('button', { name: /Apply to Girls groups/i }).click();
-  // U11 Girls play date should now match
-  await expect(groupsSection.getByLabel('Play Date').nth(1)).toHaveValue('2026-06-07');
+  // Select two franchises from the directory cards
+  await page.getByRole('listitem').filter({ hasText: 'BHA' }).first().click();
+  await page.getByRole('listitem').filter({ hasText: 'Black Hawks' }).first().click();
 
-  // ── Step 2: Teams & Fixtures ──────────────────────────────────────────────
+  await page.getByRole('button', { name: 'Next →' }).click();
 
-  await page.getByRole('button', { name: /^3\s*Teams & Fixtures/i }).click();
-  await expect(page.getByRole('heading', { name: 'Teams' })).toBeVisible();
+  // ── Step 3: Teams & Pools ─────────────────────────────────────────────────
 
-  const teamsSection = page.locator('section', { has: page.getByRole('heading', { name: 'Teams' }) });
+  await expect(page.getByText('Step 3 of 5')).toBeVisible();
 
-  const teamGroupSelects = () => teamsSection.getByRole('combobox', { name: 'Team Group' });
-  const franchiseSelects = () => teamsSection.getByRole('combobox', { name: 'Franchise' });
-  const teamNameSelects = () => teamsSection.getByRole('combobox', { name: 'Team Name' });
+  // Accept default team slots and proceed
+  await page.getByRole('button', { name: 'Next →' }).click();
 
-  // U11 Boys team 1 — the default empty row
-  await teamGroupSelects().first().selectOption({ label: 'U11 Boys' });
-  await franchiseSelects().first().selectOption('Gryphons');
-  await expect(teamNameSelects().first()).toBeVisible();
-  await teamNameSelects().first().selectOption('Gryphons Gold');
+  // ── Step 4: Rules ─────────────────────────────────────────────────────────
 
-  // U11 Boys team 2
-  await teamsSection.getByRole('button', { name: 'Add Team' }).click();
-  await teamGroupSelects().nth(1).selectOption({ label: 'U11 Boys' });
-  await franchiseSelects().nth(1).selectOption('Knights');
-  await expect(teamNameSelects().nth(1)).toBeVisible();
-  await teamNameSelects().nth(1).selectOption('Knights Orange');
+  await expect(page.getByText('Step 4 of 5')).toBeVisible();
 
-  // U11 Boys team 3
-  await teamsSection.getByRole('button', { name: 'Add Team' }).click();
-  await teamGroupSelects().nth(2).selectOption({ label: 'U11 Boys' });
-  await franchiseSelects().nth(2).selectOption('Blue Hawks');
-  await expect(teamNameSelects().nth(2)).toBeVisible();
-  await teamNameSelects().nth(2).selectOption('Blue Hawks Blue');
+  await page.getByRole('button', { name: 'Next →' }).click();
 
-  // U11 Girls team 1
-  await teamsSection.getByRole('button', { name: 'Add Team' }).click();
-  await teamGroupSelects().nth(3).selectOption({ label: 'U11 Girls' });
-  await franchiseSelects().nth(3).selectOption('Purple Panthers');
-  await expect(teamNameSelects().nth(3)).toBeVisible();
-  await teamNameSelects().nth(3).selectOption('PP Emerald');
+  // ── Step 5: Fixtures ──────────────────────────────────────────────────────
 
-  // U11 Girls team 2
-  await teamsSection.getByRole('button', { name: 'Add Team' }).click();
-  await teamGroupSelects().nth(4).selectOption({ label: 'U11 Girls' });
-  await franchiseSelects().nth(4).selectOption('Gryphons');
-  await expect(teamNameSelects().nth(4)).toBeVisible();
-  await teamNameSelects().nth(4).selectOption('Gryphons Blue');
+  await expect(page.getByText('Step 5 of 5')).toBeVisible();
 
-  // Sprint 3 feature: placeholder quick-add for U13 Knockout (appended after real teams)
-  await teamsSection.getByRole('button', { name: /Add standard placeholders for U13 Knockout/i }).click();
-  await expect(page.locator('input[value="SF1 Winner"]')).toBeVisible();
-  await expect(page.locator('input[value="SF2 Winner"]')).toBeVisible();
-  await expect(page.locator('input[value="SF1 Loser / 3rd Place"]')).toBeVisible();
+  // Auto-generate fixtures then place one
+  await page.getByRole('button', { name: 'Auto-generate fixtures' }).click();
 
-  // Generate round-robin fixtures for U11 Boys at Dainfern College
-  const fixturesSection = page.locator('section', { has: page.getByRole('heading', { name: 'Fixtures' }) });
-  await fixturesSection.getByRole('combobox', { name: 'Generator Group' }).selectOption({ label: 'U11 Boys' });
-  await fixturesSection.getByLabel('Date').first().fill('2026-06-07');
-  await fixturesSection.getByRole('combobox', { name: 'Default Venue' }).selectOption('Dainfern College');
-  await fixturesSection.getByRole('button', { name: /Generate Fixtures/i }).click();
-  // 3-team round-robin = 3 fixtures
-  await expect(page.getByText(/Generated 3 fixtures/i)).toBeVisible();
+  const firstFixture = page.getByRole('button', { name: /BHA|Black Hawks/ }).first();
+  await firstFixture.click();
 
-  // ── Step 3: Review & Submit ───────────────────────────────────────────────
+  const firstSlot = page.getByRole('button', { name: 'click to place' }).first();
+  await firstSlot.click();
 
-  await page.getByRole('button', { name: 'Review →' }).click();
-  await expect(page.getByRole('heading', { name: 'Review Tournament' })).toBeVisible();
+  // Submit
+  await page.getByRole('button', { name: 'Create Tournament →' }).click();
 
-  // Tournament summary
+  // ── Success screen ────────────────────────────────────────────────────────
+
+  await expect(page.getByRole('heading', { name: 'Tournament Created!' })).toBeVisible();
   await expect(page.getByText(tournamentName)).toBeVisible();
-  await expect(page.getByText(/hj-spring-cup-2026/i)).toBeVisible();
-
-  // No ID conflict warning (mock returns exists:false)
-  await expect(page.getByText(/already exists/i)).not.toBeVisible();
-
-  // Confirm & Create should be enabled
-  const confirmBtn = page.getByRole('button', { name: 'Confirm & Create' });
-  await expect(confirmBtn).toBeEnabled();
-  await confirmBtn.click();
-
-  await expect(page.getByText(/Tournament created:/i)).toBeVisible();
 
   // ── Assert it appears in the public tournament directory ──────────────────
 

--- a/e2e/admin-create-tournament.spec.ts
+++ b/e2e/admin-create-tournament.spec.ts
@@ -71,8 +71,13 @@ test('admin creates a full tournament via the wizard', async ({ page }) => {
   // ── Step 1: Tournament Details ────────────────────────────────────────────
 
   await page.locator('input[aria-label="Name"]').fill(tournamentName);
-  await page.locator('input[aria-label="Start date"]').fill('2026-06-07');
-  await page.locator('input[aria-label="End date"]').fill('2026-06-08');
+  // type="date" inputs need pressSequentially in Playwright's Chromium to trigger React onChange
+  const startInput = page.locator('input[aria-label="Start date"]');
+  await startInput.click();
+  await startInput.pressSequentially('2026-06-07');
+  const endInput = page.locator('input[aria-label="End date"]');
+  await endInput.click();
+  await endInput.pressSequentially('2026-06-08');
 
   // Select a venue (pill button)
   await page.getByRole('button', { name: 'Beaulieu College' }).click();
@@ -80,9 +85,10 @@ test('admin creates a full tournament via the wizard', async ({ page }) => {
   // Enable one division
   await page.getByRole('checkbox', { name: 'U9 Mixed' }).check();
 
-  const nextBtn1 = page.getByRole('button', { name: 'Next →' });
+  const nextBtn1 = page.locator('button.hj-tw2-btn--primary', { hasText: 'Next' });
   await expect(nextBtn1).toBeEnabled();
-  await nextBtn1.click();
+  await nextBtn1.scrollIntoViewIfNeeded();
+  await nextBtn1.click({ force: true });
 
   // ── Step 2: Franchises ────────────────────────────────────────────────────
 
@@ -92,20 +98,25 @@ test('admin creates a full tournament via the wizard', async ({ page }) => {
   await page.getByRole('listitem').filter({ hasText: 'BHA' }).first().click();
   await page.getByRole('listitem').filter({ hasText: 'Black Hawks' }).first().click();
 
-  await page.getByRole('button', { name: 'Next →' }).click();
+  const nextBtn2 = page.locator('button.hj-tw2-btn--primary', { hasText: 'Next' });
+  await expect(nextBtn2).toBeEnabled();
+  await nextBtn2.click({ force: true });
 
   // ── Step 3: Teams & Pools ─────────────────────────────────────────────────
 
   await expect(page.getByText('Step 3 of 5')).toBeVisible();
 
-  // Accept default team slots and proceed
-  await page.getByRole('button', { name: 'Next →' }).click();
+  const nextBtn3 = page.locator('button.hj-tw2-btn--primary', { hasText: 'Next' });
+  await expect(nextBtn3).toBeEnabled();
+  await nextBtn3.click({ force: true });
 
   // ── Step 4: Rules ─────────────────────────────────────────────────────────
 
   await expect(page.getByText('Step 4 of 5')).toBeVisible();
 
-  await page.getByRole('button', { name: 'Next →' }).click();
+  const nextBtn4 = page.locator('button.hj-tw2-btn--primary', { hasText: 'Next' });
+  await expect(nextBtn4).toBeEnabled();
+  await nextBtn4.click({ force: true });
 
   // ── Step 5: Fixtures ──────────────────────────────────────────────────────
 

--- a/e2e/admin-create-tournament.spec.ts
+++ b/e2e/admin-create-tournament.spec.ts
@@ -70,9 +70,9 @@ test('admin creates a full tournament via the wizard', async ({ page }) => {
 
   // ── Step 1: Tournament Details ────────────────────────────────────────────
 
-  await page.getByLabel('Name').fill(tournamentName);
-  await page.getByLabel('Start date').fill('2026-06-07');
-  await page.getByLabel('End date').fill('2026-06-08');
+  await page.getByRole('textbox', { name: 'Name', exact: true }).fill(tournamentName);
+  await page.getByRole('textbox', { name: 'Start date' }).fill('2026-06-07');
+  await page.getByRole('textbox', { name: 'End date' }).fill('2026-06-08');
 
   // Select a venue (pill button)
   await page.getByRole('button', { name: 'Beaulieu College' }).click();

--- a/server/admin.mjs
+++ b/server/admin.mjs
@@ -149,6 +149,9 @@ export async function handleAdminRequest(req, res, { url, pool, sendJson, caches
         timeSlots = [],
       } = body;
 
+      const gameTiming = tournament?.game_timing ?? null;
+      const pointsConfig = tournament?.points_config ?? null;
+
       if (!tournament || !isNonEmptyString(tournament.name)) {
         return sendJson(req, res, 400, { ok: false, error: "tournament.name is required" });
       }
@@ -180,9 +183,11 @@ export async function handleAdminRequest(req, res, { url, pool, sendJson, caches
         }
 
         await client.query(
-          `INSERT INTO tournament (id, name, season, source)
-           VALUES ($1, $2, $3, 'App')`,
-          [tournamentId, tournamentName, tournamentSeason]
+          `INSERT INTO tournament (id, name, season, source, game_timing, points_config)
+           VALUES ($1, $2, $3, 'App', $4, $5)`,
+          [tournamentId, tournamentName, tournamentSeason,
+            gameTiming ? JSON.stringify(gameTiming) : null,
+            pointsConfig ? JSON.stringify(pointsConfig) : null]
         );
 
         // venueMap: populated on-demand from venue_directory as groupVenues are processed.

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -37,7 +37,6 @@ import AdminRoute from "./views/admin/AdminRoute";
 import AdminLogin from "./views/admin/AdminLogin";
 import AdminLoginCallback from "./views/admin/AdminLoginCallback";
 import AnnouncementsPage from "./views/admin/AnnouncementsPage";
-import TournamentWizard from "./views/admin/TournamentWizard";
 import TournamentNewWizard from "./views/admin/TournamentNewWizard";
 import AdminTournamentsPage from "./views/admin/AdminTournamentsPage";
 import AdminDashboard from "./views/admin/AdminDashboard";
@@ -558,7 +557,7 @@ export default function App() {
             <Route element={<AdminLayout />}>
               <Route index element={<AdminDashboard />} />
               <Route path="tournaments" element={<AdminTournamentsPage />} />
-              <Route path="tournaments/new" element={<TournamentWizard />} />
+              <Route path="tournaments/new" element={<TournamentNewWizard />} />
               <Route path="tournament/new" element={<TournamentNewWizard />} />
               <Route path="announcements" element={<AnnouncementsPage />} />
               <Route path="venues/*" element={<VenuesPage />} />

--- a/src/views/admin/TournamentNewWizard.jsx
+++ b/src/views/admin/TournamentNewWizard.jsx
@@ -805,7 +805,12 @@ TopStepper.propTypes = {
   onStepChange: PropTypes.func.isRequired,
 };
 
-function SummarySidebar({ tournamentName, selectedVenues, step1Timing, divisionTeamCounts }) {
+function fmtDate(d) {
+  if (!d) return null;
+  return new Date(d + "T00:00:00Z").toLocaleDateString("en-ZA", { day: "numeric", month: "short", year: "numeric" });
+}
+
+function SummarySidebar({ tournamentName, season, startDate, endDate, selectedVenues, step1Timing, divisionTeamCounts }) {
   const gameDuration = React.useMemo(() => {
     const chakas = Number(step1Timing.chakasPerGame) || 0;
     const dur = Number(step1Timing.chakaMinutes) || 0;
@@ -814,6 +819,14 @@ function SummarySidebar({ tournamentName, selectedVenues, step1Timing, divisionT
     return chakas * dur + half + co;
   }, [step1Timing.chakasPerGame, step1Timing.chakaMinutes, step1Timing.halftimeMinutes, step1Timing.changeoverMinutes]);
 
+  const dateLine = React.useMemo(() => {
+    const s = fmtDate(startDate);
+    const e = fmtDate(endDate);
+    if (s && e) return `${s} – ${e}`;
+    if (s) return s;
+    return null;
+  }, [startDate, endDate]);
+
   return (
     <aside className="hj-tw2-sidebar" aria-label="Tournament summary">
       <div className="hj-tw2-sidebar-card">
@@ -821,15 +834,25 @@ function SummarySidebar({ tournamentName, selectedVenues, step1Timing, divisionT
         <dl className="hj-tw2-sidebar-dl">
           <div>
             <dt>Tournament</dt>
-            <dd>{tournamentName || "—"}</dd>
+            <dd>
+              {tournamentName || "—"}
+              {(season || dateLine) && (
+                <div className="hj-tw2-sidebar-meta">
+                  {season && dateLine ? `${season} • ${dateLine}` : season || dateLine}
+                </div>
+              )}
+            </dd>
           </div>
 
           <div>
             <dt>Game Duration</dt>
             <dd>
-              <div className="hj-tw2-sidebar-duration-value">
-                {gameDuration > 0 ? `${gameDuration} min/game` : "—"}
-              </div>
+              {gameDuration > 0 ? (
+                <div className="hj-tw2-sidebar-duration-row">
+                  <span className="hj-tw2-sidebar-duration-value">{gameDuration}</span>
+                  <span className="hj-tw2-sidebar-duration-label">min/game</span>
+                </div>
+              ) : "—"}
               {gameDuration > 0 && (
                 <div className="hj-tw2-sidebar-duration-formula">
                   {Number(step1Timing.chakasPerGame)}×{Number(step1Timing.chakaMinutes)}
@@ -878,6 +901,9 @@ function SummarySidebar({ tournamentName, selectedVenues, step1Timing, divisionT
 
 SummarySidebar.propTypes = {
   tournamentName: PropTypes.string.isRequired,
+  season: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  startDate: PropTypes.string,
+  endDate: PropTypes.string,
   selectedVenues: PropTypes.arrayOf(PropTypes.string).isRequired,
   step1Timing: PropTypes.shape({
     chakasPerGame: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
@@ -1254,6 +1280,8 @@ function Step1({ value, onChange, onValidityChange }) {
                   className="hj-tw2-points-input"
                   type="number"
                   inputMode="numeric"
+                  min={0}
+                  max={99}
                   aria-label={`${t.label} points`}
                   value={value.points[t.key]}
                   onChange={(e) =>
@@ -1261,7 +1289,7 @@ function Step1({ value, onChange, onValidityChange }) {
                       ...value,
                       points: {
                         ...value.points,
-                        [t.key]: Number(e.target.value || 0),
+                        [t.key]: Math.min(99, Math.max(0, Number(e.target.value || 0))),
                       },
                     })
                   }
@@ -1275,7 +1303,7 @@ function Step1({ value, onChange, onValidityChange }) {
                       ...value,
                       points: {
                         ...value.points,
-                        [t.key]: Number(value.points[t.key] || 0) + 1,
+                        [t.key]: Math.min(99, Number(value.points[t.key] || 0) + 1),
                       },
                     })
                   }
@@ -1310,15 +1338,10 @@ Step1.propTypes = {
   value: PropTypes.shape({
     name: PropTypes.string.isRequired,
     season: PropTypes.string.isRequired,
-    seasonOptions: PropTypes.arrayOf(PropTypes.string).isRequired,
+    seasonOptions: PropTypes.arrayOf(PropTypes.number).isRequired,
     startDate: PropTypes.string.isRequired,
     endDate: PropTypes.string.isRequired,
-    venueDirectory: PropTypes.arrayOf(
-      PropTypes.shape({
-        id: PropTypes.string.isRequired,
-        name: PropTypes.string.isRequired,
-      })
-    ).isRequired,
+    venueDirectory: PropTypes.arrayOf(PropTypes.string).isRequired,
     selectedVenues: PropTypes.arrayOf(PropTypes.string).isRequired,
     customVenueDraft: PropTypes.string.isRequired,
     divisionTable: PropTypes.arrayOf(
@@ -1342,7 +1365,7 @@ Step1.propTypes = {
       draw: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
       loss: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
     }).isRequired,
-    _continue: PropTypes.bool,
+    _continue: PropTypes.number,
     activeDivisions: PropTypes.array,
   }).isRequired,
   onChange: PropTypes.func.isRequired,
@@ -1891,6 +1914,13 @@ export default function TournamentNewWizard() {
           id: normaliseId(`${step1.name} ${step1.season}`),
           name: step1.name,
           season: String(step1.season),
+          game_timing: {
+            chakas: Number(step1.chakasPerGame),
+            duration_mins: Number(step1.chakaMinutes),
+            halftime_mins: Number(step1.halftimeMinutes),
+            changeover_mins: Number(step1.changeoverMinutes),
+          },
+          points_config: { ...step1.points },
         },
         venues: step1.selectedVenues,
         groups: activeDivisions.map((d) => ({
@@ -2019,6 +2049,9 @@ export default function TournamentNewWizard() {
           <div ref={mainRef}>{main}</div>
           <SummarySidebar
             tournamentName={step1.name}
+            season={step1.season}
+            startDate={step1.startDate}
+            endDate={step1.endDate}
             selectedVenues={step1.selectedVenues}
             step1Timing={{
               chakasPerGame: step1.chakasPerGame,

--- a/src/views/admin/TournamentNewWizard.test.jsx
+++ b/src/views/admin/TournamentNewWizard.test.jsx
@@ -403,6 +403,26 @@ describe("TournamentNewWizard (v2)", () => {
     expect(drawPoints).toHaveValue(0);
   });
 
+  it("clamps points stepper plus button to a maximum of 99", async () => {
+    const user = userEvent.setup();
+    render(<TournamentNewWizard />);
+
+    await completeStep1(user);
+
+    const winPoints = screen.getByLabelText("WIN points");
+    fireEvent.change(winPoints, { target: { value: "99" } });
+    await user.click(screen.getByRole("button", { name: "WIN plus" }));
+    expect(winPoints).toHaveValue(99);
+  });
+
+  it("clamps points direct input to a maximum of 99", async () => {
+    render(<TournamentNewWizard />);
+
+    const winPoints = screen.getByLabelText("WIN points");
+    fireEvent.change(winPoints, { target: { value: "150" } });
+    expect(winPoints).toHaveValue(99);
+  });
+
   it("allows proceeding to Step 3 once Step 2 is valid (two franchises selected)", async () => {
     const user = userEvent.setup();
     render(<TournamentNewWizard />);
@@ -604,6 +624,15 @@ describe("TournamentNewWizard (v2)", () => {
       expect.objectContaining({ method: "POST" })
     );
 
+    const callBody = JSON.parse(adminFetchSpy.mock.calls[0][1].body);
+    expect(callBody.tournament.game_timing).toEqual({
+      chakas: 2,
+      duration_mins: 20,
+      halftime_mins: 5,
+      changeover_mins: 3,
+    });
+    expect(callBody.tournament.points_config).toEqual({ win: 3, draw: 1, loss: 0 });
+
     adminFetchSpy.mockRestore();
   });
 
@@ -784,8 +813,23 @@ describe("TournamentNewWizard (v2)", () => {
 
     // Default timing: 2 chakas × 20 min + 5 half + 3 change = 48 min/game
     const sidebar = screen.getByRole("complementary", { name: "Tournament summary" });
-    expect(within(sidebar).getByText("48 min/game")).toBeInTheDocument();
+    expect(within(sidebar).getByText("48")).toBeInTheDocument();
+    expect(within(sidebar).getByText("min/game")).toBeInTheDocument();
     expect(within(sidebar).getByText(/2×20/)).toBeInTheDocument();
+  });
+
+  it("sidebar shows season and date range after Step 1 is filled", async () => {
+    const user = userEvent.setup();
+    render(<TournamentNewWizard />);
+
+    await completeStep1(user); // sets startDate=2026-05-01, endDate=2026-05-02, season=current year
+
+    const sidebar = screen.getByRole("complementary", { name: "Tournament summary" });
+    // Season (current year) should appear in sidebar meta
+    const currentYear = String(new Date().getFullYear());
+    expect(within(sidebar).getByText(new RegExp(currentYear))).toBeInTheDocument();
+    // Date range should appear
+    expect(within(sidebar).getByText(/May/)).toBeInTheDocument();
   });
 
   // ── Design token alignment tests ─────────────────────────────────────────

--- a/src/views/admin/tournamentNewWizard.css
+++ b/src/views/admin/tournamentNewWizard.css
@@ -907,10 +907,28 @@
 }
 
 /* ── Enhanced sidebar content ─────────────────────────────────────── */
+.hj-tw2-sidebar-meta {
+  font-size: var(--hj-font-size-xs);
+  color: rgba(255, 255, 255, 0.52);
+  margin-top: 2px;
+}
+
+.hj-tw2-sidebar-duration-row {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+}
+
 .hj-tw2-sidebar-duration-value {
+  font-size: 36px;
+  font-weight: 900;
+  line-height: 1;
+  color: var(--hj-color-brand);
+}
+
+.hj-tw2-sidebar-duration-label {
   font-size: var(--hj-font-size-sm);
-  color: rgba(255, 255, 255, 0.92);
-  font-weight: var(--hj-font-weight-semibold);
+  color: rgba(255, 255, 255, 0.72);
 }
 
 .hj-tw2-sidebar-duration-formula {


### PR DESCRIPTION
## Summary

- **Route fix**: `/admin/tournaments/new` now loads the v2 wizard (`TournamentNewWizard`) — the legacy `TournamentWizard` is no longer wired
- **Sidebar**: shows season + date range below tournament name; game duration rendered as 36px weight-900 green number matching the prototype
- **Points**: input and stepper plus button clamped to max 99
- **PropTypes**: fixed `venueDirectory` (string[]), `seasonOptions` (number[]), `_continue` (number)
- **Backend + migration**: `game_timing` and `points_config` JSONB columns added to `tournament` table (migration `017_game_timing_points.sql`) and persisted on tournament creation

## ⚠️ Migration required

Before or immediately after merging, run against the production DB:

```sql
-- db/migrations/017_game_timing_points.sql
ALTER TABLE tournament
  ADD COLUMN IF NOT EXISTS game_timing JSONB,
  ADD COLUMN IF NOT EXISTS points_config JSONB;
```

Without this, tournament creation will fail on the new server code.

## Test plan

- [ ] Run migration on production DB
- [ ] Navigate to `/admin/tournaments/new` — confirms v2 wizard loads (5 steps)
- [ ] "Create tournament" button on Tournaments list also lands on v2 wizard
- [ ] Step 1: set timing → sidebar shows large green duration number + `min/game` label
- [ ] Step 1: set season + dates → sidebar shows `{year} • {start} – {end}` below name
- [ ] Points stepper: clicking + at 99 stays at 99
- [ ] Complete all 5 steps → submit → network payload includes `game_timing` and `points_config`
- [ ] All 57 wizard tests pass (`npm test -- --run src/views/admin/TournamentNewWizard.test.jsx`)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)