### PR TITLE
ci(staging): fix diff detection for deploy-staging

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          fetch-depth: 0
 
       # Determine whether this PR contains any non-doc changes.
       # If it's docs-only, we skip deploy (SSH is locked down) but still succeed the required check.


### PR DESCRIPTION
Fixes staging deploy skip: checkout was shallow (fetch-depth=1), so git diff against base sha failed (fatal: bad object) and workflow treated code PRs as docs-only. Set actions/checkout fetch-depth=0.