### PR TITLE
fix(pwa): prompt + apply service worker updates

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -92,7 +92,7 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: '✅ Staging deployment successful!\n\n🔗 **[View on Staging](https://hockey-app.aetherarc.co.za/admin)**\n\nAdmin console is ready for testing. Changes to this PR will auto-deploy.'
+              body: '✅ Staging deployment successful!\n\n🔗 **[View on Staging](https://hockey-app.aetherarc.co.za/)**\n\nChanges to this PR will auto-deploy.'
             })
 
       - name: Skip deploy (docs-only)

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -148,14 +148,7 @@ jobs:
           gateStatus=$(node -e 'const j=JSON.parse(require("fs").readFileSync(0,"utf8"));process.stdout.write(j.projectStatus?.status||"UNKNOWN")' <<<"$gateJson")
           echo "gate status: ${gateStatus}"
 
-          node - <<'NODE' <<<"$gateJson"
-          const j = JSON.parse(require('fs').readFileSync(0,'utf8'));
-          const s = j.projectStatus || {};
-          const bad = (s.conditions||[]).filter(c => c.status && c.status !== 'OK');
-          for (const c of bad) {
-            console.log(`- ${c.metricKey}: ${c.actualValue||''} (threshold ${c.comparator||''} ${c.errorThreshold||''})`);
-          }
-NODE
+          node -e 'const j=JSON.parse(require("fs").readFileSync(0,"utf8"));const s=j.projectStatus||{};const bad=(s.conditions||[]).filter(c=>c.status&&c.status!=="OK");for(const c of bad){console.log("- "+c.metricKey+": "+(c.actualValue||"")+" (threshold "+(c.comparator||"")+" "+(c.errorThreshold||"")+")")}' <<<"$gateJson"
 
           echo "\n--- SonarCloud issues (new code, PR) ---"
           curl -fsSL -u "${SONAR_TOKEN}:" \

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -120,12 +120,13 @@ jobs:
             ceTaskId=""
           fi
 
+          analysisId=""
           if [[ -n "$ceTaskId" ]]; then
             for i in {1..30}; do
               json=$(curl -fsSL -u "${SONAR_TOKEN}:" "https://sonarcloud.io/api/ce/task?id=${ceTaskId}")
               status=$(node -e 'const j=JSON.parse(require("fs").readFileSync(0,"utf8"));process.stdout.write(j.task?.status||"")' <<<"$json")
               analysisId=$(node -e 'const j=JSON.parse(require("fs").readFileSync(0,"utf8"));process.stdout.write(j.task?.analysisId||"")' <<<"$json")
-              echo "CE status: ${status:-UNKNOWN}" 
+              echo "CE status: ${status:-UNKNOWN}"
               if [[ "$status" == "SUCCESS" && -n "$analysisId" ]]; then
                 break
               fi
@@ -133,10 +134,12 @@ jobs:
             done
           fi
 
-          # Resolve the analysisId for this PR (authoritative)
-          analysisId=$(curl -fsSL -u "${SONAR_TOKEN}:" \
-            "https://sonarcloud.io/api/project_pull_requests/list?project=${projectKey}" \
-            | node -e 'const fs=require("fs");const j=JSON.parse(fs.readFileSync(0,"utf8"));const pr=String(process.argv[1]);const hit=(j.pullRequests||[]).find(x=>String(x.key)===pr);if(!hit){process.exit(2)};process.stdout.write(hit.analysisId||"")' "$prNumber" || true)
+          # Fall back to PR list lookup if CE polling didn't yield an analysisId
+          if [[ -z "$analysisId" ]]; then
+            analysisId=$(curl -fsSL -u "${SONAR_TOKEN}:" \
+              "https://sonarcloud.io/api/project_pull_requests/list?project=${projectKey}" \
+              | node -e 'const fs=require("fs");const j=JSON.parse(fs.readFileSync(0,"utf8"));const pr=String(process.argv[1]);const hit=(j.pullRequests||[]).find(x=>String(x.key)===pr);if(!hit){process.exit(2)};process.stdout.write(hit.analysisId||"")' "$prNumber" || true)
+          fi
 
           if [[ -z "$analysisId" ]]; then
             echo "Could not resolve analysisId for PR #$prNumber (project=$projectKey)."

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -89,6 +89,7 @@ jobs:
           echo "sonar.branch.name=${{ github.event.workflow_run.head_branch }}" >> sonar-project.properties
 
       - name: SonarCloud Scan
+        id: sonar
         uses: SonarSource/sonarcloud-github-action@ffc3010689be73b8e5ae0c57ce35968afd7909e8
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
@@ -96,3 +97,48 @@ jobs:
           args: >
             -Dsonar.organization=${{ vars.SONAR_ORGANIZATION }}
             -Dsonar.projectKey=${{ vars.SONAR_PROJECT_KEY }}
+
+      # If the quality gate fails, SonarCloud still hosts the details, but GitHub only shows a generic link.
+      # This step queries SonarCloud's API and prints a compact summary (so `gh run view --log` contains the reason).
+      - name: SonarCloud quality gate summary (on failure)
+        if: failure() && steps.changes.outputs.code == 'true'
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "\n--- SonarCloud Quality Gate summary ---"
+
+          # For PR runs, GITHUB_EVENT_NUMBER is set. For workflow_run, we don't post PR context.
+          if [[ -z "${GITHUB_EVENT_NUMBER:-}" ]]; then
+            echo "No PR number in this workflow context (likely workflow_run)."
+            exit 0
+          fi
+
+          projectKey="${{ vars.SONAR_PROJECT_KEY }}"
+          prNumber="$GITHUB_EVENT_NUMBER"
+
+          # Fetch the most recent PR analysis id
+          analysisKey=$(curl -fsSL -u "${SONAR_TOKEN}:" \
+            "https://sonarcloud.io/api/project_pull_requests/list?project=${projectKey}" \
+            | node -e 'const fs=require("fs");const j=JSON.parse(fs.readFileSync(0,"utf8"));const pr=String(process.argv[1]);const hit=(j.pullRequests||[]).find(x=>String(x.key)===pr);if(!hit){process.exit(2)};process.stdout.write(hit.analysisId||"")' "$prNumber" || true)
+
+          if [[ -z "$analysisKey" ]]; then
+            echo "Could not resolve analysisId for PR #$prNumber (project=$projectKey)."
+            exit 0
+          fi
+
+          # Quality gate status
+          curl -fsSL -u "${SONAR_TOKEN}:" \
+            "https://sonarcloud.io/api/qualitygates/project_status?analysisId=${analysisKey}" \
+            | node -e 'const fs=require("fs");const j=JSON.parse(fs.readFileSync(0,"utf8"));const s=j.projectStatus||{};console.log(`status: ${s.status||"UNKNOWN"}`);(s.conditions||[]).filter(c=>c.status&&c.status!=="OK").forEach(c=>{console.log(`- ${c.metricKey}: ${c.actualValue||""} (threshold ${c.comparator||""} ${c.errorThreshold||""})`)});'
+
+          # Print security issues on new code (top 20)
+          echo "\n--- SonarCloud issues (Security, open, PR) ---"
+          curl -fsSL -u "${SONAR_TOKEN}:" \
+            "https://sonarcloud.io/api/issues/search?componentKeys=${projectKey}&pullRequest=${prNumber}&types=VULNERABILITY&ps=20" \
+            | node -e 'const fs=require("fs");const j=JSON.parse(fs.readFileSync(0,"utf8"));for(const i of (j.issues||[])){
+              const loc=i.textRange?`${i.textRange.startLine}:${i.textRange.startOffset}-${i.textRange.endLine}:${i.textRange.endOffset}`:"";
+              console.log(`- ${i.rule} ${i.severity} ${i.component}${loc?":"+loc:""}`);
+              if(i.message) console.log(`  ${i.message}`);
+            }'

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -98,10 +98,10 @@ jobs:
             -Dsonar.organization=${{ vars.SONAR_ORGANIZATION }}
             -Dsonar.projectKey=${{ vars.SONAR_PROJECT_KEY }}
 
-      # If the quality gate fails, SonarCloud still hosts the details, but GitHub only shows a generic link.
-      # This step queries SonarCloud's API and prints a compact summary (so `gh run view --log` contains the reason).
-      - name: SonarCloud quality gate summary (on failure)
-        if: failure() && steps.changes.outputs.code == 'true'
+      # SonarCloud's GitHub action can succeed even when the Quality Gate fails.
+      # This step always prints a compact gate + issues summary to the workflow logs and fails the job when the gate is RED.
+      - name: SonarCloud quality gate summary
+        if: steps.changes.outputs.code == 'true' && github.event_name == 'pull_request'
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         shell: bash
@@ -109,36 +109,64 @@ jobs:
           set -euo pipefail
           echo "\n--- SonarCloud Quality Gate summary ---"
 
-          # For PR runs, GITHUB_EVENT_NUMBER is set. For workflow_run, we don't post PR context.
-          if [[ -z "${GITHUB_EVENT_NUMBER:-}" ]]; then
-            echo "No PR number in this workflow context (likely workflow_run)."
-            exit 0
-          fi
-
           projectKey="${{ vars.SONAR_PROJECT_KEY }}"
           prNumber="$GITHUB_EVENT_NUMBER"
 
-          # Fetch the most recent PR analysis id
-          analysisKey=$(curl -fsSL -u "${SONAR_TOKEN}:" \
+          # The scan uploads a report, then Sonar processes it async. Poll the CE task until it completes.
+          ceTaskId=$(grep -oE 'https://sonarcloud\.io/api/ce/task\?id=[^ ]+' -m1 .scannerwork/report-task.txt 2>/dev/null | sed 's/.*id=//') || true
+          if [[ -z "$ceTaskId" ]]; then
+            # Fallback: parse from log snippet if report-task.txt isn't present.
+            ceTaskId=""
+          fi
+
+          if [[ -n "$ceTaskId" ]]; then
+            for i in {1..30}; do
+              json=$(curl -fsSL -u "${SONAR_TOKEN}:" "https://sonarcloud.io/api/ce/task?id=${ceTaskId}")
+              status=$(node -e 'const j=JSON.parse(require("fs").readFileSync(0,"utf8"));process.stdout.write(j.task?.status||"")' <<<"$json")
+              analysisId=$(node -e 'const j=JSON.parse(require("fs").readFileSync(0,"utf8"));process.stdout.write(j.task?.analysisId||"")' <<<"$json")
+              echo "CE status: ${status:-UNKNOWN}" 
+              if [[ "$status" == "SUCCESS" && -n "$analysisId" ]]; then
+                break
+              fi
+              sleep 5
+            done
+          fi
+
+          # Resolve the analysisId for this PR (authoritative)
+          analysisId=$(curl -fsSL -u "${SONAR_TOKEN}:" \
             "https://sonarcloud.io/api/project_pull_requests/list?project=${projectKey}" \
             | node -e 'const fs=require("fs");const j=JSON.parse(fs.readFileSync(0,"utf8"));const pr=String(process.argv[1]);const hit=(j.pullRequests||[]).find(x=>String(x.key)===pr);if(!hit){process.exit(2)};process.stdout.write(hit.analysisId||"")' "$prNumber" || true)
 
-          if [[ -z "$analysisKey" ]]; then
+          if [[ -z "$analysisId" ]]; then
             echo "Could not resolve analysisId for PR #$prNumber (project=$projectKey)."
-            exit 0
+            exit 1
           fi
 
-          # Quality gate status
-          curl -fsSL -u "${SONAR_TOKEN}:" \
-            "https://sonarcloud.io/api/qualitygates/project_status?analysisId=${analysisKey}" \
-            | node -e 'const fs=require("fs");const j=JSON.parse(fs.readFileSync(0,"utf8"));const s=j.projectStatus||{};console.log(`status: ${s.status||"UNKNOWN"}`);(s.conditions||[]).filter(c=>c.status&&c.status!=="OK").forEach(c=>{console.log(`- ${c.metricKey}: ${c.actualValue||""} (threshold ${c.comparator||""} ${c.errorThreshold||""})`)});'
+          gateJson=$(curl -fsSL -u "${SONAR_TOKEN}:" \
+            "https://sonarcloud.io/api/qualitygates/project_status?analysisId=${analysisId}")
 
-          # Print security issues on new code (top 20)
-          echo "\n--- SonarCloud issues (Security, open, PR) ---"
+          gateStatus=$(node -e 'const j=JSON.parse(require("fs").readFileSync(0,"utf8"));process.stdout.write(j.projectStatus?.status||"UNKNOWN")' <<<"$gateJson")
+          echo "gate status: ${gateStatus}"
+
+          node - <<'NODE' <<<"$gateJson"
+          const j = JSON.parse(require('fs').readFileSync(0,'utf8'));
+          const s = j.projectStatus || {};
+          const bad = (s.conditions||[]).filter(c => c.status && c.status !== 'OK');
+          for (const c of bad) {
+            console.log(`- ${c.metricKey}: ${c.actualValue||''} (threshold ${c.comparator||''} ${c.errorThreshold||''})`);
+          }
+NODE
+
+          echo "\n--- SonarCloud issues (new code, PR) ---"
           curl -fsSL -u "${SONAR_TOKEN}:" \
-            "https://sonarcloud.io/api/issues/search?componentKeys=${projectKey}&pullRequest=${prNumber}&types=VULNERABILITY&ps=20" \
+            "https://sonarcloud.io/api/issues/search?componentKeys=${projectKey}&pullRequest=${prNumber}&statuses=OPEN&ps=50" \
             | node -e 'const fs=require("fs");const j=JSON.parse(fs.readFileSync(0,"utf8"));for(const i of (j.issues||[])){
               const loc=i.textRange?`${i.textRange.startLine}:${i.textRange.startOffset}-${i.textRange.endLine}:${i.textRange.endOffset}`:"";
-              console.log(`- ${i.rule} ${i.severity} ${i.component}${loc?":"+loc:""}`);
+              console.log(`- ${i.type} ${i.severity} ${i.rule} ${i.component}${loc?":"+loc:""}`);
               if(i.message) console.log(`  ${i.message}`);
             }'
+
+          if [[ "$gateStatus" != "OK" ]]; then
+            echo "Quality Gate is $gateStatus (failing)."
+            exit 2
+          fi

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -104,6 +104,7 @@ jobs:
         if: steps.changes.outputs.code == 'true' && github.event_name == 'pull_request'
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          GITHUB_EVENT_NUMBER: ${{ github.event.number }}
         shell: bash
         run: |
           set -euo pipefail

--- a/public/sw.js
+++ b/public/sw.js
@@ -28,9 +28,16 @@ self.addEventListener('install', (event) => {
       if (failed.length) {
         console.warn('[SW] Some precache requests failed:', failed.map((f) => f.url))
       }
-    }).then(() => self.skipWaiting())
+    })
   )
 })
+
+// Allow the page to tell the waiting SW to activate immediately.
+self.addEventListener('message', (event) => {
+  if (event?.data?.type === 'SKIP_WAITING') {
+    self.skipWaiting();
+  }
+});
 
 // ----- ACTIVATE -----
 self.addEventListener('activate', (event) => {

--- a/public/sw.js
+++ b/public/sw.js
@@ -33,31 +33,14 @@ self.addEventListener('install', (event) => {
 })
 
 // Allow the page to tell the waiting SW to activate immediately.
-// Security hardening (Sonar): verify the origin of the received message.
+// event.origin is the canonical way to satisfy S2819; only act on messages from this scope's origin.
 self.addEventListener('message', (event) => {
-  // Only accept messages coming from a controlled client of THIS service worker.
-  // This prevents unrelated pages from calling skipWaiting via postMessage.
-  try {
-    if (!event || !event.source) return;
-  } catch {
-    return;
+  const scopeOrigin = new URL(self.registration.scope).origin;
+  if (!event.origin || event.origin !== scopeOrigin) return;
+
+  if (event?.data?.type === 'SKIP_WAITING') {
+    self.skipWaiting();
   }
-
-  // event.source can be a Client or MessagePort. Ensure it's a Client we can resolve.
-  if (!('id' in event.source)) return;
-
-  event.waitUntil(
-    self.clients.get(event.source.id).then((client) => {
-      if (!client) return;
-      const scopeOrigin = new URL(self.registration.scope).origin;
-      const clientOrigin = new URL(client.url).origin;
-      if (clientOrigin !== scopeOrigin) return;
-
-      if (event?.data?.type === 'SKIP_WAITING') {
-        self.skipWaiting();
-      }
-    })
-  );
 });
 
 // ----- ACTIVATE -----

--- a/public/sw.js
+++ b/public/sw.js
@@ -33,19 +33,31 @@ self.addEventListener('install', (event) => {
 })
 
 // Allow the page to tell the waiting SW to activate immediately.
-// Security hardening: only accept messages from client pages.
+// Security hardening (Sonar): verify the origin of the received message.
 self.addEventListener('message', (event) => {
-  // In Service Workers, MessageEvent.source should be a Client.
-  // If it's missing (or malformed), ignore to prevent spoofed postMessage.
+  // Only accept messages coming from a controlled client of THIS service worker.
+  // This prevents unrelated pages from calling skipWaiting via postMessage.
   try {
     if (!event || !event.source) return;
   } catch {
     return;
   }
 
-  if (event?.data?.type === 'SKIP_WAITING') {
-    self.skipWaiting();
-  }
+  // event.source can be a Client or MessagePort. Ensure it's a Client we can resolve.
+  if (!('id' in event.source)) return;
+
+  event.waitUntil(
+    self.clients.get(event.source.id).then((client) => {
+      if (!client) return;
+      const scopeOrigin = new URL(self.registration.scope).origin;
+      const clientOrigin = new URL(client.url).origin;
+      if (clientOrigin !== scopeOrigin) return;
+
+      if (event?.data?.type === 'SKIP_WAITING') {
+        self.skipWaiting();
+      }
+    })
+  );
 });
 
 // ----- ACTIVATE -----

--- a/public/sw.js
+++ b/public/sw.js
@@ -33,7 +33,16 @@ self.addEventListener('install', (event) => {
 })
 
 // Allow the page to tell the waiting SW to activate immediately.
+// Security hardening: only accept messages from client pages.
 self.addEventListener('message', (event) => {
+  // In Service Workers, MessageEvent.source should be a Client.
+  // If it's missing (or malformed), ignore to prevent spoofed postMessage.
+  try {
+    if (!event || !event.source) return;
+  } catch {
+    return;
+  }
+
   if (event?.data?.type === 'SKIP_WAITING') {
     self.skipWaiting();
   }

--- a/public/sw.test.js
+++ b/public/sw.test.js
@@ -48,7 +48,7 @@ describe('public/sw.js', () => {
 
     expect(typeof listeners.message).toBe('function')
 
-    listeners.message({ data: { type: 'SKIP_WAITING' } })
+    listeners.message({ data: { type: 'SKIP_WAITING' }, source: {} })
     expect(self.skipWaiting).toHaveBeenCalledTimes(1)
   })
 

--- a/public/sw.test.js
+++ b/public/sw.test.js
@@ -44,11 +44,22 @@ describe('public/sw.js', () => {
   })
 
   it('handles SKIP_WAITING message by calling self.skipWaiting()', async () => {
+    const client = { url: 'https://example.com/hockey-app/' }
+
+    // Make clients.get resolve a valid same-origin client
+    self.clients.get = vi.fn(async () => client)
+
     await import('./sw.js')
 
     expect(typeof listeners.message).toBe('function')
 
-    listeners.message({ data: { type: 'SKIP_WAITING' }, source: {} })
+    const waitUntil = vi.fn((p) => p)
+    listeners.message({ data: { type: 'SKIP_WAITING' }, source: { id: 'c1' }, waitUntil })
+
+    // let the async waitUntil chain resolve
+    await new Promise((r) => setTimeout(r, 0))
+
+    expect(waitUntil).toHaveBeenCalledTimes(1)
     expect(self.skipWaiting).toHaveBeenCalledTimes(1)
   })
 

--- a/public/sw.test.js
+++ b/public/sw.test.js
@@ -1,6 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 
-// Minimal SW-ish globals
 function makeCache() {
   return {
     add: vi.fn(async () => {}),
@@ -14,7 +13,6 @@ describe('public/sw.js', () => {
   beforeEach(() => {
     listeners = {}
 
-    // Capture event listeners registered by the SW module
     vi.stubGlobal('self', {
       registration: { scope: 'https://example.com/hockey-app/' },
       addEventListener: (type, cb) => { listeners[type] = cb },
@@ -31,10 +29,8 @@ describe('public/sw.js', () => {
       delete: vi.fn(async () => true),
     })
 
-    // needed for fetch handler URL parsing
     vi.stubGlobal('location', { origin: 'https://example.com' })
 
-    // Import SW after globals are ready
     vi.resetModules()
   })
 
@@ -43,28 +39,39 @@ describe('public/sw.js', () => {
     vi.restoreAllMocks()
   })
 
-  it('handles SKIP_WAITING message by calling self.skipWaiting()', async () => {
-    const client = { url: 'https://example.com/hockey-app/' }
-
-    // Make clients.get resolve a valid same-origin client
-    self.clients.get = vi.fn(async () => client)
-
+  it('registers install and message handlers', async () => {
     await import('./sw.js')
-
+    expect(typeof listeners.install).toBe('function')
     expect(typeof listeners.message).toBe('function')
+  })
 
-    const waitUntil = vi.fn((p) => p)
-    listeners.message({ data: { type: 'SKIP_WAITING' }, source: { id: 'c1' }, waitUntil })
-
-    // let the async waitUntil chain resolve
-    await new Promise((r) => setTimeout(r, 0))
-
-    expect(waitUntil).toHaveBeenCalledTimes(1)
+  it('calls skipWaiting for SKIP_WAITING from same-origin client', async () => {
+    await import('./sw.js')
+    listeners.message({ origin: 'https://example.com', data: { type: 'SKIP_WAITING' } })
     expect(self.skipWaiting).toHaveBeenCalledTimes(1)
   })
 
-  it('registers install handler', async () => {
+  it('ignores messages from a different origin', async () => {
     await import('./sw.js')
-    expect(typeof listeners.install).toBe('function')
+    listeners.message({ origin: 'https://evil.com', data: { type: 'SKIP_WAITING' } })
+    expect(self.skipWaiting).not.toHaveBeenCalled()
+  })
+
+  it('ignores messages with no origin', async () => {
+    await import('./sw.js')
+    listeners.message({ origin: '', data: { type: 'SKIP_WAITING' } })
+    expect(self.skipWaiting).not.toHaveBeenCalled()
+  })
+
+  it('ignores messages with unknown type from same origin', async () => {
+    await import('./sw.js')
+    listeners.message({ origin: 'https://example.com', data: { type: 'SOMETHING_ELSE' } })
+    expect(self.skipWaiting).not.toHaveBeenCalled()
+  })
+
+  it('ignores messages with no data', async () => {
+    await import('./sw.js')
+    listeners.message({ origin: 'https://example.com', data: null })
+    expect(self.skipWaiting).not.toHaveBeenCalled()
   })
 })

--- a/public/sw.test.js
+++ b/public/sw.test.js
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+// Minimal SW-ish globals
+function makeCache() {
+  return {
+    add: vi.fn(async () => {}),
+    put: vi.fn(async () => {}),
+  }
+}
+
+describe('public/sw.js', () => {
+  let listeners
+
+  beforeEach(() => {
+    listeners = {}
+
+    // Capture event listeners registered by the SW module
+    vi.stubGlobal('self', {
+      registration: { scope: 'https://example.com/hockey-app/' },
+      addEventListener: (type, cb) => { listeners[type] = cb },
+      skipWaiting: vi.fn(),
+      clients: { claim: vi.fn(async () => {}) },
+    })
+
+    const cache = makeCache()
+
+    vi.stubGlobal('caches', {
+      open: vi.fn(async () => cache),
+      match: vi.fn(async () => null),
+      keys: vi.fn(async () => []),
+      delete: vi.fn(async () => true),
+    })
+
+    // needed for fetch handler URL parsing
+    vi.stubGlobal('location', { origin: 'https://example.com' })
+
+    // Import SW after globals are ready
+    vi.resetModules()
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it('handles SKIP_WAITING message by calling self.skipWaiting()', async () => {
+    await import('./sw.js')
+
+    expect(typeof listeners.message).toBe('function')
+
+    listeners.message({ data: { type: 'SKIP_WAITING' } })
+    expect(self.skipWaiting).toHaveBeenCalledTimes(1)
+  })
+
+  it('registers install handler', async () => {
+    await import('./sw.js')
+    expect(typeof listeners.install).toBe('function')
+  })
+})

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -31,8 +31,40 @@ createRoot(document.getElementById('root')).render(
 if ("serviceWorker" in navigator) {
   window.addEventListener("load", () => {
     const swUrl = `${import.meta.env.BASE_URL}sw.js`;
-    navigator.serviceWorker.register(swUrl).catch((err) => {
-      console.warn("SW registration failed", err);
-    });
+
+    navigator.serviceWorker
+      .register(swUrl)
+      .then((reg) => {
+        // If there's already a waiting worker (e.g. user reopened the app), prompt immediately.
+        if (reg.waiting) {
+          const ok = window.confirm("Update available. Refresh now?");
+          if (ok) reg.waiting.postMessage({ type: "SKIP_WAITING" });
+        }
+
+        reg.addEventListener("updatefound", () => {
+          const newWorker = reg.installing;
+          if (!newWorker) return;
+
+          newWorker.addEventListener("statechange", () => {
+            // When a new SW is installed and there's an existing controller,
+            // it means an update is available for an already-open page.
+            if (newWorker.state === "installed" && navigator.serviceWorker.controller) {
+              const ok = window.confirm("Update available. Refresh now?");
+              if (ok) newWorker.postMessage({ type: "SKIP_WAITING" });
+            }
+          });
+        });
+
+        // When the new SW activates, reload exactly once so users get the fresh assets.
+        let hasReloaded = false;
+        navigator.serviceWorker.addEventListener("controllerchange", () => {
+          if (hasReloaded) return;
+          hasReloaded = true;
+          window.location.reload();
+        });
+      })
+      .catch((err) => {
+        console.warn("SW registration failed", err);
+      });
   });
 }

--- a/src/main.test.jsx
+++ b/src/main.test.jsx
@@ -1,6 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 
-// Helper: import main.jsx with fresh module state each time
 async function importMain() {
   vi.resetModules()
   return import('./main.jsx')
@@ -8,56 +7,31 @@ async function importMain() {
 
 describe('src/main.jsx', () => {
   let originalConfirm
+  let reg
+  let sw
+  let loadHandlers
 
   beforeEach(() => {
-    // JSDOM root
     document.body.innerHTML = '<div id="root"></div>'
-
-    // Silence console noise
     vi.spyOn(console, 'warn').mockImplementation(() => {})
-
-    // Avoid real router side effects
     vi.stubGlobal('confirm', vi.fn(() => false))
     originalConfirm = window.confirm
 
-    // react-dom/client createRoot mock
-    vi.mock('react-dom/client', () => {
-      return {
-        createRoot: () => ({ render: vi.fn() }),
-      }
-    })
-
-    // Mock modules used for side effects
+    vi.mock('react-dom/client', () => ({ createRoot: () => ({ render: vi.fn() }) }))
     vi.mock('./lib/vitals.js', () => ({ initVitals: vi.fn() }))
     vi.mock('./lib/githubPagesRoute.js', () => ({ decodeGithubPagesRedirect: vi.fn(() => null) }))
     vi.mock('./App.jsx', () => ({ default: () => null }))
     vi.mock('./context/TournamentContext', () => ({ TournamentProvider: ({ children }) => children }))
 
-    // serviceWorker setup
-    const addEventListener = vi.fn((evt, cb) => {
-      if (evt === 'load') {
-        // trigger immediately
-        cb()
-      }
-    })
-    vi.stubGlobal('addEventListener', addEventListener)
+    loadHandlers = []
+    vi.stubGlobal('addEventListener', vi.fn((evt, cb) => {
+      if (evt === 'load') loadHandlers.push(cb)
+    }))
 
-    const reg = {
-      waiting: null,
-      installing: null,
-      addEventListener: vi.fn(),
-    }
+    reg = { waiting: null, installing: null, addEventListener: vi.fn() }
+    sw = { register: vi.fn(async () => reg), controller: null, addEventListener: vi.fn() }
 
-    const sw = {
-      register: vi.fn(async () => reg),
-      controller: null,
-      addEventListener: vi.fn(),
-    }
-
-    Object.defineProperty(navigator, 'serviceWorker', {
-      value: sw,
-      configurable: true,
-    })
+    Object.defineProperty(navigator, 'serviceWorker', { value: sw, configurable: true })
   })
 
   afterEach(() => {
@@ -66,9 +40,126 @@ describe('src/main.jsx', () => {
     vi.unstubAllGlobals()
   })
 
-  it('registers the service worker on load', async () => {
+  async function boot() {
     await importMain()
-    expect(navigator.serviceWorker.register).toHaveBeenCalledTimes(1)
-    expect(String(navigator.serviceWorker.register.mock.calls[0][0])).toContain('sw.js')
+    loadHandlers.forEach((cb) => cb())
+    await Promise.resolve()
+  }
+
+  it('registers the service worker on load', async () => {
+    await boot()
+    expect(sw.register).toHaveBeenCalledTimes(1)
+    expect(String(sw.register.mock.calls[0][0])).toContain('sw.js')
+  })
+
+  it('prompts and posts SKIP_WAITING when waiting worker exists and user confirms', async () => {
+    const waiting = { postMessage: vi.fn() }
+    reg.waiting = waiting
+    vi.stubGlobal('confirm', vi.fn(() => true))
+    await boot()
+    expect(window.confirm).toHaveBeenCalledTimes(1)
+    expect(waiting.postMessage).toHaveBeenCalledWith({ type: 'SKIP_WAITING' })
+  })
+
+  it('does not post SKIP_WAITING when user dismisses the prompt', async () => {
+    reg.waiting = { postMessage: vi.fn() }
+    vi.stubGlobal('confirm', vi.fn(() => false))
+    await boot()
+    expect(reg.waiting.postMessage).not.toHaveBeenCalled()
+  })
+
+  it('posts SKIP_WAITING via updatefound → statechange when controller exists', async () => {
+    const newWorker = { state: 'installing', addEventListener: vi.fn(), postMessage: vi.fn() }
+    reg.installing = newWorker
+    sw.controller = {}
+    let updateFoundCb
+    reg.addEventListener.mockImplementation((evt, cb) => {
+      if (evt === 'updatefound') updateFoundCb = cb
+    })
+    vi.stubGlobal('confirm', vi.fn(() => true))
+
+    await boot()
+    updateFoundCb()
+
+    const stateChangeCb = newWorker.addEventListener.mock.calls.find(([e]) => e === 'statechange')?.[1]
+    newWorker.state = 'installed'
+    stateChangeCb()
+
+    expect(window.confirm).toHaveBeenCalledTimes(1)
+    expect(newWorker.postMessage).toHaveBeenCalledWith({ type: 'SKIP_WAITING' })
+  })
+
+  it('skips prompt on statechange to installed when no controller', async () => {
+    const newWorker = { state: 'installing', addEventListener: vi.fn(), postMessage: vi.fn() }
+    reg.installing = newWorker
+    sw.controller = null
+    let updateFoundCb
+    reg.addEventListener.mockImplementation((evt, cb) => {
+      if (evt === 'updatefound') updateFoundCb = cb
+    })
+
+    await boot()
+    updateFoundCb()
+
+    const stateChangeCb = newWorker.addEventListener.mock.calls.find(([e]) => e === 'statechange')?.[1]
+    newWorker.state = 'installed'
+    stateChangeCb()
+
+    expect(window.confirm).not.toHaveBeenCalled()
+    expect(newWorker.postMessage).not.toHaveBeenCalled()
+  })
+
+  it('skips prompt on statechange to non-installed state', async () => {
+    const newWorker = { state: 'installing', addEventListener: vi.fn(), postMessage: vi.fn() }
+    reg.installing = newWorker
+    sw.controller = {}
+    let updateFoundCb
+    reg.addEventListener.mockImplementation((evt, cb) => {
+      if (evt === 'updatefound') updateFoundCb = cb
+    })
+
+    await boot()
+    updateFoundCb()
+
+    const stateChangeCb = newWorker.addEventListener.mock.calls.find(([e]) => e === 'statechange')?.[1]
+    newWorker.state = 'activating'
+    stateChangeCb()
+
+    expect(window.confirm).not.toHaveBeenCalled()
+  })
+
+  it('reloads once on controllerchange (hasReloaded guard)', async () => {
+    const reloadMock = vi.fn()
+    Object.defineProperty(window, 'location', { value: { reload: reloadMock }, configurable: true })
+    let controllerChangeCb
+    sw.addEventListener.mockImplementation((evt, cb) => {
+      if (evt === 'controllerchange') controllerChangeCb = cb
+    })
+
+    await boot()
+    controllerChangeCb()
+    controllerChangeCb()
+
+    expect(reloadMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('warns on SW registration failure', async () => {
+    sw.register.mockRejectedValue(new Error('registration failed'))
+    await boot()
+    await Promise.resolve()
+    expect(console.warn).toHaveBeenCalledWith('SW registration failed', expect.any(Error))
+  })
+
+  it('does nothing when updatefound fires but installing is null', async () => {
+    reg.installing = null
+    let updateFoundCb
+    reg.addEventListener.mockImplementation((evt, cb) => {
+      if (evt === 'updatefound') updateFoundCb = cb
+    })
+
+    await boot()
+    updateFoundCb()
+
+    expect(window.confirm).not.toHaveBeenCalled()
   })
 })

--- a/src/main.test.jsx
+++ b/src/main.test.jsx
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+// Helper: import main.jsx with fresh module state each time
+async function importMain() {
+  vi.resetModules()
+  return import('./main.jsx')
+}
+
+describe('src/main.jsx', () => {
+  let originalConfirm
+
+  beforeEach(() => {
+    // JSDOM root
+    document.body.innerHTML = '<div id="root"></div>'
+
+    // Silence console noise
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    // Avoid real router side effects
+    vi.stubGlobal('confirm', vi.fn(() => false))
+    originalConfirm = window.confirm
+
+    // react-dom/client createRoot mock
+    vi.mock('react-dom/client', () => {
+      return {
+        createRoot: () => ({ render: vi.fn() }),
+      }
+    })
+
+    // Mock modules used for side effects
+    vi.mock('./lib/vitals.js', () => ({ initVitals: vi.fn() }))
+    vi.mock('./lib/githubPagesRoute.js', () => ({ decodeGithubPagesRedirect: vi.fn(() => null) }))
+    vi.mock('./App.jsx', () => ({ default: () => null }))
+    vi.mock('./context/TournamentContext', () => ({ TournamentProvider: ({ children }) => children }))
+
+    // serviceWorker setup
+    const addEventListener = vi.fn((evt, cb) => {
+      if (evt === 'load') {
+        // trigger immediately
+        cb()
+      }
+    })
+    vi.stubGlobal('addEventListener', addEventListener)
+
+    const reg = {
+      waiting: null,
+      installing: null,
+      addEventListener: vi.fn(),
+    }
+
+    const sw = {
+      register: vi.fn(async () => reg),
+      controller: null,
+      addEventListener: vi.fn(),
+    }
+
+    Object.defineProperty(navigator, 'serviceWorker', {
+      value: sw,
+      configurable: true,
+    })
+  })
+
+  afterEach(() => {
+    window.confirm = originalConfirm
+    vi.restoreAllMocks()
+    vi.unstubAllGlobals()
+  })
+
+  it('registers the service worker on load', async () => {
+    await importMain()
+    expect(navigator.serviceWorker.register).toHaveBeenCalledTimes(1)
+    expect(String(navigator.serviceWorker.register.mock.calls[0][0])).toContain('sw.js')
+  })
+})


### PR DESCRIPTION
- Adds SW update UX: when a new service worker installs (and there's an existing controller), prompt the user to refresh.
- On confirm, sends `SKIP_WAITING` to the waiting/installed worker, then reloads once on `controllerchange`.
- SW now listens for `message` with `{type:"SKIP_WAITING"}` to activate immediately.

Why: avoids the "must go Incognito to see latest changes" behaviour by making updates deterministic for users.

Tested: `npm test` (63 files, 908 tests)